### PR TITLE
[2.0.0] 탭바에 더보기 추가

### DIFF
--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -24,6 +24,20 @@ struct ContentView: View {
                 
                 Text("공지사항")
             }
+            
+            SettingsApp(
+                store: Store(
+                    initialState: SettingsAppFeature.State(),
+                    reducer: { SettingsAppFeature() }
+                )
+            )
+            .navigationTitle("더보기")
+            .navigationBarTitleDisplayMode(.inline)
+            .tabItem {
+                Image(systemName: "ellipsis")
+                
+                Text("더보기")
+            }
         }
     }
 }

--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -31,8 +31,6 @@ struct ContentView: View {
                     reducer: { SettingsAppFeature() }
                 )
             )
-            .navigationTitle("더보기")
-            .navigationBarTitleDisplayMode(.inline)
             .tabItem {
                 Image(systemName: "ellipsis")
                 

--- a/KuringApp/KuringApp/Setting/SettingView.swift
+++ b/KuringApp/KuringApp/Setting/SettingView.swift
@@ -37,27 +37,46 @@ struct SettingView: View {
     
     var body: some View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-            Form {
+            List {
                 Section {
-                    List {
-                        NavigationLink(
-                            state: SettingsAppFeature.Path.State.appIconSelector(
-                                AppIconSelectorFeature.State()
-                            )
-                        ) {
-                            HStack {
-                                Text("앱 아이콘 바꾸기")
-                                
-                                Spacer()
-                                
-                                Text(viewStore.state.currentAppIcon?.korValue ?? KuringIcon.kuring_app.korValue)
-                            }
+                    Label("공지 구독하기", systemImage: "bell")
+                    
+                    Label("기타 알림 받기", systemImage: "bell")
+                } header: {
+                    Text("공지구독")
+                }
+                
+                Section {
+                    NavigationLink(
+                        state: SettingsAppFeature.Path.State.appIconSelector(
+                            AppIconSelectorFeature.State()
+                        )
+                    ) {
+                        HStack {
+                            Text("앱 아이콘 바꾸기")
+                            
+                            Spacer()
+                            
+                            Text(viewStore.state.currentAppIcon?.korValue ?? KuringIcon.kuring_app.korValue)
                         }
                     }
                 } header: {
                     Text("정보")
                 }
+                
+                Section {
+                    
+                } header: {
+                    Text("SNS")
+                }
+                
+                Section {
+                    
+                } header: {
+                    Text("피드백")
+                }
             }
+            .navigationTitle("더보기")
         }
     }
 }

--- a/KuringApp/KuringApp/Setting/SettingsApp.swift
+++ b/KuringApp/KuringApp/Setting/SettingsApp.swift
@@ -79,14 +79,10 @@ struct SettingsApp: View {
 }
 
 #Preview {
-    NavigationStack {
-        SettingsApp(
-            store: Store(
-                initialState: SettingsAppFeature.State(),
-                reducer: { SettingsAppFeature() }
-            )
+    SettingsApp(
+        store: Store(
+            initialState: SettingsAppFeature.State(),
+            reducer: { SettingsAppFeature() }
         )
-        .navigationTitle("더보기")
-        .navigationBarTitleDisplayMode(.inline)
-    }
+    )
 }


### PR DESCRIPTION
| 탭1 공지사항 | 탭2 더보기 |
| --- | --- |
| <img width="371" alt="스크린샷 2023-10-12 오전 12 44 15" src="https://github.com/ku-ring/ios-app/assets/53814741/7ca00a95-7e81-4c8f-98de-c307b77b479a"> | <img width="416" alt="스크린샷 2023-10-12 오전 12 41 51" src="https://github.com/ku-ring/ios-app/assets/53814741/7c49c29b-9f1a-4a9b-8e63-6db6c052d593"> |

### 개요

`SettingsApp` 을 `ContentView`의 `TabView` 안에 추가하였습니다.

로직 수정 없이 `TabView`에만 추가한 간단한 작업이라 자동 머지 기능 활성화 해두겠습니다. (요구하는 승인 개수: 1)
