### PR TITLE
[2.0.0] NoticeFeatures 에 bookmarks 디펜던시 로직 적용

### DIFF
--- a/.github/workflows/TEST_PACKAGE_TARGET_iOS17.yml
+++ b/.github/workflows/TEST_PACKAGE_TARGET_iOS17.yml
@@ -3,12 +3,14 @@ name: 쿠링 패키지 iOS17에서 테스트하기
 on:
   issue_comment:
     types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
 
 # TODO: 각 스킴 비동기로 실행하도록 하기
 
 jobs:
   build:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/쿠링') && contains(github.event.comment.body, '패키지 테스트')
+    if: contains(github.event.comment.body, '/쿠링') && contains(github.event.comment.body, '패키지 테스트')
     runs-on: macos-13  #최신버전
     steps:
       # 테스트 요청 시작

--- a/.github/workflows/TEST_PACKAGE_TARGET_iOS17.yml
+++ b/.github/workflows/TEST_PACKAGE_TARGET_iOS17.yml
@@ -3,14 +3,12 @@ name: 쿠링 패키지 iOS17에서 테스트하기
 on:
   issue_comment:
     types: [created, edited]
-  pull_request_review_comment:
-    types: [created, edited]
 
 # TODO: 각 스킴 비동기로 실행하도록 하기
 
 jobs:
   build:
-    if: contains(github.event.comment.body, '/쿠링') && contains(github.event.comment.body, '패키지 테스트')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/쿠링') && contains(github.event.comment.body, '패키지 테스트')
     runs-on: macos-13  #최신버전
     steps:
       # 테스트 요청 시작
@@ -31,9 +29,11 @@ jobs:
               body: '🔨 iOS 17 iPhone 15 Pro 에서 쿠링 패키지를 테스트 합니다.'
             })
 
-      # 코드를 체크아웃 합니다.
+      # 코드를 PR 브랜치 HEAD로 체크아웃 합니다.
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
     
       # Xcode 버전을 설정합니다.
       - name: Setup Xcode version

--- a/KuringPackage/Package.swift
+++ b/KuringPackage/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
             name: "NoticeUI",
             dependencies: [
                 "NoticeFeatures", "SearchFeatures", "SubscriptionUI", "DepartmentUI", "SearchUI",
-                "ColorSet",
+                "ColorSet", "Caches",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ],
             path: "Sources/UIKit/NoticeUI",
@@ -86,6 +86,7 @@ let package = Package(
             name: "NoticeFeatures",
             dependencies: [
                 "Models",
+                "Caches",
                 "DepartmentFeatures",
                 "SearchFeatures",
                 "SubscriptionFeatures",

--- a/KuringPackage/Package.swift
+++ b/KuringPackage/Package.swift
@@ -190,7 +190,7 @@ let package = Package(
         .testTarget(
             name: "NoticeFeaturesTests",
             dependencies: [
-                "NoticeFeatures", "SearchFeatures", "Models",
+                "NoticeFeatures", "SearchFeatures", "Models", "Caches",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
             ]
         ),

--- a/KuringPackage/Sources/Features/NoticeFeatures/NoticeList.swift
+++ b/KuringPackage/Sources/Features/NoticeFeatures/NoticeList.swift
@@ -1,3 +1,4 @@
+import Caches
 import Models
 import KuringLink
 import DepartmentFeatures
@@ -92,6 +93,7 @@ public struct NoticeListFeature {
         case fetchNotices
     }
     
+    @Dependency(\.bookmarks) public var bookmarks
     @Dependency(\.kuringLink) public var kuringLink
     
     public var body: some ReducerOf<Self> {
@@ -178,7 +180,12 @@ public struct NoticeListFeature {
                 return .none
             
             case let .bookmarkTapped(notice):
-                print("공지#\(notice.articleId)을 북마크 했습니다.")
+                do {
+                    print("공지#\(notice.articleId)을 북마크 했습니다.")
+                    try bookmarks.add(notice)
+                } catch {
+                    print("북마크 하는 중에 에러가 발생했습니다: \(error.localizedDescription)")
+                }
                 return .none
                 
             case let .loadingChanged(isLoading):
@@ -193,7 +200,7 @@ public struct NoticeListFeature {
                 return .none
             }
         }
-        .ifLet(\.$changeDepartment, action: /Action.changeDepartment) {
+        .ifLet(\.$changeDepartment, action: \.changeDepartment) {
             DepartmentSelectorFeature()
         }
     }

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeRow.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeRow.swift
@@ -1,5 +1,7 @@
+import Caches
 import Models
 import SwiftUI
+import ComposableArchitecture
 
 public struct NoticeRow: View {
     var rowType: NoticeRowType
@@ -8,13 +10,19 @@ public struct NoticeRow: View {
     public init(notice: Notice) {
         self.notice = notice
         
-        var bookmarkedNotices = [Notice]()
-        let isBookmark: Bool = bookmarkedNotices.contains(notice)
+        var isBookmarked: Bool
+        @Dependency(\.bookmarks) var bookmarks
+        do {
+            let bookmarkedNotices = try bookmarks()
+            isBookmarked = bookmarkedNotices.contains(self.notice)
+        } catch {
+            isBookmarked = false
+        }
         if notice.important {
-            if isBookmark { self.rowType = .importantAndBookmark }
+            if isBookmarked { self.rowType = .importantAndBookmark }
             else { self.rowType = .important }
         } else {
-            if isBookmark { self.rowType = .bookmark }
+            if isBookmarked { self.rowType = .bookmark }
             else { self.rowType = .none }
         }
     }

--- a/KuringPackage/Tests/NoticeFeaturesTests/NoticeDetailTests.swift
+++ b/KuringPackage/Tests/NoticeFeaturesTests/NoticeDetailTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import Models
+import Caches
+import ComposableArchitecture
+@testable import NoticeFeatures
+
+// TODO: associatedType 으로 TestStore 자동 생성하게
+@MainActor
+final class NoticeDetailTests: XCTestCase {
+    func test_bookmarkButtonTapped() async throws {
+        let store = TestStore(
+            initialState: NoticeDetailFeature.State(notice: Notice.random),
+            reducer: { NoticeDetailFeature() },
+            withDependencies: { $0.bookmarks = Bookmarks.default }
+        )
+        let isNoticeBookmarked = store.state.isBookmarked
+        await store.send(.bookmarkButtonTapped) {
+            $0.isBookmarked = !isNoticeBookmarked
+        }
+        
+        await store.receive(.delegate(.bookmarkUpdated(!isNoticeBookmarked)))
+    }
+
+}


### PR DESCRIPTION
- 이슈: Package 쪽에 `bookmarks.remove(_:)` 가 제대로 되지 않는 이슈
- 앱프로젝트에서는 잘 동작

| 북마크 전 공지리스트 | 북마크 전 공지 화면 | 북마크 후 공지 화면 | 북마크 후 공지리스트 |
| --- | --- | --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-30 at 16 17 27](https://github.com/ku-ring/ios-app/assets/53814741/151349bc-867d-4054-acb1-ea066bd91836) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-30 at 16 17 30](https://github.com/ku-ring/ios-app/assets/53814741/85102566-1871-491c-8a13-d8e09d773cc5) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-30 at 16 17 34](https://github.com/ku-ring/ios-app/assets/53814741/84021c81-407d-43cc-8c3f-f96ea3f48a8d) |  ![Simulator Screenshot - iPhone 15 Pro - 2023-12-30 at 16 17 37](https://github.com/ku-ring/ios-app/assets/53814741/262307c3-6ea4-4fe4-bbc0-2ae8e6a1119a) |



