### PR TITLE
[추가] 첫번째 탭화면 TCA 기반 네비게이션 구성

### DIFF
--- a/KuringApp/KuringApp.xcodeproj/project.pbxproj
+++ b/KuringApp/KuringApp.xcodeproj/project.pbxproj
@@ -10,6 +10,16 @@
 		A947DCBE2AB47D3800A6D614 /* Notices in Frameworks */ = {isa = PBXBuildFile; productRef = A947DCBD2AB47D3800A6D614 /* Notices */; };
 		A947DCC02AB47D3B00A6D614 /* Feedbacks in Frameworks */ = {isa = PBXBuildFile; productRef = A947DCBF2AB47D3B00A6D614 /* Feedbacks */; };
 		A947DCC22AB47D3E00A6D614 /* Subscriptions in Frameworks */ = {isa = PBXBuildFile; productRef = A947DCC12AB47D3E00A6D614 /* Subscriptions */; };
+		A965B7A32AC013060026ECDC /* DepartmentEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A965B7A22AC013060026ECDC /* DepartmentEditor.swift */; };
+		A965B7A52AC013BF0026ECDC /* DepartmentSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A965B7A42AC013BF0026ECDC /* DepartmentSelector.swift */; };
+		A965B7A72AC0696B0026ECDC /* Department.swift in Sources */ = {isa = PBXBuildFile; fileRef = A965B7A62AC0696B0026ECDC /* Department.swift */; };
+		A965B7AB2AC0750E0026ECDC /* SubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A965B7AA2AC0750E0026ECDC /* SubscriptionView.swift */; };
+		A965B7AF2AC084D20026ECDC /* SubscriptionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A965B7AE2AC084D20026ECDC /* SubscriptionApp.swift */; };
+		A9B4F0142ABCA86500354C00 /* NoticeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B4F0132ABCA86500354C00 /* NoticeApp.swift */; };
+		A9B4F0162ABCA93400354C00 /* NoticeApp.Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B4F0152ABCA93400354C00 /* NoticeApp.Path.swift */; };
+		A9B4F0182ABCA9AF00354C00 /* NoticeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B4F0172ABCA9AF00354C00 /* NoticeDetailView.swift */; };
+		A9B4F01A2ABCAF9800354C00 /* NoticeList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B4F0192ABCAF9800354C00 /* NoticeList.swift */; };
+		A9B4F01D2ABCB4CE00354C00 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B4F01C2ABCB4CE00354C00 /* SearchView.swift */; };
 		A9DAFA542AB1F04B0064F748 /* KuringApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAFA532AB1F04B0064F748 /* KuringApp.swift */; };
 		A9DAFA562AB1F04B0064F748 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAFA552AB1F04B0064F748 /* ContentView.swift */; };
 		A9DAFA582AB1F04C0064F748 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9DAFA572AB1F04C0064F748 /* Assets.xcassets */; };
@@ -17,6 +27,16 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A965B7A22AC013060026ECDC /* DepartmentEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepartmentEditor.swift; sourceTree = "<group>"; };
+		A965B7A42AC013BF0026ECDC /* DepartmentSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepartmentSelector.swift; sourceTree = "<group>"; };
+		A965B7A62AC0696B0026ECDC /* Department.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Department.swift; sourceTree = "<group>"; };
+		A965B7AA2AC0750E0026ECDC /* SubscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionView.swift; sourceTree = "<group>"; };
+		A965B7AE2AC084D20026ECDC /* SubscriptionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionApp.swift; sourceTree = "<group>"; };
+		A9B4F0132ABCA86500354C00 /* NoticeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeApp.swift; sourceTree = "<group>"; };
+		A9B4F0152ABCA93400354C00 /* NoticeApp.Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeApp.Path.swift; sourceTree = "<group>"; };
+		A9B4F0172ABCA9AF00354C00 /* NoticeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailView.swift; sourceTree = "<group>"; };
+		A9B4F0192ABCAF9800354C00 /* NoticeList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeList.swift; sourceTree = "<group>"; };
+		A9B4F01C2ABCB4CE00354C00 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		A9DAFA502AB1F04B0064F748 /* KuringApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KuringApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9DAFA532AB1F04B0064F748 /* KuringApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KuringApp.swift; sourceTree = "<group>"; };
 		A9DAFA552AB1F04B0064F748 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -46,6 +66,49 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		A965B7A82AC074BD0026ECDC /* WillBeRemoved */ = {
+			isa = PBXGroup;
+			children = (
+				A965B7A62AC0696B0026ECDC /* Department.swift */,
+			);
+			path = WillBeRemoved;
+			sourceTree = "<group>";
+		};
+		A965B7A92AC074CC0026ECDC /* Department */ = {
+			isa = PBXGroup;
+			children = (
+				A965B7A22AC013060026ECDC /* DepartmentEditor.swift */,
+				A965B7A42AC013BF0026ECDC /* DepartmentSelector.swift */,
+			);
+			path = Department;
+			sourceTree = "<group>";
+		};
+		A965B7AC2AC083080026ECDC /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				A9B4F01C2ABCB4CE00354C00 /* SearchView.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		A965B7AD2AC0830F0026ECDC /* Subscription */ = {
+			isa = PBXGroup;
+			children = (
+				A965B7AA2AC0750E0026ECDC /* SubscriptionView.swift */,
+				A965B7AE2AC084D20026ECDC /* SubscriptionApp.swift */,
+			);
+			path = Subscription;
+			sourceTree = "<group>";
+		};
+		A9B4F01B2ABCB4B600354C00 /* NoticeList */ = {
+			isa = PBXGroup;
+			children = (
+				A9B4F0172ABCA9AF00354C00 /* NoticeDetailView.swift */,
+				A9B4F0192ABCAF9800354C00 /* NoticeList.swift */,
+			);
+			path = NoticeList;
+			sourceTree = "<group>";
+		};
 		A9DAFA472AB1F04B0064F748 = {
 			isa = PBXGroup;
 			children = (
@@ -68,6 +131,13 @@
 			isa = PBXGroup;
 			children = (
 				A9DAFA532AB1F04B0064F748 /* KuringApp.swift */,
+				A9B4F0132ABCA86500354C00 /* NoticeApp.swift */,
+				A9B4F0152ABCA93400354C00 /* NoticeApp.Path.swift */,
+				A965B7AC2AC083080026ECDC /* Search */,
+				A965B7AD2AC0830F0026ECDC /* Subscription */,
+				A965B7A92AC074CC0026ECDC /* Department */,
+				A965B7A82AC074BD0026ECDC /* WillBeRemoved */,
+				A9B4F01B2ABCB4B600354C00 /* NoticeList */,
 				A9DAFA552AB1F04B0064F748 /* ContentView.swift */,
 				A9DAFA572AB1F04C0064F748 /* Assets.xcassets */,
 				A9DAFA592AB1F04C0064F748 /* Preview Content */,
@@ -160,7 +230,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9B4F0142ABCA86500354C00 /* NoticeApp.swift in Sources */,
+				A965B7AB2AC0750E0026ECDC /* SubscriptionView.swift in Sources */,
+				A9B4F01A2ABCAF9800354C00 /* NoticeList.swift in Sources */,
 				A9DAFA562AB1F04B0064F748 /* ContentView.swift in Sources */,
+				A9B4F01D2ABCB4CE00354C00 /* SearchView.swift in Sources */,
+				A965B7A32AC013060026ECDC /* DepartmentEditor.swift in Sources */,
+				A965B7A52AC013BF0026ECDC /* DepartmentSelector.swift in Sources */,
+				A9B4F0162ABCA93400354C00 /* NoticeApp.Path.swift in Sources */,
+				A965B7A72AC0696B0026ECDC /* Department.swift in Sources */,
+				A9B4F0182ABCA9AF00354C00 /* NoticeDetailView.swift in Sources */,
+				A965B7AF2AC084D20026ECDC /* SubscriptionApp.swift in Sources */,
 				A9DAFA542AB1F04B0064F748 /* KuringApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import NoticeListFeature
 import ComposableArchitecture
 
 struct ContentView: View {
@@ -26,23 +25,7 @@ struct ContentView: View {
         }
     }
 }
-struct NoticeList: View {
-    let store: StoreOf<NoticeListFeature>
-    
-    var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
-            List {
-                ForEach(viewStore.notices) {
-                    NoticeRow(title: $0.subject)
-                }
-            }
-            .listStyle(.plain)
-            .onAppear {
-                viewStore.send(.onAppear)
-            }
-        }
-    }
-}
+
 
 struct NoticeRow: View {
     let title: String
@@ -63,15 +46,5 @@ struct NoticeRow: View {
 
 #Preview {
     ContentView()
-}
-
-
-#Preview {
-    NoticeList(
-        store: Store(
-            initialState: NoticeListFeature.State(),
-            reducer: { NoticeListFeature() }
-        )
-    )
 }
 

--- a/KuringApp/KuringApp/Department/DepartmentEditor.swift
+++ b/KuringApp/KuringApp/Department/DepartmentEditor.swift
@@ -1,0 +1,166 @@
+//
+//  DepartmentEditor.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/24.
+//
+
+import Model
+import SwiftUI
+import ComposableArchitecture
+
+struct DepartmentEditorFeature: Reducer {
+    struct State: Equatable {
+        var myDepartments: IdentifiedArrayOf<Department> = []
+        var results: IdentifiedArrayOf<Department> = []
+        
+        @BindingState var searchText: String = ""
+        @BindingState var focus: Field? = .search
+        
+        enum Field {
+            case search
+        }
+    }
+    
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+
+        case addDepartmentButtonTapped(id: Department.ID)
+        case cancelAdditionButtonTapped(id: Department.ID)
+        
+        case deleteMyDepartmentButtonTapped(id: Department.ID)
+        case deleteAllMyDepartmentButtonTapped
+    }
+    
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+                
+            case let .addDepartmentButtonTapped(id: id):
+                guard let department = state.results.first(where: { $0.id == id }) else {
+                    return .none
+                }
+                state.myDepartments.append(department)
+                return .none
+                
+            case let .cancelAdditionButtonTapped(id: id):
+                state.myDepartments.remove(id: id)
+                return .none
+                
+                // TODO: Alert 띄우도록
+            case let .deleteMyDepartmentButtonTapped(id: id):
+                state.myDepartments.remove(id: id)
+                return .none
+                
+                // TODO: Alert 띄우도록
+            case .deleteAllMyDepartmentButtonTapped:
+                state.myDepartments.removeAll()
+                return .none
+            }
+        }
+    }
+}
+
+struct DepartmentEditor: View {
+    let store: StoreOf<DepartmentEditorFeature>
+    
+    @FocusState private var focus: DepartmentEditorFeature.State.Field?
+    
+    var body: some View {
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            VStack {
+                List {
+                    Text("학과를 추가하거나 삭제할 수 있어요")
+                    
+                    /**
+                     - `viewStore.$searchText`
+                     - `bind(viewStore.$focus, to: $focus)`
+                     */
+                    Section {
+                        TextField("추가할 학과를 검색해 주세요", text: viewStore.$searchText)
+                            .focused($focus, equals: .search)
+                            .bind(viewStore.$focus, to: self.$focus)
+                    }
+                    
+                    /**
+                     - `viewStore.myDepartments`
+                     - `.deleteMyDepartmentButtonTapped`
+                     */
+                    Section {
+                        ForEach(viewStore.myDepartments) { myDepartment in
+                            HStack {
+                                Text(myDepartment.korName)
+                                
+                                Spacer()
+                                
+                                Button("삭제") {
+                                    viewStore.send(.deleteMyDepartmentButtonTapped(id: myDepartment.id))
+                                }
+                            }
+                        }
+                    } header: {
+                        Text("내 학과")
+                    }
+                    
+                    /**
+                     - `viewStore.results`
+                     - `addDepartmentButtonTapped`
+                     - `cancelAdditionButtonTapped`
+                     */
+                    Section {
+                        ForEach(viewStore.results) { result in
+                            HStack {
+                                Text(result.korName)
+                                
+                                Spacer()
+                                
+                                Button {
+                                    if viewStore.myDepartments.contains(result) {
+                                        viewStore.send(.cancelAdditionButtonTapped(id: result.id))
+                                    } else {
+                                        viewStore.send(.addDepartmentButtonTapped(id: result.id))
+                                    }
+                                } label: {
+                                    Image(
+                                        systemName: viewStore.myDepartments.contains(result)
+                                        ? "checkmark.circle.fill"
+                                        : "plus.circle"
+                                    )
+                                }
+                            }
+                        }
+                    } header: {
+                        Text("검색 결과")
+                    }
+                }
+            }
+            .navigationTitle("Department Editor")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("전체 삭제") {
+                        viewStore.send(.deleteAllMyDepartmentButtonTapped)
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+#Preview {
+    NavigationStack {
+        DepartmentEditor(
+            store: Store(
+                initialState: DepartmentEditorFeature.State(
+                    myDepartments: [.전기전자공학부, .컴퓨터공학부],
+                    results: [.전기전자공학부, .컴퓨터공학부, .산업디자인학과]
+                ),
+                reducer: { DepartmentEditorFeature() }
+            )
+        )
+    }
+}

--- a/KuringApp/KuringApp/Department/DepartmentEditor.swift
+++ b/KuringApp/KuringApp/Department/DepartmentEditor.swift
@@ -138,7 +138,6 @@ struct DepartmentEditor: View {
                     }
                 }
             }
-            .navigationTitle("Department Editor")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("전체 삭제") {
@@ -162,5 +161,6 @@ struct DepartmentEditor: View {
                 reducer: { DepartmentEditorFeature() }
             )
         )
+        .navigationTitle("Department Editor")
     }
 }

--- a/KuringApp/KuringApp/Department/DepartmentSelector.swift
+++ b/KuringApp/KuringApp/Department/DepartmentSelector.swift
@@ -72,7 +72,6 @@ struct DepartmentSelector: View {
                     viewStore.send(.editDepartmentsButtonTapped)
                 }
             }
-            .navigationTitle("Department Selector")
         }
     }
 }
@@ -85,5 +84,6 @@ struct DepartmentSelector: View {
                 reducer: { DepartmentSelectorFeature() }
             )
         )
+        .navigationTitle("Department Selector")
     }
 }

--- a/KuringApp/KuringApp/Department/DepartmentSelector.swift
+++ b/KuringApp/KuringApp/Department/DepartmentSelector.swift
@@ -1,0 +1,89 @@
+//
+//  DepartmentSelector.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/24.
+//
+
+import Model
+import SwiftUI
+import ComposableArchitecture
+
+struct DepartmentSelectorFeature: Reducer {
+    struct State: Equatable {
+        var currentDepartment: Department?
+        var addedDepartment: IdentifiedArrayOf<Department>
+    }
+    
+    enum Action {
+        // TODO: String -> Department
+        case selectDepartment(id: Department.ID)
+        case editDepartmentsButtonTapped
+        case delegate(Delegate)
+        
+        enum Delegate {
+            case editDepartment
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case let .selectDepartment(id: id):
+                guard let department = state.addedDepartment.first(where: { $0.id == id }) else {
+                    return .none
+                    
+                }
+                state.currentDepartment = department
+                return .none
+            
+            case .editDepartmentsButtonTapped:
+                return .send(.delegate(.editDepartment))
+                
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+struct DepartmentSelector: View {
+    let store: StoreOf<DepartmentSelectorFeature>
+    
+    var body: some View {
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            List {
+                Section {
+                    ForEach(viewStore.addedDepartment) { department in
+                        Button {
+                            viewStore.send(.selectDepartment(id: department.id))
+                        } label: {
+                            Label(
+                                department.korName,
+                                systemImage: department == viewStore.currentDepartment
+                                ? "checkmark.circle.fill"
+                                : "circle"
+                            )
+                        }
+                    }
+                }
+                
+                Button("내 학과 편집하기") {
+                    viewStore.send(.editDepartmentsButtonTapped)
+                }
+            }
+            .navigationTitle("Department Selector")
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DepartmentSelector(
+            store: Store(
+                initialState: DepartmentSelectorFeature.State(addedDepartment: [.전기전자공학부, .컴퓨터공학부, .산업디자인학과]),
+                reducer: { DepartmentSelectorFeature() }
+            )
+        )
+    }
+}

--- a/KuringApp/KuringApp/NoticeApp.Path.swift
+++ b/KuringApp/KuringApp/NoticeApp.Path.swift
@@ -1,0 +1,41 @@
+//
+//  Path.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/22.
+//
+
+import Model
+import SwiftUI
+import ComposableArchitecture
+
+extension NoticeAppFeature {
+    struct Path: Reducer {
+        enum State {
+            case detail(NoticeDetailFeature.State)
+            case search(SearchFeature.State)
+            case departmentEditor(DepartmentEditorFeature.State)
+        }
+        
+        enum Action {
+            case detail(NoticeDetailFeature.Action)
+            case search(SearchFeature.Action)
+            case departmentEditor(DepartmentEditorFeature.Action)
+        }
+        
+        var body: some ReducerOf<Self> {
+            Scope(state: /State.detail, action: /Action.detail) {
+                NoticeDetailFeature()
+            }
+            
+            Scope(state: /State.search, action: /Action.search) {
+                SearchFeature()
+            }
+            
+            Scope(state: /State.departmentEditor, action: /Action.departmentEditor) {
+                DepartmentEditorFeature()
+            }
+        }
+    }
+
+}

--- a/KuringApp/KuringApp/NoticeApp.swift
+++ b/KuringApp/KuringApp/NoticeApp.swift
@@ -1,0 +1,110 @@
+//
+//  App.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/22.
+//
+
+import Model
+import SwiftUI
+import ComposableArchitecture
+
+struct NoticeAppFeature: Reducer {
+    struct State {
+        var path = StackState<Path.State>()
+        var noticeList = NoticeListFeature.State()
+    }
+    
+    enum Action {
+        case path(StackAction<Path.State, Path.Action>)
+        case noticeList(NoticeListFeature.Action)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Scope(state: \.noticeList, action: /Action.noticeList) {
+            NoticeListFeature()
+        }
+        
+        Reduce { state, action in
+            switch action {
+            case .path:
+                return .none
+                
+            case let .noticeList(.delegate(delegate)):
+                switch delegate {
+                case .editDepartment:
+                    state.path.removeAll()
+                    state.path.append(
+                        Path.State.departmentEditor(
+                            // TODO: init parameter 수정 (현재는 테스트용)
+                            DepartmentEditorFeature.State(
+                                myDepartments: [.전기전자공학부, .컴퓨터공학부],
+                                results: [.전기전자공학부, .컴퓨터공학부, .산업디자인학과]
+                            )
+                        )
+                    )
+                    return .none
+                }
+                
+            case .noticeList:
+                return .none
+            }
+        }
+        .forEach(\.path, action: /Action.path) {
+            Path()
+        }
+    }
+}
+
+struct NoticeAppView: View {
+    let store: StoreOf<NoticeAppFeature>
+    
+    var body: some View {
+        NavigationStackStore(self.store.scope(state: \.path, action: { .path($0) })) {
+            NoticeList(
+                store: self.store.scope(
+                    state: \.noticeList,
+                    action: { .noticeList($0) }
+                )
+            )
+        } destination: { state in
+            switch state {
+            case .detail:
+                CaseLet(
+                    /NoticeAppFeature.Path.State.detail,
+                     action: NoticeAppFeature.Path.Action.detail
+                ) { store in
+                    NoticeDetailView(store: store)
+                }
+                
+            case .search:
+                CaseLet(
+                    /NoticeAppFeature.Path.State.search,
+                     action: NoticeAppFeature.Path.Action.search
+                ) { store in
+                    SearchView(store: store)
+                }
+                
+            case .departmentEditor:
+                CaseLet(
+                    /NoticeAppFeature.Path.State.departmentEditor,
+                     action: NoticeAppFeature.Path.Action.departmentEditor
+                ) { store in
+                    DepartmentEditor(store: store)
+                }
+            }
+        }
+
+    }
+}
+
+#Preview {
+    NoticeAppView(
+        store: Store(
+            initialState: NoticeAppFeature.State(
+                noticeList: NoticeListFeature.State(notices: [.random])
+            ),
+            reducer: { NoticeAppFeature() }
+        )
+    )
+}

--- a/KuringApp/KuringApp/NoticeApp.swift
+++ b/KuringApp/KuringApp/NoticeApp.swift
@@ -75,6 +75,7 @@ struct NoticeAppView: View {
                      action: NoticeAppFeature.Path.Action.detail
                 ) { store in
                     NoticeDetailView(store: store)
+                        .navigationTitle("Notice Detail View")
                 }
                 
             case .search:
@@ -83,6 +84,7 @@ struct NoticeAppView: View {
                      action: NoticeAppFeature.Path.Action.search
                 ) { store in
                     SearchView(store: store)
+                        .navigationTitle("Search View")
                 }
                 
             case .departmentEditor:
@@ -91,6 +93,7 @@ struct NoticeAppView: View {
                      action: NoticeAppFeature.Path.Action.departmentEditor
                 ) { store in
                     DepartmentEditor(store: store)
+                        .navigationTitle("Department Editor")
                 }
             }
         }

--- a/KuringApp/KuringApp/NoticeList/NoticeDetailView.swift
+++ b/KuringApp/KuringApp/NoticeList/NoticeDetailView.swift
@@ -1,0 +1,120 @@
+//
+//  NoticeDetailView.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/22.
+//
+
+import Model
+import SwiftUI
+import ComposableArchitecture
+
+struct NoticeDetailFeature: Reducer {
+    struct State: Equatable {
+        var notice: Notice
+        var isBookmarked: Bool = false
+    }
+    
+    enum Action {
+        case bookmarkButtonTapped
+        
+        case delegate(Delegate)
+        
+        enum Delegate {
+            case bookmarkUpdated(Bool)
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .bookmarkButtonTapped:
+                state.isBookmarked.toggle()
+                return .none
+                
+            case .delegate:
+                return .none
+            }
+        }
+        .onChange(of: \.isBookmarked) { oldValue, newValue in
+            Reduce { state, action in
+                return .send(.delegate(.bookmarkUpdated(newValue)))
+            }
+        }
+    }
+}
+
+struct NoticeDetailView: View {
+    let store: StoreOf<NoticeDetailFeature>
+    
+    var body: some View {
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            List {
+                Section {
+                    Text(viewStore.state.notice.articleId)
+                    
+                    Text("`notice.articleId`")
+                } header: {
+                    Text("고유번호")
+                }
+
+                Section {
+                    Text(viewStore.state.notice.category)
+                    
+                    Text("`notice.category`")
+                } header: {
+                    Text("공지 카테고리")
+                }
+                
+                Section {
+                    Text(viewStore.state.notice.postedDate)
+                    
+                    Text("`notice.postedDate`")
+                } header: {
+                    Text("Posted date")
+                }
+                
+                Section {
+                    Text(viewStore.state.notice.subject)
+                    
+                    Text("`notice.subject`")
+                } header: {
+                    Text("공지 제목")
+                }
+                
+                Section {
+                    Text(viewStore.state.notice.url)
+                    
+                    Text("`notice.url`")
+                } header: {
+                    Text("URL")
+                }
+            }
+            .navigationTitle("Notice Detail View")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        viewStore.send(.bookmarkButtonTapped)
+                    } label: {
+                        Image(
+                            systemName: viewStore.state.isBookmarked
+                            ? "bookmark.fill"
+                            : "bookmark"
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        NoticeDetailView(
+            store: Store(
+                initialState: NoticeDetailFeature.State(notice: Notice.random),
+                reducer: { NoticeDetailFeature() }
+            )
+        )
+    }
+}

--- a/KuringApp/KuringApp/NoticeList/NoticeDetailView.swift
+++ b/KuringApp/KuringApp/NoticeList/NoticeDetailView.swift
@@ -90,7 +90,7 @@ struct NoticeDetailView: View {
                     Text("URL")
                 }
             }
-            .navigationTitle("Notice Detail View")
+            // TODO: Move to parent
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -116,5 +116,6 @@ struct NoticeDetailView: View {
                 reducer: { NoticeDetailFeature() }
             )
         )
+        .navigationTitle("Notice Detail View")
     }
 }

--- a/KuringApp/KuringApp/NoticeList/NoticeList.swift
+++ b/KuringApp/KuringApp/NoticeList/NoticeList.swift
@@ -138,6 +138,7 @@ struct NoticeList: View {
             ) { store in
                 NavigationStack {
                     DepartmentSelector(store: store)
+                        .navigationTitle("Department Selector")
                 }
             }
             .sheet(

--- a/KuringApp/KuringApp/NoticeList/NoticeList.swift
+++ b/KuringApp/KuringApp/NoticeList/NoticeList.swift
@@ -1,0 +1,166 @@
+//
+//  NoticeList.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/22.
+//
+
+import Model
+import SwiftUI
+import ComposableArchitecture
+
+struct NoticeListFeature: Reducer {
+    struct State: Equatable {
+        var notices: IdentifiedArrayOf<Notice> = []
+
+        var currentDepartment: Department?
+        @PresentationState var changeDepartment: DepartmentSelectorFeature.State?
+        
+        // TODO: (고민포인트) AppFeature 단으로 (부모 리듀서) 로 옮길 필요는 없을까? - 도메인에 대한 고민
+        @PresentationState var changeSubscription: SubscriptionAppFeature.State?
+    }
+    
+    enum Action {
+        case changeDepartmentButtonTapped
+        case changeSubscriptionButtonTapped
+        
+        case changeDepartment(PresentationAction<DepartmentSelectorFeature.Action>)
+        case changeSubscription(PresentationAction<SubscriptionAppFeature.Action>)
+        
+        case delegate(Delegate)
+        
+        enum Delegate {
+            case editDepartment
+        }
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .changeDepartmentButtonTapped:
+                state.changeDepartment = DepartmentSelectorFeature.State(
+                    currentDepartment: state.currentDepartment,
+                    addedDepartment: [.전기전자공학부, .컴퓨터공학부, .산업디자인학과]
+                )
+                return .none
+                
+            case .changeSubscriptionButtonTapped:
+                state.changeSubscription = SubscriptionAppFeature.State()
+                return .none
+                
+            case let .changeDepartment(.presented(.delegate(delegate))):
+                switch delegate {
+                case .editDepartment:
+                    state.changeDepartment = nil
+                    return .send(.delegate(.editDepartment))
+                }
+                
+                // TODO: Delegate
+            case .changeDepartment(.presented(.selectDepartment)):
+                guard let selectedDepartment = state.changeDepartment?.currentDepartment else {
+                    return .none
+                }
+                state.currentDepartment = selectedDepartment
+                return .none
+                
+            case .changeSubscription(.presented(.subscriptionView(.confirmButtonTapped))):
+                state.changeSubscription = nil
+                return .none
+                
+            case .changeDepartment:
+                return .none
+
+            case .changeSubscription:
+                return .none
+                
+            case .delegate:
+                return .none
+            }
+        }
+        .ifLet(\.$changeDepartment, action: /Action.changeDepartment) {
+            DepartmentSelectorFeature()
+        }
+        .ifLet(\.$changeSubscription, action: /Action.changeSubscription) {
+            SubscriptionAppFeature()
+        }
+    }
+}
+
+struct NoticeList: View {
+    let store: StoreOf<NoticeListFeature>
+    
+    var body: some View {
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            List {
+                Button((viewStore.currentDepartment ?? .전기전자공학부).korName) {
+                    viewStore.send(.changeDepartmentButtonTapped)
+                }
+                
+                ForEach(viewStore.state.notices) { notice in
+                    NavigationLink(
+                        state: NoticeAppFeature.Path.State.detail(
+                            NoticeDetailFeature.State(notice: notice)
+                        )
+                    ) {
+                        VStack(alignment: .leading) {
+                            Text(notice.subject)
+                            
+                            Text(notice.postedDate)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Notice List")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink(
+                        state: NoticeAppFeature.Path.State.search(
+                            SearchFeature.State()
+                        )
+                    ) {
+                        Image(systemName: "magnifyingglass")
+                    }
+                }
+                
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        viewStore.send(.changeSubscriptionButtonTapped)
+                    } label: {
+                        Image(systemName: "bell")
+                    }
+                }
+            }
+            .sheet(
+                store: self.store.scope(
+                    state: \.$changeDepartment,
+                    action: { .changeDepartment($0) }
+                )
+            ) { store in
+                NavigationStack {
+                    DepartmentSelector(store: store)
+                }
+            }
+            .sheet(
+                store: self.store.scope(
+                    state: \.$changeSubscription,
+                    action: { .changeSubscription($0) }
+                )
+            ) { store in
+                NavigationStack {
+                    SubscriptionApp(store: store)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        NoticeList(
+            store: Store(
+                initialState: NoticeListFeature.State(notices: [.random]),
+                reducer: { NoticeListFeature() }
+            )
+        )
+    }
+}

--- a/KuringApp/KuringApp/Search/SearchView.swift
+++ b/KuringApp/KuringApp/Search/SearchView.swift
@@ -1,0 +1,122 @@
+//
+//  SearchView.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/22.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct SearchFeature: Reducer {
+    struct State: Equatable {
+        var recents: [String] = []
+        var results: [String]? = nil
+        @BindingState var searchInfo: SearchInfo = SearchInfo()
+        @BindingState var focus: Field? = .search
+        
+        struct SearchInfo: Equatable {
+            var text: String = ""
+            var searchType: SearchType = .notice
+            
+            enum SearchType: String {
+                case notice
+                case staff
+            }
+        }
+        
+        enum Field {
+            case search
+        }
+    }
+    
+    enum Action: BindableAction {
+        /// 최근 검색어 전체 삭제
+        case deleteAllRecentsButtonTapped
+        case binding(BindingAction<State>)
+    }
+    
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+                
+            case .deleteAllRecentsButtonTapped:
+                state.recents.removeAll()
+                return .none
+            }
+        }
+    }
+}
+
+struct SearchView: View {
+    let store: StoreOf<SearchFeature>
+    @FocusState var focus: SearchFeature.State.Field?
+    
+    var body: some View {
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            List {
+                TextField("검색어를 입력해주세요", text: viewStore.$searchInfo.text)
+                    .focused($focus, equals: .search)
+                
+                Picker("어떤 것을 검색하시나요?", selection: viewStore.$searchInfo.searchType) {
+                    Text("공지")
+                        .tag(SearchFeature.State.SearchInfo.SearchType.notice)
+                    
+                    Text("교직원")
+                        .tag(SearchFeature.State.SearchInfo.SearchType.staff)
+                }
+                .pickerStyle(.segmented)
+                
+                Section {
+                    ScrollView(.horizontal) {
+                        LazyHStack {
+                            ForEach(viewStore.recents, id: \.self) { recent in
+                                Button(recent) {
+                                    
+                                }
+                            }
+                        }
+                    }
+                    
+                    Button("전체 삭제") {
+                        viewStore.send(.deleteAllRecentsButtonTapped)
+                    }
+                    .tint(.pink)
+                } header: {
+                    Text("최근 검색어")
+                }
+                
+                Section {
+                    Text(viewStore.searchInfo.text)
+                    
+                    Text(viewStore.searchInfo.searchType.rawValue)
+                } header: {
+                    Text("검색 정보")
+                }
+                
+                Section {
+                    if viewStore.results?.isEmpty == true {
+                        Text("검색결과가 없어요")
+                    }
+                }
+            }
+            .bind(viewStore.$focus, to: self.$focus)
+            .navigationTitle("Search View")
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SearchView(
+            store: Store(
+                initialState: SearchFeature.State(recents: ["방학", "운송수단", "운임표"]),
+                reducer: { SearchFeature() }
+            )
+        )        
+    }
+}

--- a/KuringApp/KuringApp/Search/SearchView.swift
+++ b/KuringApp/KuringApp/Search/SearchView.swift
@@ -105,7 +105,6 @@ struct SearchView: View {
                 }
             }
             .bind(viewStore.$focus, to: self.$focus)
-            .navigationTitle("Search View")
         }
     }
 }
@@ -118,5 +117,6 @@ struct SearchView: View {
                 reducer: { SearchFeature() }
             )
         )        
+        .navigationTitle("Search View")
     }
 }

--- a/KuringApp/KuringApp/Subscription/SubscriptionApp.swift
+++ b/KuringApp/KuringApp/Subscription/SubscriptionApp.swift
@@ -77,6 +77,7 @@ struct SubscriptionApp: View {
                      action: SubscriptionAppFeature.Path.Action.departmentEditor
                 ) { store in
                     DepartmentEditor(store: store)
+                        .navigationTitle("Department Editor")
                 }
             }
         }

--- a/KuringApp/KuringApp/Subscription/SubscriptionApp.swift
+++ b/KuringApp/KuringApp/Subscription/SubscriptionApp.swift
@@ -1,0 +1,96 @@
+//
+//  SubscriptionApp.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/24.
+//
+
+import Model
+import SwiftUI
+import ComposableArchitecture
+
+struct SubscriptionAppFeature: Reducer {
+    struct State: Equatable {
+        var path = StackState<Path.State>()
+        var subscriptionView = SubscriptionFeature.State()
+    }
+    
+    enum Action {
+        case path(StackAction<Path.State, Path.Action>)
+        case subscriptionView(SubscriptionFeature.Action)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Scope(state: \.subscriptionView, action: /Action.subscriptionView) {
+            SubscriptionFeature()
+        }
+        
+        Reduce { state, action in
+            switch action {
+            case .path:
+                return .none
+                
+            case .subscriptionView:
+                return .none
+            }
+        }
+        .forEach(\.path, action: /Action.path) {
+            Path()
+        }
+    }
+    
+    struct Path: Reducer {
+        enum State: Equatable {
+            case departmentEditor(DepartmentEditorFeature.State)
+        }
+        
+        enum Action {
+            case departmentEditor(DepartmentEditorFeature.Action)
+        }
+        
+        var body: some ReducerOf<Self> {
+            Scope(state: /State.departmentEditor, action: /Action.departmentEditor) {
+                DepartmentEditorFeature()
+            }
+        }
+    }
+}
+
+struct SubscriptionApp: View {
+    let store: StoreOf<SubscriptionAppFeature>
+    
+    var body: some View {
+        NavigationStackStore(
+            self.store.scope(state: \.path, action: { .path($0) })
+        ) {
+            SubscriptionView(
+                store: self.store.scope(
+                    state: \.subscriptionView, 
+                    action: { .subscriptionView($0) }
+                )
+            )
+        } destination: { state in
+            switch state {
+            case .departmentEditor:
+                CaseLet(
+                    /SubscriptionAppFeature.Path.State.departmentEditor,
+                     action: SubscriptionAppFeature.Path.Action.departmentEditor
+                ) { store in
+                    DepartmentEditor(store: store)
+                }
+            }
+        }
+
+    }
+}
+
+#Preview {
+    SubscriptionApp(
+        store: Store(
+            initialState: SubscriptionAppFeature.State(
+                subscriptionView: SubscriptionFeature.State()
+            ),
+            reducer: { SubscriptionAppFeature() }
+        )
+    )
+}

--- a/KuringApp/KuringApp/Subscription/SubscriptionView.swift
+++ b/KuringApp/KuringApp/Subscription/SubscriptionView.swift
@@ -1,0 +1,124 @@
+//
+//  SubscriptionView.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/24.
+//
+
+import Model
+import SwiftUI
+import ComposableArchitecture
+
+struct SubscriptionFeature: Reducer {
+    struct State: Equatable {
+        @BindingState var subscriptionType: SubscriptionType = .university
+        
+        var myDepartments: IdentifiedArrayOf<Department> = []
+        
+        enum SubscriptionType: Equatable {
+            case university
+            case department
+        }
+    }
+    
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        
+        case confirmButtonTapped
+        case editDepartmentsButtonTapped
+    }
+    
+    
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+                
+            case .binding:
+                return .none
+                
+            case .confirmButtonTapped:
+                return .none
+                
+            case .editDepartmentsButtonTapped:
+                return .none
+            }
+        }
+    }
+}
+
+struct SubscriptionView: View {
+    let store: StoreOf<SubscriptionFeature>
+    
+    var body: some View {
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            List {
+                Text("알림 받고 싶은 카테고리를 선택해 주세요")
+                
+                /**
+                 - `viewStore.$subscriptionType`
+                 */
+                Section {
+                    Picker("", selection: viewStore.$subscriptionType) {
+                        Text("일반 카테고리")
+                            .tag(SubscriptionFeature.State.SubscriptionType.university)
+                        
+                        Text("학과 카테고리")
+                            .tag(SubscriptionFeature.State.SubscriptionType.department)
+                    }
+                    .pickerStyle(.segmented)
+                }
+                
+                /**
+                 - `.editDepartmentsButtonTapped`
+                 */
+                if viewStore.subscriptionType == .department {
+                    Section {
+                        Button(
+                            viewStore.myDepartments.isEmpty
+                            ? "학과 추가하기"
+                            : "학과 편집하기"
+                        ) {
+                            viewStore.send(.editDepartmentsButtonTapped)
+                        }
+                        
+                        NavigationLink(
+                            state: SubscriptionAppFeature.Path.State.departmentEditor(
+                                // TODO: init parameter 수정 (현재는 테스트용)
+                                DepartmentEditorFeature.State(
+                                    myDepartments: [.전기전자공학부, .컴퓨터공학부],
+                                    results: [.전기전자공학부, .컴퓨터공학부, .산업디자인학과]
+                                )
+                            )
+                        ) {
+                            Text(
+                                viewStore.myDepartments.isEmpty
+                                ? "학과 추가하기"
+                                : "학과 편집하기"
+                            )
+                        }
+                    }
+                }
+                
+            }
+            .navigationTitle("Subscription View")
+            .toolbar {
+                Button("완료") {
+                    viewStore.send(.confirmButtonTapped)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SubscriptionView(
+            store: Store(
+                initialState: SubscriptionFeature.State(),
+                reducer: { SubscriptionFeature() }
+            )
+        )
+    }
+}

--- a/KuringApp/KuringApp/WillBeRemoved/Department.swift
+++ b/KuringApp/KuringApp/WillBeRemoved/Department.swift
@@ -1,0 +1,20 @@
+//
+//  Department.swift
+//  KuringApp
+//
+//  Created by Jaesung Lee on 2023/09/24.
+//
+
+import Foundation
+
+struct Department: Identifiable, Equatable {
+    let id: String
+    
+    var korName: String { self.id }
+}
+
+extension Department {
+    static let 전기전자공학부 = Department(id: "전기전자공학부")
+    static let 컴퓨터공학부 = Department(id: "컴퓨터공학부")
+    static let 산업디자인학과 = Department(id: "디자인학과")
+}

--- a/KuringModulePackage/Sources/Shared/Model/Notice.swift
+++ b/KuringModulePackage/Sources/Shared/Model/Notice.swift
@@ -30,11 +30,11 @@ public struct Notice: Codable, Hashable, Identifiable, Equatable {
 extension Notice {
     public static var random: Notice {
         Notice(
-            articleId: UUID().uuidString,
-            postedDate: UUID().uuidString,
-            subject: UUID().uuidString,
-            url: UUID().uuidString,
-            category: UUID().uuidString,
+            articleId: "5b4924e",
+            postedDate: "20211109",
+            subject: "교내 출입문 3곳(상허문, 일감문, 건국문) 차량 통제 안내 - 2022학년도 수시모집 논술고사일 - ",
+            url: "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?id=5b4924e",
+            category: "normal",
             important: false
         )
     }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@
 
 > **📄 개발 문서** [Documentation | ComposableArchitecture](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/)
 
+**Xcode 코드 스니펫**
+
+다음 경로에 자동으로 `Reducer` 와 `View`, `Preview` 까지 생성하는 코드 스니펫 파일이 있습니다.
+> /XcodeSnippets/FeatureSnippet.codesnippet
+
+터미널을 열고 다음 명령어를 실행하여 Xcode에 코드 스니펫 관리 폴더를 엽니다.
+> $ open Library/Developer/Xcode/UserData/CodeSnippets/
+
+폴더에 코드 스니펫 파일을 복사 붙여넣기 합니다.
+
+이제 Xcode 로 돌아가 `.swift` 파일에서 `feature` 를 입력하면 자동완성 목록에 뜨는 걸 확인할 수 있습니다.
+
 ### 디자인
 
 > **정보** 아래 링크는 쿠링 멤버만 볼 수 있는 노션 링크 입니다.

--- a/XcodeSnippets/FeatureSnippet.codesnippet
+++ b/XcodeSnippets/FeatureSnippet.codesnippet
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>feature</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>struct &lt;#Feature#&gt;: Reducer {
+    struct State: Equatable {
+        
+    }
+    
+    enum Action {
+        
+    }
+    
+    var body: some ReducerOf&lt;Self&gt; {
+        Reduce { state, action in
+            switch action {
+                
+            }
+        }
+    }
+}
+
+struct &lt;#View#&gt;: View {
+    let store: StoreOf&lt;&lt;#Feature#&gt;&gt;
+    
+    var body: some View {
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            Text("Hello world")
+        }
+    }
+}
+
+#Preview {
+    &lt;#View#&gt;(
+        store: Store(
+            initialState: &lt;#Feature.State#&gt;,
+            reducer: { &lt;#Feature#&gt; }
+        )
+    )
+}</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>A7AA6377-34F7-4CFA-BC42-D3F053CF01FA</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetPlatformFamily</key>
+	<string>iphoneos</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>The template for some feature that conforms to Reducer protocol.</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>Feature Template</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>


### PR DESCRIPTION
https://github.com/ku-ring/ios-app/assets/53814741/254f56fd-57a5-4696-bb63-8991255b3106

### 공지리스트
- [x] 공지리스트를 Root 로 하는 네비게이션 스택
- [x] 공지리스트 --push--> 공지상세뷰

### 검색
- [x] 공지리스트 --push--> 검색뷰

### 학과선택
- [x] 공지리스트 --modal--> 학과 선택 뷰
- [x] 학과선택뷰 --dismiss--> 공지리스트 --push--> 학과편집뷰

### 구독
- [x] 공지리스트 --push--> 구독뷰
- [x] 구독뷰 --push--> 학과편집뷰 


## 중요

pointfree.co 에피소드 244(Introducing Standups), 245(Navigation), 246(Stacks) 에 대한 선수지식을 필요로합니다.

## Xcode 코드스니펫

/XcodeSnippets 경로에 FeatureSnippet 이라는 코드스니펫 파일을 올려두었습니다.
README.md 에 적어놓은 가이드를 따라서 Xcode에 적용 후 사용하면 됩니다.

**자동완성 목록**
<img width="322" alt="Screenshot 2023-09-25 at 12 49 17 AM" src="https://github.com/ku-ring/ios-app/assets/53814741/0bd34fad-0c35-4039-af88-068b64c3418b">

**자동완성**
<img width="694" alt="Screenshot 2023-09-25 at 12 49 37 AM" src="https://github.com/ku-ring/ios-app/assets/53814741/66e0902a-fd89-48b0-93ea-dfccc8df2b3a">

| 입력 | 설명 |
| --- | --- |
| Feature | 리듀서 프로토콜을 준수하는 도메인 이름 |
| View | `Feature` 를 사용할 뷰 이름 |
| Feature.State | `Feature` 의 `State` |