### PR TITLE
[2.0.0] 이슈해결: Scoping from uncached Store is not compatible with observation 

### DIFF
--- a/.github/workflows/BUILD_APP_TARGET_iOS17.yml
+++ b/.github/workflows/BUILD_APP_TARGET_iOS17.yml
@@ -29,7 +29,9 @@ jobs:
 
       # 코드를 체크아웃 합니다.
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
     
       # Xcode 버전을 설정합니다.
       - name: Setup Xcode version

--- a/.github/workflows/BUILD_PACKAGE.yml
+++ b/.github/workflows/BUILD_PACKAGE.yml
@@ -29,7 +29,9 @@ jobs:
 
       # 코드를 체크아웃 합니다.
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
     
       # Xcode 버전을 설정합니다.
       - name: Setup Xcode version

--- a/.github/workflows/TEST_APP_TARGET_iOS17.yml
+++ b/.github/workflows/TEST_APP_TARGET_iOS17.yml
@@ -29,7 +29,9 @@ jobs:
 
       # 코드를 체크아웃 합니다.
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
     
       # Xcode 버전을 설정합니다.
       - name: Setup Xcode version

--- a/KuringPackage/Sources/Features/SearchFeatures/Search.swift
+++ b/KuringPackage/Sources/Features/SearchFeatures/Search.swift
@@ -195,7 +195,7 @@ public struct SearchFeature {
                 return .none
             }
         }
-        .ifLet(\.$staffDetail, action: /Action.staffDetail) {
+        .ifLet(\.$staffDetail, action: \.staffDetail) {
             StaffDetailFeature()
         }
     }

--- a/KuringPackage/Sources/Features/SubscriptionFeatures/SubscriptionApp.swift
+++ b/KuringPackage/Sources/Features/SubscriptionFeatures/SubscriptionApp.swift
@@ -51,6 +51,9 @@ public struct SubscriptionAppFeature {
         .forEach(\.path, action: \.path) {
             Path()
         }
+        .onChange(of: \.path.first?.departmentEditor?.myDepartments) { _, _ in
+            EmptyReducer()
+        }
     }
     
     public init() {

--- a/KuringPackage/Sources/UIKit/NoticeUI/DepartmentSelectorLink.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/DepartmentSelectorLink.swift
@@ -35,6 +35,6 @@ struct DepartmentSelectorLink: View {
         department: .init(name: "산업디자인학과", hostPrefix: "kuid", korName: "산업디자인학과", category: .학과),
         isLoading: .constant(false)
     ) {
-        // 액션 정의. 예) `viewStore.send(.changeDepartmentButtonTapped)`
+        // 액션 정의. 예) `store.send(.changeDepartmentButtonTapped)`
     }
 }

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -46,8 +46,8 @@ public struct NoticeApp: View {
                 }
             }
             .sheet(
-                store: self.store.scope(
-                    state: \.$changeSubscription,
+                item: $store.scope(
+                    state: \.changeSubscription,
                     action: \.changeSubscription
                 )
             ) { store in

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeContentView.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeContentView.swift
@@ -24,8 +24,8 @@ struct NoticeContentView: View {
             store.send(.onAppear) // TODO: error on the preview canvas
         }
         .sheet(
-            store: self.store.scope(
-                state: \.$changeDepartment,
+            item: $store.scope(
+                state: \.changeDepartment,
                 action: \.changeDepartment
             )
         ) { store in

--- a/KuringPackage/Sources/UIKit/SearchUI/SearchDetailView.swift
+++ b/KuringPackage/Sources/UIKit/SearchUI/SearchDetailView.swift
@@ -4,7 +4,7 @@ import SearchFeatures
 import ComposableArchitecture
 
 public struct StaffDetailView: View {
-    let store: StoreOf<StaffDetailFeature>
+    @Bindable var store: StoreOf<StaffDetailFeature>
     
     public var body: some View {
         List {

--- a/KuringPackage/Sources/UIKit/SearchUI/SearchView.swift
+++ b/KuringPackage/Sources/UIKit/SearchUI/SearchView.swift
@@ -180,8 +180,8 @@ public struct SearchView: View {
         .padding(.horizontal, 20)
         .bind($store.focus, to: self.$focus)
         .sheet(
-            store: self.store.scope(
-                state: \.$staffDetail,
+            item: $store.scope(
+                state: \.staffDetail,
                 action: \.staffDetail
             )
         ) { store in

--- a/KuringPackage/Sources/UIKit/SettingsUI/SettingsApp.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/SettingsApp.swift
@@ -5,7 +5,7 @@ import SettingsFeatures
 import ComposableArchitecture
 
 public struct SettingsApp: View {
-    @Bindable public var store: StoreOf<SettingsAppFeature>
+    @Bindable var store: StoreOf<SettingsAppFeature>
     
     public var body: some View {
         NavigationStack(
@@ -38,32 +38,32 @@ public struct SettingsApp: View {
             }
         }
         .sheet(
-            store: self.store.scope(
-                state: \.$destination.labs,
+            item: $store.scope(
+                state: \.destination?.labs,
                 action: \.destination.labs
             )
         ) { store in
             LabApp(store: store)
         }
         .sheet(
-            store: self.store.scope(
-                state: \.$destination.subscription,
+            item: $store.scope(
+                state: \.destination?.subscription,
                 action: \.destination.subscription
             )
         ) { store in
             SubscriptionApp(store: store)
         }
         .sheet(
-            store: self.store.scope(
-                state: \.$destination.feedback,
+            item: $store.scope(
+                state: \.destination?.feedback,
                 action: \.destination.feedback
             )
         ) { store in
             FeedbackView(store: store)
         }
         .sheet(
-            store: self.store.scope(
-                state: \.$destination.informationWeb,
+            item: $store.scope(
+                state: \.destination?.informationWeb,
                 action: \.destination.informationWeb
             )
         ) { store in


### PR DESCRIPTION
## 이슈

이슈링크: https://github.com/ku-ring/ios-app/issues/79

Subscription 화면에서 학과 편집 버튼을 눌러서 DepartmentEditor 로 넘어가는 경우 다음과 같은 런타임 경고가 발생합니다.

> **에러** Scoping from uncached StoreOf<SubscriptionAppFeature.Path> is not compatible with observation. Ensure that all parent store scoping operations take key paths and case key paths instead of transform functions, which have been deprecated.

## 해결방법

1.7 마이그레이션 가이드에 따라 `sheet(store:content:)` 가 아닌 `sheet(item:content:)` 으로 수정하여 해결