### PR TITLE
[2.0.0] 일반 카테고리 아이템 배경 둥근 모서리 적용

### DIFF
--- a/KuringPackage/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
+++ b/KuringPackage/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
@@ -56,7 +56,7 @@ struct SubscriptionView: View {
                                         isSelected ? Color.accentColor : Color.clear,
                                         lineWidth: isSelected ? 2 : 0
                                     )
-                                    .background(
+                                    .fill(
                                         isSelected
                                         ? Color.accentColor.opacity(0.1)
                                         : Color.black.opacity(0.03)

--- a/KuringPackage/Tests/SubscriptionFeaturesTests/SubscriptionTests.swift
+++ b/KuringPackage/Tests/SubscriptionFeaturesTests/SubscriptionTests.swift
@@ -7,9 +7,14 @@ import ComposableArchitecture
 @MainActor
 class SubscriptionTests: XCTestCase {
     func test_tapConfirmButton() async throws {
+        let dismissed = self.expectation(description: "dismissed")
+
         let store = TestStore(
             initialState: SubscriptionFeature.State(),
-            reducer: { SubscriptionFeature() }
+            reducer: { SubscriptionFeature() },
+            withDependencies: {
+                $0.dismiss = DismissEffect { dismissed.fulfill() }
+            }
         )
         await store.send(.confirmButtonTapped) {
             $0.isWaitingResponse = true
@@ -18,6 +23,8 @@ class SubscriptionTests: XCTestCase {
         await store.receive(.subscriptionResponse(true)) {
             $0.isWaitingResponse = false
         }
+        
+        await self.fulfillment(of: [dismissed])
     }
     
     func test_selectSegment() async throws {


### PR DESCRIPTION
| 변경 전 | 변경 후 |
| --- | --- |
|  <img width="98" alt="스크린샷 2023-12-30 오전 12 44 07" src="https://github.com/ku-ring/ios-app/assets/53814741/a34ef2ce-24f2-4370-a92c-d3668fa2731f"> | <img width="95" alt="스크린샷 2023-12-30 오전 12 43 59" src="https://github.com/ku-ring/ios-app/assets/53814741/f51f9849-a02a-4136-b62d-13233f11cdd9"> |

