### PR TITLE
[2.0.0] 보관함 UI 추가

### DIFF
--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -7,8 +7,10 @@
 
 import SwiftUI
 import NoticeUI
+import BookmarkUI
 import SettingsUI
 import NoticeFeatures
+import BookmarkFeatures
 import SettingsFeatures
 import ComposableArchitecture
 
@@ -27,6 +29,20 @@ struct ContentView: View {
                 Image(systemName: "list.dash")
                 
                 Text("공지사항")
+            }
+            
+            BookmarkApp(
+                store: Store(
+                    initialState: BookmarkAppFeature.State(
+                        bookmarkList: BookmarkListFeature.State()
+                    ),
+                    reducer: { BookmarkAppFeature() }
+                )
+            )
+            .tabItem {
+                Image(systemName: "archivebox")
+                
+                Text("공지보관함")
             }
             
             SettingsApp(

--- a/KuringPackage/Package.swift
+++ b/KuringPackage/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
                 "SubscriptionUI",
                 "DepartmentUI",
                 "SearchUI",
+                "BookmarkUI",
                 "SettingsUI",
             ]
         ),
@@ -68,6 +69,14 @@ let package = Package(
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ],
             path: "Sources/UIKit/SearchUI"
+        ),
+        .target(
+            name: "BookmarkUI",
+            dependencies: [
+                "BookmarkFeatures", "NoticeUI", "NoticeFeatures",
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+            ],
+            path: "Sources/UIKit/BookmarkUI"
         ),
         .target(
             name: "SettingsUI",
@@ -127,6 +136,7 @@ let package = Package(
         .target(
             name: "BookmarkFeatures",
             dependencies: [
+                "NoticeFeatures",
                 "Models",
                 "Caches",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")

--- a/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkApp.Path.swift
+++ b/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkApp.Path.swift
@@ -1,0 +1,22 @@
+import NoticeFeatures
+import ComposableArchitecture
+
+extension BookmarkAppFeature {
+    @Reducer
+    public struct Path {
+        @ObservableState // TODO: 필요??
+        public enum State: Equatable {
+            case detail(NoticeDetailFeature.State)
+        }
+        
+        public enum Action {
+            case detail(NoticeDetailFeature.Action)
+        }
+        
+        public var body: some ReducerOf<Self> {
+            Scope(state: \.detail, action: \.detail) {
+                NoticeDetailFeature()
+            }
+        }
+    }
+}

--- a/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkApp.swift
+++ b/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkApp.swift
@@ -1,0 +1,51 @@
+import ComposableArchitecture
+
+@Reducer
+public struct BookmarkAppFeature {
+    @ObservableState
+    public struct State: Equatable {
+        // MARK: 네비게이션
+        
+        /// 루트
+        public var bookmarkList = BookmarkListFeature.State()
+        /// 스택 네비게이션
+        public var path = StackState<Path.State>()
+        
+        public init(
+            bookmarkList: BookmarkListFeature.State = BookmarkListFeature.State(),
+            path: StackState<Path.State> = StackState<Path.State>()
+        ) {
+            self.bookmarkList = bookmarkList
+            self.path = path
+        }
+    }
+    
+    public enum Action {
+        /// 루트 액션 (``BookmarkListFeature/Action``)
+        case bookmarkList(BookmarkListFeature.Action)
+        
+        /// 스택 네비게이션 액션 (``BookmarkAppFeature/Path/Action``)
+        case path(StackAction<Path.State, Path.Action>)
+    }
+    
+    public var body: some ReducerOf<Self> {
+        Scope(state: \.bookmarkList, action: \.bookmarkList) {
+            BookmarkListFeature()
+        }
+        
+        Reduce { state, action in
+            switch action {
+            case .path:
+                return .none
+                
+            case .bookmarkList:
+                return .none
+            }
+        }
+        .forEach(\.path, action: \.path) {
+            Path()
+        }
+    }
+    
+    public init() { }
+}

--- a/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkList.swift
+++ b/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkList.swift
@@ -11,7 +11,9 @@ public struct BookmarkListFeature: Reducer {
     public struct State: Equatable {
         public var bookmarkedNotices: IdentifiedArrayOf<Notice> = []
         
-        public var selectedIDs: [Notice.ID] = []
+        /// 편집시 선택한 북마크 ID
+        /// - Note: 순서는 중요하지 않고 중복제거만 중요하므로 `Set` 사용
+        public var selectedIDs: Set<Notice.ID> = []
         
         public var editMode: EditMode = .none
         
@@ -34,6 +36,8 @@ public struct BookmarkListFeature: Reducer {
         case bookmarksUpdate([Notice])
         /// 편집 버튼 눌렀을 때
         case editButtonTapped
+        /// 전체 선택 버튼 눌렀을 때
+        case selectAllButtonTapped
         /// 삭제 버튼 눌렀을 때
         case deleteButtonTapped
     }
@@ -66,6 +70,10 @@ public struct BookmarkListFeature: Reducer {
                 
             case .editButtonTapped:
                 state.editMode = .editing(deletable: false)
+                return .none
+                
+            case .selectAllButtonTapped:
+                state.selectedIDs = Set(state.bookmarkedNotices.ids)
                 return .none
                 
             case .deleteButtonTapped:

--- a/KuringPackage/Sources/Networks/KuringLink.Dependency.swift
+++ b/KuringPackage/Sources/Networks/KuringLink.Dependency.swift
@@ -90,7 +90,7 @@ extension KuringLink: DependencyKey {
             let isSucceed = (200..<300) ~= response.code
             return isSucceed
         }
-        )
+    )
 }
 
 extension DependencyValues {

--- a/KuringPackage/Sources/Networks/KuringLink.swift
+++ b/KuringPackage/Sources/Networks/KuringLink.swift
@@ -42,6 +42,7 @@ public struct KuringLink {
     
     public var searchStaffs: (_ keyword: String) async throws -> [Staff]
     
+    // MARK: - Subscriptions
     public var subscribeUnivNotices: ([NoticeTypeName]) async throws -> Bool
     
     public var subscribeDepartments: ([DepartmentHostPrefix]) async throws -> Bool

--- a/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkApp.swift
+++ b/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkApp.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import NoticeUI
+import BookmarkFeatures
+import ComposableArchitecture
+
+struct BookmarkApp: View {
+    @Bindable var store: StoreOf<BookmarkAppFeature>
+    
+    public var body: some View {
+        NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+            BookmarkList(
+                store: store.scope(
+                    state: \.bookmarkList,
+                    action: \.bookmarkList
+                )
+            )
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("보관함")
+            
+        } destination: { store in
+            switch store.state {
+            case .detail:
+                if let store = store.scope(state: \.detail, action: \.detail) {
+                    NoticeDetailView(store: store)
+                }
+            }
+        }
+    }
+    
+    public init(store: StoreOf<BookmarkAppFeature>) {
+        self.store = store
+    }
+}
+
+#Preview {
+    BookmarkApp(
+        store: Store(
+            initialState: BookmarkAppFeature.State(
+                bookmarkList: BookmarkListFeature.State(
+                    bookmarkedNotices: [.random]
+                )
+            ),
+            reducer: { BookmarkAppFeature() }
+        )
+    )
+}

--- a/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkApp.swift
+++ b/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkApp.swift
@@ -3,7 +3,7 @@ import NoticeUI
 import BookmarkFeatures
 import ComposableArchitecture
 
-struct BookmarkApp: View {
+public struct BookmarkApp: View {
     @Bindable var store: StoreOf<BookmarkAppFeature>
     
     public var body: some View {
@@ -36,9 +36,7 @@ struct BookmarkApp: View {
     BookmarkApp(
         store: Store(
             initialState: BookmarkAppFeature.State(
-                bookmarkList: BookmarkListFeature.State(
-                    bookmarkedNotices: [.random]
-                )
+                bookmarkList: BookmarkListFeature.State()
             ),
             reducer: { BookmarkAppFeature() }
         )

--- a/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkList.swift
+++ b/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkList.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import NoticeUI
+import NoticeFeatures
+import BookmarkFeatures
+import ComposableArchitecture
+
+public struct BookmarkList: View {
+    @Bindable var store: StoreOf<BookmarkListFeature>
+    
+    public var body: some View {
+        List {
+            ForEach(self.store.bookmarkedNotices, id: \.id) { notice in
+                HStack {
+                    NoticeRow(notice: notice)
+                        .background {
+                            NavigationLink(
+                                state: BookmarkAppFeature.Path.State.detail(
+                                    NoticeDetailFeature.State(notice: notice)
+                                )
+                            ) {
+                                EmptyView()
+                            }
+                            .opacity(0)
+                        }
+                    .disabled(store.editMode != .none)
+                    
+                    Button {
+                        if store.selectedIDs.contains(notice.id) {
+                            store.selectedIDs.remove(notice.id)
+                        } else {
+                            store.selectedIDs.insert(notice.id)
+                        }
+                    } label: {
+                        Image(
+                            systemName: store.selectedIDs.contains(notice.id)
+                            ? "checkmark.circle.fill"
+                            : "circle"
+                        )
+                        .foregroundStyle(Color.accentColor)
+                    }
+                    .opacity(store.editMode == .none ? 0 : 1)
+                    .disabled(store.editMode == .none)
+                }
+            }
+            .listRowSeparator(.hidden)
+        }
+        .listStyle(.plain)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    store.editMode = .none
+                } label: {
+                    Text("취소")
+                }
+                .disabled(store.selectedIDs.isEmpty)
+                .opacity(store.editMode == .none ? 0 : 1)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    switch store.editMode {
+                    case .none:
+                        store.send(.editButtonTapped)
+                    case .editing:
+                        store.send(.selectAllButtonTapped)
+                    }
+                } label: {
+                    switch store.editMode {
+                    case .none:
+                        Text("편집")
+                    case .editing:
+                        Text("전체 선택")
+                    }
+                }
+                .foregroundStyle(Color.accentColor)
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        BookmarkList(
+            store: Store(
+                initialState: BookmarkListFeature.State(
+                    bookmarkedNotices: [.random]
+                ),
+                reducer: { BookmarkListFeature() }
+            )
+        )
+    }
+}

--- a/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkList.swift
+++ b/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkList.swift
@@ -8,10 +8,16 @@ public struct BookmarkList: View {
     @Bindable var store: StoreOf<BookmarkListFeature>
     
     public var body: some View {
-        List {
-            ForEach(self.store.bookmarkedNotices, id: \.id) { notice in
-                HStack {
-                    NoticeRow(notice: notice)
+        ZStack(alignment: .bottom) {
+            List {
+                ForEach(self.store.bookmarkedNotices, id: \.id) { notice in
+                    HStack {
+                        NoticeRow(
+                            notice: notice,
+                            rowType: store.isEditing
+                            ? NoticeRow.NoticeRowType.none
+                            : nil
+                        )
                         .background {
                             NavigationLink(
                                 state: BookmarkAppFeature.Path.State.detail(
@@ -22,70 +28,123 @@ public struct BookmarkList: View {
                             }
                             .opacity(0)
                         }
-                    .disabled(store.editMode != .none)
-                    
-                    Button {
-                        if store.selectedIDs.contains(notice.id) {
-                            store.selectedIDs.remove(notice.id)
-                        } else {
-                            store.selectedIDs.insert(notice.id)
+                        .disabled(store.editMode != .none)
+                        
+                        if store.isEditing {
+                            Button {
+                                if store.selectedIDs.contains(notice.id) {
+                                    store.selectedIDs.remove(notice.id)
+                                } else {
+                                    store.selectedIDs.insert(notice.id)
+                                }
+                            } label: {
+                                Image(
+                                    systemName: store.selectedIDs.contains(notice.id)
+                                    ? "checkmark.circle.fill"
+                                    : "circle"
+                                )
+                                .foregroundStyle(
+                                    store.selectedIDs.contains(notice.id)
+                                    ? Color.accentColor
+                                    : Color.caption1.opacity(0.15)
+                                )
+                            }
                         }
-                    } label: {
-                        Image(
-                            systemName: store.selectedIDs.contains(notice.id)
-                            ? "checkmark.circle.fill"
-                            : "circle"
-                        )
-                        .foregroundStyle(Color.accentColor)
                     }
-                    .opacity(store.editMode == .none ? 0 : 1)
-                    .disabled(store.editMode == .none)
                 }
+                .listRowSeparator(.hidden)
+                
             }
-            .listRowSeparator(.hidden)
+            .listStyle(.plain)
+            
+            if store.editMode != .none {
+                Button {
+                    store.send(.deleteButtonTapped)
+                } label: {
+                    topBlurButton(
+                        "삭제하기",
+                        fontColor: store.selectedIDs.isEmpty
+                        ? Color.accentColor.opacity(0.4)
+                        : .white,
+                        backgroundColor: store.selectedIDs.isEmpty
+                        ? Color.accentColor.opacity(0.15)
+                        : Color.accentColor
+                    )
+                }
+                .padding(.horizontal, 20)
+            }
         }
-        .listStyle(.plain)
+        .onAppear { store.send(.onAppear) }
+        .toolbar(
+            store.isEditing ? .hidden : .visible,
+            for: .tabBar
+        )
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button {
-                    store.editMode = .none
+                    store.send(.cancelButtonTapped)
                 } label: {
                     Text("취소")
                 }
-                .disabled(store.selectedIDs.isEmpty)
-                .opacity(store.editMode == .none ? 0 : 1)
+                .foregroundStyle(.primary)
+                .opacity(store.isEditing ? 1 : 0)
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    switch store.editMode {
-                    case .none:
-                        store.send(.editButtonTapped)
-                    case .editing:
-                        store.send(.selectAllButtonTapped)
-                    }
+                    store.send(
+                        store.isEditing
+                        ? .selectAllButtonTapped
+                        : .editButtonTapped
+                    )
                 } label: {
-                    switch store.editMode {
-                    case .none:
-                        Text("편집")
-                    case .editing:
-                        Text("전체 선택")
-                    }
+                    Text(
+                        store.isEditing
+                        ? "전체 선택"
+                        : "편집"
+                    )
                 }
+                .disabled(store.bookmarkedNotices.isEmpty)
                 .foregroundStyle(Color.accentColor)
             }
+        }
+    }
+    
+    // TODO: 디자인 시스템 분리 - 상단에 블러가 존재하는 버튼
+    @ViewBuilder
+    private func topBlurButton(_ title: String, fontColor: Color, backgroundColor: Color) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            Spacer()
+            Text(title)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(fontColor)
+            Spacer()
+        }
+        .padding(.horizontal, 50)
+        .padding(.vertical, 16)
+        .frame(height: 50, alignment: .center)
+        .background(backgroundColor)
+        .cornerRadius(100)
+        .background {
+            LinearGradient(gradient: Gradient(colors: [.white.opacity(0.1), .white]), startPoint: .top, endPoint: .bottom)
+                .offset(x: 0, y: -32)
         }
     }
 }
 
 #Preview {
-    NavigationStack {
-        BookmarkList(
-            store: Store(
-                initialState: BookmarkListFeature.State(
-                    bookmarkedNotices: [.random]
-                ),
-                reducer: { BookmarkListFeature() }
+    TabView {
+        NavigationStack {
+            BookmarkList(
+                store: Store(
+                    initialState: BookmarkListFeature.State(),
+                    reducer: { BookmarkListFeature() }
+                )
             )
-        )
+        }
+        .tabItem {
+            Image(systemName: "archivebox")
+            
+            Text("공지보관함")
+        }
     }
 }

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 import NoticeFeatures
 import ComposableArchitecture
 
-struct NoticeDetailView: View {
+public struct NoticeDetailView: View {
     @Bindable var store: StoreOf<NoticeDetailFeature>
     
-    var body: some View {
+    public var body: some View {
         List {
             Section {
                 Text(self.store.notice.articleId)
@@ -62,6 +62,10 @@ struct NoticeDetailView: View {
                 }
             }
         }
+    }
+    
+    public init(store: StoreOf<NoticeDetailFeature>) {
+        self.store = store
     }
 }
 

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeRow.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeRow.swift
@@ -7,7 +7,7 @@ public struct NoticeRow: View {
     var rowType: NoticeRowType
     let notice: Notice
     
-    public init(notice: Notice) {
+    public init(notice: Notice, rowType: NoticeRowType? = nil) {
         self.notice = notice
         
         var isBookmarked: Bool
@@ -18,6 +18,12 @@ public struct NoticeRow: View {
         } catch {
             isBookmarked = false
         }
+        
+        if let rowType {
+            self.rowType = rowType
+            return
+        }
+        
         if notice.important {
             if isBookmarked { self.rowType = .importantAndBookmark }
             else { self.rowType = .important }

--- a/KuringPackage/Tests/BookmarkFeaturesTests/BookmarkListTests.swift
+++ b/KuringPackage/Tests/BookmarkFeaturesTests/BookmarkListTests.swift
@@ -12,7 +12,7 @@ final class BookmarkListTests: XCTestCase {
     }
     
     /// 북마크 리스트 가져오기
-    func test_onTask() async throws {
+    func test_onAppear() async throws {
         let store = TestStore(
             initialState: BookmarkListFeature.State(),
             reducer: { BookmarkListFeature() },
@@ -22,9 +22,7 @@ final class BookmarkListTests: XCTestCase {
         )
         let notice = Notice.random
         
-        await store.send(.onTask)
-        
-        await store.receive(.bookmarksUpdate([notice])) {
+        await store.send(.onAppear) {
             $0.bookmarkedNotices = IdentifiedArray(uniqueElements: [notice])
         }
     }
@@ -48,7 +46,7 @@ final class BookmarkListTests: XCTestCase {
     /// 삭제 가능 상태인지 체크
     func test_editButtonTappedAndSelectedIDsUpdated() async throws {
         let store = TestStore(
-            initialState: BookmarkListFeature.State(bookmarkedNotices: [Notice.random]),
+            initialState: BookmarkListFeature.State(),
             reducer: { BookmarkListFeature() },
             withDependencies: {
                 $0.bookmarks = Bookmarks.default
@@ -71,7 +69,7 @@ final class BookmarkListTests: XCTestCase {
     /// 편집모드 업데이트 되는지 확인
     func test_editButtonTappedAndDeleteButtonTapped() async throws {
         let store = TestStore(
-            initialState: BookmarkListFeature.State(bookmarkedNotices: [Notice.random]),
+            initialState: BookmarkListFeature.State(),
             reducer: { BookmarkListFeature() },
             withDependencies: {
                 $0.bookmarks = Bookmarks.default
@@ -91,10 +89,7 @@ final class BookmarkListTests: XCTestCase {
         
         await store.send(.deleteButtonTapped) {
             $0.bookmarkedNotices = []
-        }
-        
-        await store.receive(.binding(.set(\.selectedIDs, []))) {
-            $0.editMode = .editing(deletable: false)
+            $0.editMode = .none
         }
     }
 }


### PR DESCRIPTION
[추가] BookmarkUI 타겟 추가
- [추가] BookmarkAppFeature, BookmarkAppFeature.Path 추가
- [수정] NoticeDetailView 를 public 으로 수정
- [수정] BookmarkListFeature 에 selectAllButtonTapped 추가
- [수정] BookmarkListFeature 에 selectedIDs 컬렉션 타입을 Set 으로 수정

```
BookmarkApp
|___ BookmarkList
|    |___ NoticeRow
|
|___ NoticeDetailView
```
| 공지사항에서 북마크 | 공지보관함 모습 | 편집모드 | 
| --- | --- | --- |
|  ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 21 42 18](https://github.com/ku-ring/ios-app/assets/53814741/c1ebfe9f-f361-4569-8417-1d46db7f4a29) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 21 42 22](https://github.com/ku-ring/ios-app/assets/53814741/0fe27155-de95-41fa-99a9-aa7408a4eb9d) |  ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 21 42 26](https://github.com/ku-ring/ios-app/assets/53814741/b3cabafa-5a48-4039-a40e-77e2a14eab8b) |


| 북마크 선택 | 빈 공지보관함 | 공지사항으로 돌아가기 |
| --- | --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 21 42 28](https://github.com/ku-ring/ios-app/assets/53814741/257f7fea-b276-4fac-941e-b9df87e5a8bb) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 21 42 38](https://github.com/ku-ring/ios-app/assets/53814741/0a3ef9fa-b1d2-43c4-81a9-27b82d896641) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 21 42 45](https://github.com/ku-ring/ios-app/assets/53814741/08904a5b-e577-4324-9a07-062e237af75d) |
