### PR TITLE
[추가] SwiftFormat 적용

### DIFF
--- a/.github/scripts/Format.sh
+++ b/.github/scripts/Format.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../../KuringPackage
+swift package plugin --allow-writing-to-package-directory swiftformat

--- a/KuringPackage/.swiftformat
+++ b/KuringPackage/.swiftformat
@@ -1,0 +1,17 @@
+--header "\nCopyright (c) {year} 쿠링\nSee the 'License.txt' file for licensing information.\n"
+
+--self init-only 
+--semicolons never 
+--extensionacl on-declarations
+--importgrouping length
+
+--xcodeindentation enabled
+
+--guardelse same-line
+--stripunusedargs closure-only
+--emptybraces spaced
+--wrapternary before-operators
+
+--disable redundantRawValues
+--disable redundantFileprivate
+--disable redundantClosure

--- a/KuringPackage/Package.resolved
+++ b/KuringPackage/Package.resolved
@@ -91,6 +91,15 @@
       }
     },
     {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "fef156a6135e584985ed26713dd2e9ee41f952cb",
+        "version" : "0.53.0"
+      }
+    },
+    {
       "identity" : "swiftui-navigation",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",

--- a/KuringPackage/Package.swift
+++ b/KuringPackage/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "KuringPackage",
-    platforms: [.iOS(.v17)],
+    platforms: [.iOS(.v17), .macOS(.v14)],
     products: [
         .library(
             name: "App",
@@ -28,7 +28,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", branch: "observation-beta"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.1.5"),
-        .package(url: "https://github.com/ku-ring/the-satellite", branch: "main")
+        .package(url: "https://github.com/ku-ring/the-satellite", branch: "main"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),
     ],
     targets: [
         // MARK: App Library Dependencies

--- a/KuringPackage/Sources/Caches/AppIcons.swift
+++ b/KuringPackage/Sources/Caches/AppIcons.swift
@@ -1,13 +1,18 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import UIKit
 import Dependencies
 
 public enum KuringIcon: String, CaseIterable, Identifiable, Equatable {
-    public var id: String { self.rawValue }
+    public var id: String { rawValue }
     case kuring_app
     case kuring_app_classic
     case kuring_app_blueprint
     case kuring_app_sketch
-    
+
     public var korValue: String {
         switch self {
         case .kuring_app: return "쿠링 기본"
@@ -18,19 +23,18 @@ public enum KuringIcon: String, CaseIterable, Identifiable, Equatable {
     }
 }
 
-
 public struct AppIcons: DependencyKey {
-    public static let liveValue: AppIcons = AppIcons(
+    public static let liveValue: AppIcons = .init(
         changeTo: { icon in
             guard UIApplication.shared.supportsAlternateIcons else { return }
             do {
                 try await UIApplication.shared.setAlternateIconName(icon.rawValue)
-            } catch let error {
+            } catch {
                 print(error.localizedDescription)
             }
         }
     )
-    
+
     /// 현재 앱 아이콘
     public var currentAppIcon: KuringIcon {
         guard let iconName = UIApplication.shared.alternateIconName else {
@@ -38,7 +42,7 @@ public struct AppIcons: DependencyKey {
         }
         return KuringIcon(rawValue: iconName) ?? .kuring_app
     }
-    
+
     /// 앱 아이콘을 변경합니다.
     /// - Important: 메인에서 돌아감.
     public var changeTo: @MainActor (KuringIcon) async -> Void

--- a/KuringPackage/Sources/Caches/Bookmarks.swift
+++ b/KuringPackage/Sources/Caches/Bookmarks.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import Foundation
 import Dependencies
@@ -5,7 +10,7 @@ import Dependencies
 public struct Bookmarks {
     public var add: (_ notice: Notice) throws -> Void
     public var remove: (_ id: Notice.ID) throws -> Void
-    public var getAll: () throws  -> [Notice]
+    public var getAll: () throws -> [Notice]
     public init(
         add: @escaping (_ notice: Notice) throws -> Void,
         remove: @escaping (_ noidtice: Notice.ID) throws -> Void,
@@ -15,13 +20,13 @@ public struct Bookmarks {
         self.remove = remove
         self.getAll = getAll
     }
-    
+
     /// 객체를 함수 호출처럼 사용하여 모든 북마크를 가져올 수 있습니다.
     /// ```swift
     /// let cachedNotices = try bookmarks()
     /// ```
     public func callAsFunction() throws -> [Notice] {
-        try self.getAll()
+        try getAll()
     }
 }
 
@@ -35,14 +40,14 @@ extension Bookmarks {
                 create: true
             )
             .appendingPathComponent("bookmarks")
-            
+
             try FileManager.default.createDirectory(
                 at: folderURL,
                 withIntermediateDirectories: true,
                 attributes: nil
             )
             let fileURL = folderURL.appendingPathComponent("\(notice.id).json")
-            
+
             let encoder = JSONEncoder()
             encoder.outputFormatting = .prettyPrinted
             try encoder.encode(notice).write(to: fileURL)
@@ -57,7 +62,7 @@ extension Bookmarks {
             .deletingPathExtension()
             .appendingPathComponent("bookmarks")
             .appendingPathComponent("\(noticeID).json")
-            
+
             if FileManager.default.fileExists(atPath: fileURL.path()) {
                 try FileManager.default.removeItem(atPath: fileURL.path())
             }
@@ -70,7 +75,7 @@ extension Bookmarks {
                 create: true
             )
             .appendingPathComponent("bookmarks")
-            
+
             let contents = try FileManager.default
                 .contentsOfDirectory(
                     at: fileURL,
@@ -83,11 +88,10 @@ extension Bookmarks {
             return notices
         }
     )
-    
 }
 
 extension Bookmarks: DependencyKey {
-    public static var liveValue: Bookmarks = Bookmarks.default
+    public static var liveValue: Bookmarks = .default
 }
 
 extension DependencyValues {

--- a/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkApp.Path.swift
+++ b/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkApp.Path.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import NoticeFeatures
 import ComposableArchitecture
 
@@ -8,11 +13,11 @@ extension BookmarkAppFeature {
         public enum State: Equatable {
             case detail(NoticeDetailFeature.State)
         }
-        
+
         public enum Action {
             case detail(NoticeDetailFeature.Action)
         }
-        
+
         public var body: some ReducerOf<Self> {
             Scope(state: \.detail, action: \.detail) {
                 NoticeDetailFeature()

--- a/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkApp.swift
+++ b/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import ComposableArchitecture
 
 @Reducer
@@ -5,12 +10,12 @@ public struct BookmarkAppFeature {
     @ObservableState
     public struct State: Equatable {
         // MARK: 네비게이션
-        
+
         /// 루트
         public var bookmarkList = BookmarkListFeature.State()
         /// 스택 네비게이션
         public var path = StackState<Path.State>()
-        
+
         public init(
             bookmarkList: BookmarkListFeature.State = BookmarkListFeature.State(),
             path: StackState<Path.State> = StackState<Path.State>()
@@ -19,25 +24,25 @@ public struct BookmarkAppFeature {
             self.path = path
         }
     }
-    
+
     public enum Action {
         /// 루트 액션 (``BookmarkListFeature/Action``)
         case bookmarkList(BookmarkListFeature.Action)
-        
+
         /// 스택 네비게이션 액션 (``BookmarkAppFeature/Path/Action``)
         case path(StackAction<Path.State, Path.Action>)
     }
-    
+
     public var body: some ReducerOf<Self> {
         Scope(state: \.bookmarkList, action: \.bookmarkList) {
             BookmarkListFeature()
         }
-        
-        Reduce { state, action in
+
+        Reduce { _, action in
             switch action {
             case .path:
                 return .none
-                
+
             case .bookmarkList:
                 return .none
             }
@@ -46,6 +51,6 @@ public struct BookmarkAppFeature {
             Path()
         }
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkList.swift
+++ b/KuringPackage/Sources/Features/BookmarkFeatures/BookmarkList.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Caches
 import Models
 import ComposableArchitecture
@@ -10,23 +15,23 @@ public struct BookmarkListFeature: Reducer {
     @ObservableState
     public struct State: Equatable {
         public var bookmarkedNotices: IdentifiedArrayOf<Notice> = []
-        
+
         /// 편집시 선택한 북마크 ID
         /// - Note: 순서는 중요하지 않고 중복제거만 중요하므로 `Set` 사용
         public var selectedIDs: Set<Notice.ID> = []
-        
+
         public var editMode: EditMode = .none
-        
+
         public var isEditing: Bool { editMode != .none }
-        
+
         public enum EditMode: Equatable {
-            case `none`
+            case none
             case editing(deletable: Bool)
         }
-        
+
         public init() { }
     }
-    
+
     public enum Action: Equatable, BindableAction {
         /// 바인딩
         case binding(BindingAction<State>)
@@ -41,13 +46,13 @@ public struct BookmarkListFeature: Reducer {
         /// 삭제 버튼 눌렀을 때
         case deleteButtonTapped
     }
-    
+
     /// 북마크 저장소 디펜던시
     @Dependency(\.bookmarks) public var bookmarks
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
+
         Reduce { state, action in
             switch action {
             case .onAppear:
@@ -56,7 +61,7 @@ public struct BookmarkListFeature: Reducer {
                     uniqueElements: bookmarkedNotices ?? []
                 )
                 return .none
-                
+
             case .binding(\.selectedIDs):
                 switch state.editMode {
                 case .editing:
@@ -65,46 +70,44 @@ public struct BookmarkListFeature: Reducer {
                 default:
                     return .none
                 }
-                
+
             case .editButtonTapped:
                 state.editMode = .editing(deletable: false)
                 return .none
-                
+
             case .cancelButtonTapped:
                 state.editMode = .none
                 state.selectedIDs.removeAll()
-                
+
                 return .none
-                
+
             case .selectAllButtonTapped:
                 state.editMode = .editing(deletable: true)
                 state.selectedIDs = Set(state.bookmarkedNotices.ids)
                 return .none
-                
+
             case .deleteButtonTapped:
                 switch state.editMode {
                 case .editing(deletable: true):
-                    state.selectedIDs.forEach {
-                        state.bookmarkedNotices.remove(id: $0)
-                        try? bookmarks.remove($0)
+                    for selectedID in state.selectedIDs {
+                        state.bookmarkedNotices.remove(id: selectedID)
+                        try? bookmarks.remove(selectedID)
                     }
                     if state.bookmarkedNotices.isEmpty {
                         state.editMode = .none
                         return .none
                     } else {
-                        return .send(.binding(.set(\.selectedIDs, [])))                        
+                        return .send(.binding(.set(\.selectedIDs, [])))
                     }
                 default:
                     return .none
                 }
-                
+
             case .binding:
                 return .none
             }
         }
     }
-    
-    public init() {
-        
-    }
+
+    public init() { }
 }

--- a/KuringPackage/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
+++ b/KuringPackage/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import ComposableArchitecture
 
@@ -7,25 +12,25 @@ public struct DepartmentEditorFeature {
     public struct State: Equatable {
         public var myDepartments: IdentifiedArrayOf<NoticeProvider> = []
         public var results: IdentifiedArrayOf<NoticeProvider> = []
-        
+
         public var searchText: String = ""
         public var focus: Field? = .search
-        
+
         public var displayOption: Display = .myDepartment
-        
+
         public enum Field {
             case search
         }
-        
+
         public enum Display: Hashable {
             /// 검색 결과 보여주기
             case searchResult
             /// 내 학과 보여주기
             case myDepartment
         }
-        
+
         @Presents public var alert: AlertState<Action.Alert>?
-        
+
         public init(
             myDepartments: IdentifiedArrayOf<NoticeProvider> = [],
             results: IdentifiedArrayOf<NoticeProvider> = [],
@@ -42,10 +47,10 @@ public struct DepartmentEditorFeature {
             self.alert = alert
         }
     }
-    
+
     public enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
-        
+
         /// 학과 추가 버튼 눌렀을 때
         case addDepartmentButtonTapped(id: NoticeProvider.ID)
         /// 추가했던 학과 취소 버튼 눌렀을 때
@@ -56,7 +61,7 @@ public struct DepartmentEditorFeature {
         case deleteAllMyDepartmentButtonTapped
         /// 텍스트 필드의 xmark를 눌렀을 때
         case clearTextFieldButtonTapped
-        
+
         /// 알림 관련 액션
         case alert(PresentationAction<Alert>)
         /// 알림
@@ -67,15 +72,15 @@ public struct DepartmentEditorFeature {
             case confirmDeleteAll
         }
     }
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
+
         Reduce { state, action in
             switch action {
             case .binding:
                 return .none
-                
+
             case let .addDepartmentButtonTapped(id: id):
                 guard let department = state.results.first(where: { $0.id == id }) else {
                     return .none
@@ -85,11 +90,11 @@ public struct DepartmentEditorFeature {
                 }
                 state.myDepartments.append(department)
                 return .none
-                
+
             case let .cancelAdditionButtonTapped(id: id):
                 state.myDepartments.remove(id: id)
                 return .none
-                
+
             case let .deleteMyDepartmentButtonTapped(id: id):
                 guard let department = state.myDepartments.first(where: { $0.id == id }) else {
                     return .none
@@ -100,13 +105,13 @@ public struct DepartmentEditorFeature {
                     ButtonState(role: .cancel) {
                         TextState("취소하기")
                     }
-                    
+
                     ButtonState(role: .destructive, action: .confirmDelete(id: id)) {
                         TextState("삭제하기")
                     }
                 }
                 return .none
-                
+
             case .deleteAllMyDepartmentButtonTapped:
                 state.alert = AlertState {
                     TextState("모든 학과를 삭제하시겠습니까?")
@@ -114,18 +119,19 @@ public struct DepartmentEditorFeature {
                     ButtonState(role: .cancel) {
                         TextState("취소하기")
                     }
-                    
+
                     ButtonState(role: .destructive, action: .confirmDeleteAll) {
                         TextState("삭제하기")
                     }
                 }
                 return .none
-                
+
             case .clearTextFieldButtonTapped:
                 state.searchText.removeAll()
                 return .none
-                
+
                 // MARK: Alert
+
             case let .alert(.presented(alertAction)):
                 switch alertAction {
                 case let .confirmDelete(id: id):
@@ -135,13 +141,13 @@ public struct DepartmentEditorFeature {
                     state.myDepartments.removeAll()
                     return .none
                 }
-                
+
             case .alert(.dismiss):
                 return .none
             }
         }
         .ifLet(\.$alert, action: \.alert)
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/DepartmentFeatures/DepartmentSelector.swift
+++ b/KuringPackage/Sources/Features/DepartmentFeatures/DepartmentSelector.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import ComposableArchitecture
@@ -8,44 +13,42 @@ public struct DepartmentSelectorFeature {
     public struct State: Equatable {
         public var currentDepartment: NoticeProvider?
         public var addedDepartment: IdentifiedArrayOf<NoticeProvider>
-        
+
         public init(currentDepartment: NoticeProvider? = nil, addedDepartment: IdentifiedArrayOf<NoticeProvider>) {
             self.currentDepartment = currentDepartment
             self.addedDepartment = addedDepartment
         }
     }
-    
+
     public enum Action: Equatable {
         // TODO: String -> Department
         case selectDepartment(id: NoticeProvider.ID)
         case editDepartmentsButtonTapped
         case delegate(Delegate)
-        
+
         public enum Delegate {
             case editDepartment
         }
     }
-    
+
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case let .selectDepartment(id: id):
                 guard let department = state.addedDepartment.first(where: { $0.id == id }) else {
                     return .none
-                    
                 }
                 state.currentDepartment = department
                 return .none
-                
+
             case .editDepartmentsButtonTapped:
                 return .send(.delegate(.editDepartment))
-                
+
             case .delegate:
                 return .none
             }
         }
     }
-    
+
     public init() { }
 }
-

--- a/KuringPackage/Sources/Features/NoticeFeatures/NoticeApp.Path.swift
+++ b/KuringPackage/Sources/Features/NoticeFeatures/NoticeApp.Path.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SearchFeatures
 import DepartmentFeatures
@@ -12,27 +17,25 @@ extension NoticeAppFeature {
             case search(SearchFeature.State)
             case departmentEditor(DepartmentEditorFeature.State)
         }
-        
+
         public enum Action {
             case detail(NoticeDetailFeature.Action)
             case search(SearchFeature.Action)
             case departmentEditor(DepartmentEditorFeature.Action)
         }
-        
+
         public var body: some ReducerOf<Self> {
             Scope(state: \.detail, action: \.detail) {
                 NoticeDetailFeature()
             }
-            
+
             Scope(state: \.search, action: \.search) {
                 SearchFeature()
             }
-            
+
             Scope(state: \.departmentEditor, action: \.departmentEditor) {
                 DepartmentEditorFeature()
             }
         }
     }
-
 }
-

--- a/KuringPackage/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/KuringPackage/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import DepartmentFeatures
 import SubscriptionFeatures
@@ -8,14 +13,14 @@ public struct NoticeAppFeature {
     @ObservableState
     public struct State: Equatable {
         // MARK: 네비게이션
-        
+
         /// 루트
         public var noticeList = NoticeListFeature.State()
         /// 스택 네비게이션
         public var path = StackState<Path.State>()
         /// 트리 네비게이션 - ``SubscriptionAppFeature``
         @Presents public var changeSubscription: SubscriptionAppFeature.State?
-        
+
         public init(
             noticeList: NoticeListFeature.State = NoticeListFeature.State(),
             path: StackState<Path.State> = StackState<Path.State>(),
@@ -26,31 +31,31 @@ public struct NoticeAppFeature {
             self.changeSubscription = changeSubscription
         }
     }
-    
+
     public enum Action {
         /// 루트(``NoticeListFeature``) 액션
         case noticeList(NoticeListFeature.Action)
-        
+
         /// 스택 네비게이션 액션 (``NoticeAppFeature/Path``)
         case path(StackAction<Path.State, Path.Action>)
-        
+
         /// 구독 변경 버튼을 탭한 경우
         case changeSubscriptionButtonTapped
-        
+
         /// ``SubscriptionAppFeature`` 의 Presentation 액션
         case changeSubscription(PresentationAction<SubscriptionAppFeature.Action>)
     }
-    
+
     public var body: some ReducerOf<Self> {
         Scope(state: \.noticeList, action: \.noticeList) {
             NoticeListFeature()
         }
-        
+
         Reduce { state, action in
             switch action {
             case .path:
                 return .none
-                
+
             case let .noticeList(.delegate(delegate)):
                 switch delegate {
                 case .editDepartment:
@@ -66,16 +71,16 @@ public struct NoticeAppFeature {
                     )
                     return .none
                 }
-                
+
             case .changeSubscription(.presented(.subscriptionView(.subscriptionResponse))):
                 /// ``SubscriptionAppFeature`` 액션
                 state.changeSubscription = nil
                 return .none
-                
+
             case .changeSubscriptionButtonTapped:
                 state.changeSubscription = SubscriptionAppFeature.State()
                 return .none
-                
+
             case .noticeList, .changeSubscription:
                 return .none
             }
@@ -87,6 +92,6 @@ public struct NoticeAppFeature {
             SubscriptionAppFeature()
         }
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/NoticeFeatures/NoticeDetail.swift
+++ b/KuringPackage/Sources/Features/NoticeFeatures/NoticeDetail.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Caches
 import Models
 import SwiftUI
@@ -9,7 +14,7 @@ public struct NoticeDetailFeature {
     public struct State: Equatable {
         public var notice: Notice
         public var isBookmarked: Bool = false
-        
+
         public init(notice: Notice, isBookmarked: Bool = false) {
             self.notice = notice
             @Dependency(\.bookmarks) var bookmarks
@@ -20,19 +25,19 @@ public struct NoticeDetailFeature {
             }
         }
     }
-    
+
     public enum Action: Equatable {
         case bookmarkButtonTapped
-        
+
         case delegate(Delegate)
-        
+
         public enum Delegate: Equatable {
             case bookmarkUpdated(Bool)
         }
     }
-    
+
     @Dependency(\.bookmarks) var bookmarks
-    
+
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
@@ -48,17 +53,17 @@ public struct NoticeDetailFeature {
                     print("북마크 업데이트에 실패했습니다: \(error.localizedDescription)")
                 }
                 return .none
-                
+
             case .delegate:
                 return .none
             }
         }
-        .onChange(of: \.isBookmarked) { oldValue, newValue in
-            Reduce { state, action in
-                return .send(.delegate(.bookmarkUpdated(newValue)))
+        .onChange(of: \.isBookmarked) { _, newValue in
+            Reduce { _, _ in
+                .send(.delegate(.bookmarkUpdated(newValue)))
             }
         }
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/NoticeFeatures/NoticeList.swift
+++ b/KuringPackage/Sources/Features/NoticeFeatures/NoticeList.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Caches
 import Models
 import KuringLink
@@ -9,25 +14,26 @@ public struct NoticeListFeature {
     @ObservableState
     public struct State: Equatable {
         // MARK: 네비게이션
+
         @Presents public var changeDepartment: DepartmentSelectorFeature.State?
-        
+
         /// 현재 공지리스트를 제공하는 `NoticeProvider` 값
         ///
         /// - IMPORTANT: 추가한 학과가 있으면 추가한 학과의 첫번째 값이 초기값으로 세팅되고 없으면 `.학사`
         public var provider: NoticeProvider = NoticeProvider.departments.first ?? NoticeProvider.학사
-        
+
         /// 현재 공지를 가져오는 중인지 알려주는 Bool 값
         public var isLoading = false
-        
+
         // TODO: 공지 데이터 저장 관련 로직은 전부 디펜던시로 옮기기
         /// 공지
         public var noticeDictionary: [NoticeProvider: NoticeInfo] = [:]
-        
+
         /// 현재 `NoticeProvider` 에 대한 공지 데이터 리스트값
         public var currentNotices: [Notice] {
-            self.noticeDictionary[self.provider]?.notices ?? []
+            noticeDictionary[provider]?.notices ?? []
         }
-        
+
         // TODO: 공지 데이터 저장 관련 로직은 전부 디펜던시로 옮기기
         public struct NoticeInfo: Equatable {
             /// 공지
@@ -39,12 +45,12 @@ public struct NoticeListFeature {
             /// 한번 요청 시 가져올 수 있는 공지 사항 개수 최댓값
             public let loadLimit = 20
         }
-        
+
         public init(
             changeDepartment: DepartmentSelectorFeature.State? = nil,
             provider: NoticeProvider = NoticeProvider.departments.first ?? NoticeProvider.학사,
             isLoading: Bool = false,
-            noticeDictionary: [NoticeProvider : NoticeInfo] = [:]
+            noticeDictionary: [NoticeProvider: NoticeInfo] = [:]
         ) {
             self.changeDepartment = changeDepartment
             self.provider = provider
@@ -52,72 +58,72 @@ public struct NoticeListFeature {
             self.noticeDictionary = noticeDictionary
         }
     }
-    
+
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
-        
+
         /// `onAppear` 이 호출된 경우
         case onAppear
-        
+
         /// 학과 변경하기 버튼을 탭한 경우
         case changeDepartmentButtonTapped
-        
+
         /// ``DepartmentSelectorFeature`` 의 Presentation 액션
         case changeDepartment(PresentationAction<DepartmentSelectorFeature.Action>)
-        
+
         /// ``NoticeAppFeature`` 으로 액션을 전달하기 위한 델리게이트
         case delegate(Delegate)
-        
+
         /// 공지를 가져오기 위한 네트워크 요청을 하는 경우
         case fetchNotices
-        
+
         /// 네트워크 요청에 대한 응답을 받은 경우
         case noticesResponse(TaskResult<(NoticeProvider, [Notice])>)
-        
+
         /// 북마크 버튼을 탭한 경우
         /// - Parameter notice: 북마크 액션 대상인 공지
         case bookmarkTapped(Notice)
-        
+
         case loadingChanged(Bool)
-        
+
         case providerChanged(NoticeProvider)
-        
+
         /// ``NoticeAppFeature`` 에 전달 될 액션 종류
         public enum Delegate {
             /// 학과 편집 버튼을 선택한 경우
             case editDepartment
         }
     }
-    
+
     public enum CancelID {
         case fetchNotices
     }
-    
+
     @Dependency(\.bookmarks) public var bookmarks
     @Dependency(\.kuringLink) public var kuringLink
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
+
         Reduce { state, action in
             switch action {
             case .onAppear:
                 return .send(.fetchNotices)
-                
+
             case .changeDepartmentButtonTapped:
                 state.changeDepartment = DepartmentSelectorFeature.State(
                     currentDepartment: state.provider,
                     addedDepartment: IdentifiedArray(uniqueElements: NoticeProvider.departments) // TODO: Dependency
                 )
                 return .none
-                
+
             case let .changeDepartment(.presented(.delegate(delegate))):
                 switch delegate {
                 case .editDepartment:
                     state.changeDepartment = nil
                     return .send(.delegate(.editDepartment))
                 }
-                
+
             case .changeDepartment(.presented(.selectDepartment)):
                 /// ``DepartmentSelectorFeature`` 액션
                 guard let selectedDepartment = state.changeDepartment?.currentDepartment else {
@@ -125,7 +131,7 @@ public struct NoticeListFeature {
                 }
                 state.provider = selectedDepartment
                 return .none
-                
+
             case .changeDepartment(.dismiss):
                 return .send(.fetchNotices)
 
@@ -134,11 +140,11 @@ public struct NoticeListFeature {
                     return .none
                 }
                 state.isLoading = true
-                
+
                 return .run { [provider = state.provider, noticeDictionary = state.noticeDictionary] send in
                     // TODO: 공지 데이터 저장 관련 로직은 전부 디펜던시로 옮기기
                     let retrievalInfo = noticeDictionary[provider] ?? State.NoticeInfo()
-                    
+
                     let department: String? = if provider.category == .학과 {
                         provider.hostPrefix
                     } else {
@@ -159,26 +165,26 @@ public struct NoticeListFeature {
                     )
                 }
                 .cancellable(id: CancelID.fetchNotices, cancelInFlight: true)
-                
+
             case let .noticesResponse(.success((noticeType, notices))):
                 if state.noticeDictionary[noticeType] == nil {
                     state.noticeDictionary[noticeType] = State.NoticeInfo()
                 }
                 guard var noticeInfo = state.noticeDictionary[noticeType] else { return .none }
-                
+
                 noticeInfo.hasNextList = notices.count >= noticeInfo.loadLimit
                 noticeInfo.page += 1
                 noticeInfo.notices += notices
-                
+
                 state.noticeDictionary[noticeType] = noticeInfo
                 state.isLoading = false
                 return .none
-            
+
             case let .noticesResponse(.failure(error)):
                 print(error.localizedDescription)
                 state.isLoading = false
                 return .none
-            
+
             case let .bookmarkTapped(notice):
                 do {
                     print("공지#\(notice.articleId)을 북마크 했습니다.")
@@ -187,15 +193,15 @@ public struct NoticeListFeature {
                     print("북마크 하는 중에 에러가 발생했습니다: \(error.localizedDescription)")
                 }
                 return .none
-                
+
             case let .loadingChanged(isLoading):
                 state.isLoading = isLoading
                 return .none
-                
+
             case let .providerChanged(provider):
                 state.provider = provider
                 return .send(.fetchNotices)
-                
+
             case .binding, .delegate, .changeDepartment:
                 return .none
             }
@@ -204,8 +210,6 @@ public struct NoticeListFeature {
             DepartmentSelectorFeature()
         }
     }
-    
-    public init() {
-        
-    }
+
+    public init() { }
 }

--- a/KuringPackage/Sources/Features/SearchFeatures/StaffDetail.swift
+++ b/KuringPackage/Sources/Features/SearchFeatures/StaffDetail.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import ComposableArchitecture
 
@@ -6,28 +11,28 @@ public struct StaffDetailFeature {
     @ObservableState
     public struct State: Equatable {
         public let staff: Staff
-        
+
         public init(staff: Staff) {
             self.staff = staff
         }
     }
-    
+
     public enum Action {
         case emailAddressTapped
         case phoneNumberTapped
     }
-    
+
     public var body: some ReducerOf<Self> {
-        Reduce { state, action in
+        Reduce { _, action in
             switch action {
             case .emailAddressTapped:
                 return .none
-                
+
             case .phoneNumberTapped:
                 return .none
             }
         }
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/SettingsFeatures/AppIconSelector.swift
+++ b/KuringPackage/Sources/Features/SettingsFeatures/AppIconSelector.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Caches
 import Foundation
 import ComposableArchitecture
@@ -9,7 +14,7 @@ public struct AppIconSelectorFeature {
         public var appIcons: IdentifiedArrayOf<KuringIcon> = IdentifiedArray(uniqueElements: KuringIcon.allCases)
         public var selectedIcon: KuringIcon?
         public var currentIcon: KuringIcon
-        
+
         public init(
             appIcons: IdentifiedArrayOf<KuringIcon> = IdentifiedArray(uniqueElements: KuringIcon.allCases),
             selectedIcon: KuringIcon? = nil
@@ -20,41 +25,41 @@ public struct AppIconSelectorFeature {
             self.currentIcon = appIconClient.currentAppIcon
         }
     }
-    
+
     public enum Action: Equatable {
         /// 앱 아이콘 선택
         case appIconSelected(KuringIcon)
         /// 앱 아이콘 저장하기 버튼
         case saveButtonTapped
-        
+
         case delegate(Delegate)
-        
+
         public enum Delegate: Equatable {
             case completeAppIconChange
         }
     }
-    
+
     @Dependency(\.appIcons) public var appIcons
-    
+
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case let .appIconSelected(icon):
                 state.selectedIcon = icon
                 return .none
-                
+
             case .saveButtonTapped:
                 return .run { [selectedIcon = state.selectedIcon] send in
                     guard let selectedIcon else { return }
                     await appIcons.changeTo(selectedIcon)
                     await send(.delegate(.completeAppIconChange))
                 }
-                
+
             case .delegate:
                 return .none
             }
         }
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/SettingsFeatures/Feedback.swift
+++ b/KuringPackage/Sources/Features/SettingsFeatures/Feedback.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import Foundation
 import KuringLink
@@ -11,46 +16,46 @@ public struct FeedbackFeature {
         public let maxLimit: Int = 256
         /// TextEditor 의 placeholder
         public let placeholder: String = "피드백을 남겨주세요."
-        
+
         /// 피드백 텍스트
         public var text: String = ""
-        
+
         /// TextEditor 활성화 여부
         public var isFocused: Bool = false
-        
+
         /// 상단 텍스트, 아이콘 보여주는 여부.
         /// - Important: `isFocused` 값과 항상 동일하며 뷰의 `.withAnimation` 에서 업데이트
         public var isTopHidden: Bool = false
-        
+
         /// TextEditor 하단에 보여질 안내문구
         public var guideline: String {
             isSendable
-            ? "글자수: \(self.text.count)/\(maxLimit)"
-            : "\(minLimit)글자 이상 입력 해주세요"
+                ? "글자수: \(text.count)/\(maxLimit)"
+                : "\(minLimit)글자 이상 입력 해주세요"
         }
-        
+
         /// `text` 가 `placeholder` 가 아니고, 글자수가 `minLimit` 이상일 때
         public var isSendable: Bool {
-            self.text != placeholder 
-            && self.text.count >= minLimit
+            text != placeholder
+                && text.count >= minLimit
         }
-        
+
         public init(text: String = "") {
             self.text = text
         }
     }
-    
+
     public enum Action: Equatable, BindableAction {
         case binding(BindingAction<State>)
         case sendFeedback
     }
-    
+
     @Dependency(\.dismiss) public var dismiss
     @Dependency(\.kuringLink) public var kuringLink
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
+
         Reduce { state, action in
             switch action {
             case .binding(\.isFocused):
@@ -62,10 +67,10 @@ public struct FeedbackFeature {
                     state.text = state.placeholder
                 }
                 return .none
-                
+
             case .binding:
                 return .none
-                
+
             case .sendFeedback:
                 state.isFocused = false
                 return .run { [text = state.text] _ in
@@ -79,7 +84,6 @@ public struct FeedbackFeature {
             }
         }
     }
-    
+
     public init() { }
 }
-

--- a/KuringPackage/Sources/Features/SettingsFeatures/InformationWebFeature.swift
+++ b/KuringPackage/Sources/Features/SettingsFeatures/InformationWebFeature.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 import ComposableArchitecture
 
@@ -6,19 +11,19 @@ public struct InformationWebFeature {
     @ObservableState
     public struct State: Equatable {
         public var url: String?
-        
+
         public init(url: String? = nil) {
             self.url = url
         }
     }
-    
+
     public enum Action: Equatable { }
-    
+
     public var body: some ReducerOf<Self> {
-        Reduce { state, action in
-            return .none
+        Reduce { _, _ in
+            .none
         }
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/SettingsFeatures/OpenSourceListFeature.swift
+++ b/KuringPackage/Sources/Features/SettingsFeatures/OpenSourceListFeature.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import UIKit
 import ComposableArchitecture
 
@@ -6,23 +11,23 @@ public struct OpenSourceListFeature {
     @ObservableState
     public struct State: Equatable {
         public let opensources: [Opensource] = Opensource.items
-        
+
         public init() { }
     }
-    
+
     public enum Action: Equatable, BindableAction {
         case binding(BindingAction<State>)
         case linkTapped(_ link: String)
     }
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
-        Reduce { state, action in
+
+        Reduce { _, action in
             switch action {
             case .binding:
                 return .none
-                
+
             case let .linkTapped(link):
                 guard let url = URL(string: link) else { return .none }
                 UIApplication.shared.open(url)
@@ -30,7 +35,7 @@ public struct OpenSourceListFeature {
             }
         }
     }
-    
+
     public init() { }
 }
 
@@ -38,7 +43,6 @@ public struct Opensource: Equatable, Identifiable {
     public var id: String { name }
     public let name: String
     public let link: String
-    
 }
 
 extension Opensource {
@@ -46,7 +50,5 @@ extension Opensource {
         Opensource(name: "Composable Architecture", link: "https://github.com/pointfreeco/swift-composable-architecture/tree/main"),
         Opensource(name: "KuringPackage", link: "https://github.com/ku-ring/ios-app"),
         Opensource(name: "The Satellite", link: "https://github.com/ku-ring/the-satellite"),
-        
     ]
-    
 }

--- a/KuringPackage/Sources/Features/SettingsFeatures/SettingList.swift
+++ b/KuringPackage/Sources/Features/SettingsFeatures/SettingList.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Caches
 import Foundation
 import ComposableArchitecture
@@ -17,22 +22,22 @@ public struct SettingListFeature {
         // TODO: 나중에 디펜던시로
         public var currentAppIcon: KuringIcon?
         public var isCustomAlarmOn: Bool = false
-        
+
         public init(
             isCustomAlarmOn: Bool = true,
             appIcon: KuringIcon? = nil
         ) {
             self.isCustomAlarmOn = isCustomAlarmOn
-            
+
             @Dependency(\.appIcons) var appIcons
             self.currentAppIcon = appIcon ?? appIcons.currentAppIcon
         }
     }
-    
+
     public enum Action: Equatable, BindableAction {
         case binding(BindingAction<State>)
         case delegate(Delegate)
-        
+
         public enum Delegate: Equatable {
             case showSubscription
             case showWhatsNew
@@ -44,17 +49,17 @@ public struct SettingListFeature {
             case showFeedback
         }
     }
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
-        Reduce { state, action in
+
+        Reduce { _, action in
             switch action {
             case .binding, .delegate:
                 return .none
             }
         }
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/SettingsFeatures/SettingsApp.Destination.swift
+++ b/KuringPackage/Sources/Features/SettingsFeatures/SettingsApp.Destination.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Labs
 import SubscriptionFeatures
 import ComposableArchitecture
@@ -12,14 +17,14 @@ extension SettingsAppFeature {
             case subscription(SubscriptionAppFeature.State)
             case informationWeb(InformationWebFeature.State)
         }
-        
+
         public enum Action: Equatable {
             case labs(LabAppFeature.Action)
             case feedback(FeedbackFeature.Action)
             case subscription(SubscriptionAppFeature.Action)
             case informationWeb(InformationWebFeature.Action)
         }
-        
+
         public var body: some ReducerOf<Self> {
             Scope(state: \.labs, action: \.labs) {
                 LabAppFeature()
@@ -34,7 +39,7 @@ extension SettingsAppFeature {
                 InformationWebFeature()
             }
         }
-        
+
         public init() { }
     }
 }

--- a/KuringPackage/Sources/Features/SettingsFeatures/SettingsApp.Path.swift
+++ b/KuringPackage/Sources/Features/SettingsFeatures/SettingsApp.Path.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import ComposableArchitecture
 
 extension SettingsAppFeature {
@@ -8,12 +13,12 @@ extension SettingsAppFeature {
             case openSourceList(OpenSourceListFeature.State)
             case appIconSelector(AppIconSelectorFeature.State)
         }
-        
+
         public enum Action: Equatable {
             case openSourceList(OpenSourceListFeature.Action)
             case appIconSelector(AppIconSelectorFeature.Action)
         }
-        
+
         public var body: some ReducerOf<Self> {
             Scope(state: \.openSourceList, action: \.openSourceList) {
                 OpenSourceListFeature()
@@ -22,7 +27,7 @@ extension SettingsAppFeature {
                 AppIconSelectorFeature()
             }
         }
-        
+
         public init() { }
     }
 }

--- a/KuringPackage/Sources/Features/SettingsFeatures/SettingsApp.swift
+++ b/KuringPackage/Sources/Features/SettingsFeatures/SettingsApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Labs
 import SubscriptionFeatures
 import ComposableArchitecture
@@ -12,7 +17,7 @@ public struct SettingsAppFeature {
         public var path = StackState<Path.State>()
         /// Root
         public var settingList = SettingListFeature.State()
-        
+
         public init(
             destination: Destination.State? = nil,
             path: StackState<Path.State> = .init(),
@@ -24,7 +29,7 @@ public struct SettingsAppFeature {
             self.settingList = root
         }
     }
-    
+
     public enum Action: Equatable, BindableAction {
         case binding(BindingAction<State>)
         /// Root
@@ -34,14 +39,14 @@ public struct SettingsAppFeature {
         /// 트리기반 네비게이션 Destination
         case destination(PresentationAction<Destination.Action>)
     }
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
+
         Scope(state: \.settingList, action: \.settingList) {
             SettingListFeature()
         }
-    
+
         Reduce { state, action in
             switch action {
             case let .settingList(.delegate(action)):
@@ -49,46 +54,46 @@ public struct SettingsAppFeature {
                 case .showSubscription:
                     state.destination = .subscription(SubscriptionAppFeature.State())
                     return .none
-                    
+
                 case .showWhatsNew:
                     state.destination = .informationWeb(
                         InformationWebFeature.State(url: URLLink.whatsNew.rawValue)
                     )
                     return .none
-                    
+
                 case .showTeam:
                     state.destination = .informationWeb(
                         InformationWebFeature.State(url: URLLink.team.rawValue)
                     )
                     return .none
-                    
+
                 case .showLabs:
                     state.destination = .labs(LabAppFeature.State())
                     return .none
-                    
+
                 case .showPrivacyPolicy:
                     state.destination = .informationWeb(
                         InformationWebFeature.State(url: URLLink.privacy.rawValue)
                     )
                     return .none
-                    
+
                 case .showTermsOfService:
                     state.destination = .informationWeb(
                         InformationWebFeature.State(url: URLLink.terms.rawValue)
                     )
                     return .none
-                    
+
                 case .showInstagram:
                     state.destination = .informationWeb(
                         InformationWebFeature.State(url: URLLink.instagram.rawValue)
                     )
                     return .none
-                    
+
                 case .showFeedback:
                     state.destination = .feedback(FeedbackFeature.State())
                     return .none
                 }
-                
+
             case let .path(.element(id: id, action: .appIconSelector(.delegate(.completeAppIconChange)))):
                 guard case let .appIconSelector(appIconSelectorState) = state.path[id: id] else {
                     return .none
@@ -96,13 +101,13 @@ public struct SettingsAppFeature {
                 state.settingList.currentAppIcon = appIconSelectorState.selectedIcon
                 state.path.pop(from: id)
                 return .none
-            
+
             case .binding:
                 return .none
-            
+
             case .destination, .path:
                 return .none
-                
+
             case .settingList:
                 return .none
             }
@@ -114,6 +119,6 @@ public struct SettingsAppFeature {
             Path()
         }
     }
-    
+
     public init() { }
 }

--- a/KuringPackage/Sources/Features/SubscriptionFeatures/SubscriptionApp.Path.swift
+++ b/KuringPackage/Sources/Features/SubscriptionFeatures/SubscriptionApp.Path.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 import DepartmentFeatures
 import ComposableArchitecture
@@ -9,17 +14,17 @@ extension SubscriptionAppFeature {
         public enum State: Equatable {
             case departmentEditor(DepartmentEditorFeature.State)
         }
-        
+
         public enum Action: Equatable {
             case departmentEditor(DepartmentEditorFeature.Action)
         }
-        
+
         public var body: some ReducerOf<Self> {
             Scope(state: \.departmentEditor, action: \.departmentEditor) {
                 DepartmentEditorFeature()
             }
         }
-        
+
         public init() { }
     }
 }

--- a/KuringPackage/Sources/Features/SubscriptionFeatures/SubscriptionApp.swift
+++ b/KuringPackage/Sources/Features/SubscriptionFeatures/SubscriptionApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import ComposableArchitecture
@@ -10,7 +15,7 @@ public struct SubscriptionAppFeature {
         public var path = StackState<Path.State>()
         /// Root
         public var subscriptionView = SubscriptionFeature.State()
-        
+
         public init(
             path: StackState<SubscriptionAppFeature.Path.State> = .init(),
             root: SubscriptionFeature.State = .init()
@@ -19,19 +24,19 @@ public struct SubscriptionAppFeature {
             self.subscriptionView = root
         }
     }
-    
+
     public enum Action: Equatable {
         /// 스택 기반 네비게이션 Path
         case path(StackAction<Path.State, Path.Action>)
         /// Root
         case subscriptionView(SubscriptionFeature.Action)
     }
-    
+
     public var body: some ReducerOf<Self> {
         Scope(state: \.subscriptionView, action: \.subscriptionView) {
             SubscriptionFeature()
         }
-        
+
         Reduce { state, action in
             switch action {
             case let .path(.popFrom(id: id)):
@@ -40,10 +45,10 @@ public struct SubscriptionAppFeature {
                 }
                 state.subscriptionView.myDepartments = departmentEditorState.myDepartments
                 return .none
-                
+
             case .path:
                 return .none
-                
+
             case .subscriptionView:
                 return .none
             }
@@ -55,8 +60,6 @@ public struct SubscriptionAppFeature {
             EmptyReducer()
         }
     }
-    
-    public init() {
-        
-    }
+
+    public init() { }
 }

--- a/KuringPackage/Sources/Labs/Dependency/LeLabo.TestValue.swift
+++ b/KuringPackage/Sources/Labs/Dependency/LeLabo.TestValue.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 extension LeLabo {
     struct TestStatus {
         var isBetaAEnabled: Bool
@@ -9,7 +14,7 @@ extension LeLabo {
         var status = TestStatus(isBetaAEnabled: false)
         return LeLabo(
             status: { _ in
-                return status.isBetaAEnabled
+                status.isBetaAEnabled
             },
             set: { newValue, _ in
                 status.isBetaAEnabled = newValue

--- a/KuringPackage/Sources/Labs/Dependency/LeLabo.swift
+++ b/KuringPackage/Sources/Labs/Dependency/LeLabo.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 import Dependencies
 
@@ -7,18 +12,18 @@ import Dependencies
 /// ```
 public struct LeLabo {
     public typealias NewValue = Bool
-    
+
     public enum Experiment: String, Equatable {
         // 기능 추가
         case betaA = "beta-a"
         case appIcon = "appicon"
-        
+
         var key: String {
             let baseKey = "com.kuring.service.lelabo.experiments"
-            return "\(baseKey).\(self.rawValue)"
+            return "\(baseKey).\(rawValue)"
         }
     }
-    
+
     public var status: (Experiment) -> Bool
     public var set: (NewValue, Experiment) -> Void
 }

--- a/KuringPackage/Sources/Labs/ExperimentList.swift
+++ b/KuringPackage/Sources/Labs/ExperimentList.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import ComposableArchitecture
 
 @Reducer
@@ -6,17 +11,15 @@ public struct ExperimentListFeature {
     public struct State: Equatable {
         public init() { }
     }
-    
-    public enum Action: Equatable {
-        
-    }
-    
+
+    public enum Action: Equatable { }
+
     public var body: some ReducerOf<Self> {
-        Reduce { state, action in
-            return .none
+        Reduce { _, _ in
+            .none
         }
     }
-    
+
     public init() { }
 }
 
@@ -24,7 +27,7 @@ import SwiftUI
 
 public struct ExperimentList: View {
     @Bindable public var store: StoreOf<ExperimentListFeature>
-    
+
     public var body: some View {
         List {
             NavigationLink(
@@ -34,7 +37,7 @@ public struct ExperimentList: View {
             ) {
                 Text("베타 A")
             }
-            
+
             NavigationLink(
                 state: LabAppFeature.Path.State.appIcon(
                     AppIconDetailFeature.State()
@@ -44,7 +47,7 @@ public struct ExperimentList: View {
             }
         }
     }
-    
+
     public init(store: StoreOf<ExperimentListFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/Labs/Experiments/AppIconDetail.swift
+++ b/KuringPackage/Sources/Labs/Experiments/AppIconDetail.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import ComposableArchitecture
 
 @Reducer
@@ -11,28 +16,28 @@ public struct AppIconDetailFeature {
         이 기능을 활성화 하면 **쿠링 앱의 아이콘을 변경할 수 있습니다.**
         """
         public var isEnabled: Bool = false
-        
+
         public init(isEnabled: Bool? = nil) {
             @Dependency(\.leLabo) var leLabo
             self.isEnabled = leLabo.status(.appIcon) // 수정
         }
     }
-    
+
     public enum Action: Equatable, BindableAction {
         case binding(BindingAction<State>)
     }
-    
+
     @Dependency(\.leLabo) public var leLabo
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
+
         Reduce { state, action in
             switch action {
             case .binding(\.isEnabled):
                 leLabo.set(state.isEnabled, .appIcon) // 수정
                 return .none
-                
+
             case .binding:
                 return .none
             }
@@ -44,7 +49,7 @@ import SwiftUI
 
 public struct AppIconDetailView: View {
     @Bindable public var store: StoreOf<AppIconDetailFeature>
-    
+
     public let markdown: LocalizedStringKey = "# hi"
     public var body: some View {
         Form {
@@ -52,16 +57,16 @@ public struct AppIconDetailView: View {
                 Text(store.title)
                     .font(.title3.bold())
                     .listRowSeparator(.hidden)
-                
+
                 Text(store.description)
-                
+
                 Toggle("기능 활성화", isOn: $store.isEnabled)
                     .tint(Color.accentColor)
             }
         }
         .navigationTitle(store.title)
     }
-    
+
     public init(store: StoreOf<AppIconDetailFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/Labs/Experiments/BetaADetail.swift
+++ b/KuringPackage/Sources/Labs/Experiments/BetaADetail.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import ComposableArchitecture
 
 @Reducer
@@ -10,28 +15,28 @@ public struct BetaADetailFeature {
         이 기능을 활성화 하면 **각 공지별로 몇 번이나 북마크 되었는지 확인**할 수 있습니다.
         """
         public var isEnabled: Bool = false
-        
+
         public init(isEnabled: Bool? = nil) {
             @Dependency(\.leLabo) var leLabo
             self.isEnabled = leLabo.status(.betaA)
         }
     }
-    
+
     public enum Action: Equatable, BindableAction {
         case binding(BindingAction<State>)
     }
-    
+
     @Dependency(\.leLabo) public var leLabo
-    
+
     public var body: some ReducerOf<Self> {
         BindingReducer()
-        
+
         Reduce { state, action in
             switch action {
             case .binding(\.isEnabled):
                 leLabo.set(state.isEnabled, .betaA)
                 return .none
-                
+
             case .binding:
                 return .none
             }
@@ -43,7 +48,7 @@ import SwiftUI
 
 public struct BetaADetailView: View {
     @Bindable public var store: StoreOf<BetaADetailFeature>
-    
+
     public let markdown: LocalizedStringKey = "# hi"
     public var body: some View {
         Form {
@@ -51,16 +56,16 @@ public struct BetaADetailView: View {
                 Text(store.title)
                     .font(.title3.bold())
                     .listRowSeparator(.hidden)
-                
+
                 Text(store.description)
-                
+
                 Toggle("기능 활성화", isOn: $store.isEnabled)
                     .tint(Color.accentColor)
             }
         }
         .navigationTitle(store.title)
     }
-    
+
     public init(store: StoreOf<BetaADetailFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/Labs/LabApp.Path.swift
+++ b/KuringPackage/Sources/Labs/LabApp.Path.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import ComposableArchitecture
 
 extension LabAppFeature {
@@ -9,24 +14,24 @@ extension LabAppFeature {
             case betaA(BetaADetailFeature.State)
             case appIcon(AppIconDetailFeature.State)
         }
-        
+
         public enum Action: Equatable {
             /// - Important: 테스트를 위한 케이스 이므로 삭제하지 말 것
             case betaA(BetaADetailFeature.Action)
             case appIcon(AppIconDetailFeature.Action)
         }
-        
+
         public var body: some ReducerOf<Self> {
             /// - Important: 테스트를 위한 리듀서 이므로 삭제하지 말 것
             Scope(state: \.betaA, action: \.betaA) {
                 BetaADetailFeature()
             }
-            
+
             Scope(state: \.appIcon, action: \.appIcon) {
                 AppIconDetailFeature()
             }
         }
-        
+
         public init() { }
     }
 }

--- a/KuringPackage/Sources/Labs/LabApp.swift
+++ b/KuringPackage/Sources/Labs/LabApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import ComposableArchitecture
 
 @Reducer
@@ -8,7 +13,7 @@ public struct LabAppFeature {
         public var path = StackState<Path.State>()
         /// root
         public var betaList = ExperimentListFeature.State()
-        
+
         public init(
             path: StackState<Path.State> = .init(),
             root: ExperimentListFeature.State = .init()
@@ -17,24 +22,24 @@ public struct LabAppFeature {
             self.betaList = root
         }
     }
-    
+
     public enum Action: Equatable {
         /// root
         case betaList(ExperimentListFeature.Action)
         /// 스택 기반 네비게이션
         case path(StackAction<Path.State, Path.Action>)
     }
-    
+
     public var body: some ReducerOf<Self> {
         Scope(state: \.betaList, action: \.betaList) {
             ExperimentListFeature()
         }
-        
-        Reduce { state, action in
+
+        Reduce { _, action in
             switch action {
             case .betaList:
                 return .none
-                
+
             case .path:
                 return .none
             }
@@ -43,7 +48,7 @@ public struct LabAppFeature {
             Path()
         }
     }
-    
+
     public init() { }
 }
 
@@ -51,7 +56,7 @@ import SwiftUI
 
 public struct LabApp: View {
     @Bindable public var store: StoreOf<LabAppFeature>
-    
+
     public var body: some View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             ExperimentList(
@@ -74,9 +79,8 @@ public struct LabApp: View {
                 }
             }
         }
-
     }
-    
+
     public init(store: StoreOf<LabAppFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/Models/Feedback.swift
+++ b/KuringPackage/Sources/Models/Feedback.swift
@@ -1,8 +1,13 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
 public struct Feedback: Codable, Equatable {
     public var content: String
-    
+
     public init(content: String) {
         self.content = content
     }

--- a/KuringPackage/Sources/Models/Notice.swift
+++ b/KuringPackage/Sources/Models/Notice.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
 public struct Notice: Codable, Hashable, Identifiable, Equatable {
@@ -49,7 +54,7 @@ public struct SearchedNotice: Codable, Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(baseUrl)
     }
-    
+
     public var asNotice: Notice {
         Notice(
             articleId: articleId,

--- a/KuringPackage/Sources/Models/NoticeProvider.swift
+++ b/KuringPackage/Sources/Models/NoticeProvider.swift
@@ -1,10 +1,15 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
 public enum NoticeType: String, Hashable, CaseIterable, Identifiable {
     case 학과, 학사, 장학, 도서관, 취창업, 국제, 학생, 산학, 일반
-    
+
     public var id: Self { self }
-    
+
     public var provider: NoticeProvider {
         switch self {
         case .학과:
@@ -30,13 +35,13 @@ public enum NoticeType: String, Hashable, CaseIterable, Identifiable {
 }
 
 public struct NoticeProvider: Identifiable, Equatable, Hashable {
-    public var id: String { self.hostPrefix }
-    
+    public var id: String { hostPrefix }
+
     public let name: String
     public let hostPrefix: String
     public let korName: String
     public var category: NoticeType
-    
+
     public init(name: String, hostPrefix: String, korName: String, category: NoticeType) {
         self.name = name
         self.hostPrefix = hostPrefix
@@ -52,65 +57,65 @@ extension NoticeProvider {
         korName: "",
         category: .학과
     )
-    
+
     public static let 학사 = NoticeProvider(
         name: "bachelor",
         hostPrefix: "bch",
         korName: "학사",
         category: .학사
     )
-    
+
     public static let 취창업 = NoticeProvider(
         name: "employment",
         hostPrefix: "emp",
         korName: "취창업",
         category: .취창업
     )
-    
+
     public static let 도서관 = NoticeProvider(
         name: "library",
         hostPrefix: "lib",
         korName: "도서관",
         category: .도서관
     )
-    
+
     public static let 학생 = NoticeProvider(
         name: "student",
         hostPrefix: "stu",
         korName: "학생",
         category: .학생
     )
-    
+
     public static let 국제 = NoticeProvider(
         name: "national",
         hostPrefix: "nat",
         korName: "국제",
         category: .국제
     )
-    
+
     public static let 장학 = NoticeProvider(
         name: "scholarship",
         hostPrefix: "sch",
         korName: "장학",
         category: .장학
     )
-    
+
     public static let 산학 = NoticeProvider(
         name: "industry_university",
         hostPrefix: "ind",
         korName: "산학",
         category: .산학
     )
-    
+
     public static let 일반 = NoticeProvider(
         name: "normal",
         hostPrefix: "nor",
         korName: "일반",
         category: .일반
     )
-    
+
     public static let univNoticeTypes: [NoticeProvider] = [
-        .학사, .취창업, .도서관, .학생, .국제, .장학, .산학, .일반
+        .학사, .취창업, .도서관, .학생, .국제, .장학, .산학, .일반,
     ]
 }
 
@@ -137,5 +142,3 @@ extension NoticeProvider {
         ),
     ]
 }
-
-

--- a/KuringPackage/Sources/Models/Staff.swift
+++ b/KuringPackage/Sources/Models/Staff.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
 public struct Staff: Codable, Hashable, Equatable {
@@ -11,6 +16,7 @@ public struct Staff: Codable, Hashable, Equatable {
 }
 
 // MARK: 테스트용
+
 extension Staff {
     public static func random(
         name: String = "박능수 (Neungsoo Park)",

--- a/KuringPackage/Sources/Models/Subscription.swift
+++ b/KuringPackage/Sources/Models/Subscription.swift
@@ -1,8 +1,13 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
 public struct UnivNoticeSubscription: Codable {
     public let categories: [String]
-    
+
     public init(categories: [String]) {
         self.categories = categories
     }
@@ -10,7 +15,7 @@ public struct UnivNoticeSubscription: Codable {
 
 public struct DepartmentSubscription: Codable {
     public let departments: [String]
-    
+
     public init(departments: [String]) {
         self.departments = departments
     }

--- a/KuringPackage/Sources/Networks/API.Path.swift
+++ b/KuringPackage/Sources/Networks/API.Path.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
 enum Path {
@@ -11,7 +16,7 @@ enum Path {
     case searchNotices
     case searchStaffs
     case sendFeedback
-    
+
     var path: String {
         switch self {
         case .subscribeUnivNotices:

--- a/KuringPackage/Sources/Networks/API.Response.swift
+++ b/KuringPackage/Sources/Networks/API.Response.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
 struct Response<ResultData: Decodable>: Decodable {

--- a/KuringPackage/Sources/Networks/KuringLink.Dependency.swift
+++ b/KuringPackage/Sources/Networks/KuringLink.Dependency.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import ComposableArchitecture
 
@@ -12,7 +17,7 @@ extension KuringLink: DependencyKey {
                         .init(name: "type", value: type),
                         .init(name: "department", value: department),
                         .init(name: "page", value: String(page)),
-                        .init(name: "size", value: String(count))
+                        .init(name: "size", value: String(count)),
                     ]
                 )
             return response.data
@@ -25,11 +30,11 @@ extension KuringLink: DependencyKey {
                     httpHeaders: [
                         "Content-Type": "application/json",
                         "User-Token": fcmToken,
-                        "User-Agent": "Kuring/\(appVersion) iOS/\(iosVersion)"
+                        "User-Agent": "Kuring/\(appVersion) iOS/\(iosVersion)",
                     ],
                     httpBody: Feedback(content: text)
                 )
-            let isSucceed = (200..<300) ~= response.code
+            let isSucceed = (200 ..< 300) ~= response.code
             return isSucceed
         },
         searchNotices: { keyword in
@@ -42,7 +47,7 @@ extension KuringLink: DependencyKey {
                     for: Path.searchNotices.path,
                     httpMethod: .get,
                     queryItems: [
-                        .init(name: "content", value: keyword)
+                        .init(name: "content", value: keyword),
                     ]
                 )
             return response.data.noticeList.compactMap { $0.asNotice }
@@ -57,7 +62,7 @@ extension KuringLink: DependencyKey {
                     for: Path.searchStaffs.path,
                     httpMethod: .get,
                     queryItems: [
-                        .init(name: "content", value: keyword)
+                        .init(name: "content", value: keyword),
                     ]
                 )
             return response.data.staffList
@@ -69,11 +74,11 @@ extension KuringLink: DependencyKey {
                     httpMethod: .post,
                     httpHeaders: [
                         "Content-Type": "application/json",
-                        "User-Token": fcmToken
+                        "User-Token": fcmToken,
                     ],
                     httpBody: UnivNoticeSubscription(categories: typeNames)
                 )
-            let isSucceed = (200..<300) ~= response.code
+            let isSucceed = (200 ..< 300) ~= response.code
             return isSucceed
         },
         subscribeDepartments: { hostPrefixes in
@@ -83,11 +88,11 @@ extension KuringLink: DependencyKey {
                     httpMethod: .post,
                     httpHeaders: [
                         "Content-Type": "application/json",
-                        "User-Token": fcmToken
+                        "User-Token": fcmToken,
                     ],
                     httpBody: DepartmentSubscription(departments: hostPrefixes)
                 )
-            let isSucceed = (200..<300) ~= response.code
+            let isSucceed = (200 ..< 300) ~= response.code
             return isSucceed
         }
     )
@@ -101,24 +106,24 @@ extension DependencyValues {
 }
 
 extension KuringLink {
-    public static let testValue: KuringLink = KuringLink(
-        fetchNotices: { count, type, department, page in
-            return [Notice.random]
+    public static let testValue: KuringLink = .init(
+        fetchNotices: { _, _, _, _ in
+            [Notice.random]
         },
-        sendFeedback: { text in
-            return true
+        sendFeedback: { _ in
+            true
         },
-        searchNotices: { keyword in
-            return [Notice.random]
+        searchNotices: { _ in
+            [Notice.random]
         },
-        searchStaffs: { keyword in
-            return [Staff.random()]
+        searchStaffs: { _ in
+            [Staff.random()]
         },
-        subscribeUnivNotices: { typeNames in
-            return true
+        subscribeUnivNotices: { _ in
+            true
         },
-        subscribeDepartments: { hostPrefixes in
-            return true
+        subscribeDepartments: { _ in
+            true
         }
     )
 }

--- a/KuringPackage/Sources/Networks/KuringLink.swift
+++ b/KuringPackage/Sources/Networks/KuringLink.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import Satellite
 import Foundation
@@ -20,30 +25,35 @@ public struct KuringLink {
             host: (dict["API_HOST"] as? String) ?? "",
             scheme: (dict["USING_HTTPS"] as? Bool) ?? true ? .https : .http
         )
-//        satellite._startGPS()
+        //        satellite._startGPS()
         return satellite
     }
+
     static let appVersion = "" // NEXT_VERSION
     static let iosVersion = {
         let osVersion = ProcessInfo.processInfo.operatingSystemVersion
         let iosVersion = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
         return iosVersion
     }()
+
     // TODO: kuring.set(\.fcmToken, "{FCM.TOKEN}")
     static var fcmToken: String = "cZSHjO4_bUjirvsrxWzig5:APA91bHPojABL5oEXi5AcjJ8v4Vcp3KpJfFUD_3b-HhfV8m23_R6czJa3PwqcVqBZSHBb2t7Z3odUeD0cFKaMSkMmrGxTqyjJPfEZVfTPvmewV-xiMTWbrk-QKuc4Nrxd_BhEArO7Svo"
-    
+
     // MARK: - Notices
+
     public var fetchNotices: (NoticeCount, NoticeType, Department?, Page) async throws -> [Notice]
-    
+
     public var sendFeedback: (String) async throws -> Bool
-    
+
     // MARK: - Search
+
     public var searchNotices: (_ keyword: String) async throws -> [Notice]
-    
+
     public var searchStaffs: (_ keyword: String) async throws -> [Staff]
-    
+
     // MARK: - Subscriptions
+
     public var subscribeUnivNotices: ([NoticeTypeName]) async throws -> Bool
-    
+
     public var subscribeDepartments: ([DepartmentHostPrefix]) async throws -> Bool
 }

--- a/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkApp.swift
+++ b/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import NoticeUI
 import BookmarkFeatures
@@ -5,7 +10,7 @@ import ComposableArchitecture
 
 public struct BookmarkApp: View {
     @Bindable var store: StoreOf<BookmarkAppFeature>
-    
+
     public var body: some View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             BookmarkList(
@@ -16,7 +21,7 @@ public struct BookmarkApp: View {
             )
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("보관함")
-            
+
         } destination: { store in
             switch store.state {
             case .detail:
@@ -26,7 +31,7 @@ public struct BookmarkApp: View {
             }
         }
     }
-    
+
     public init(store: StoreOf<BookmarkAppFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkList.swift
+++ b/KuringPackage/Sources/UIKit/BookmarkUI/BookmarkList.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import NoticeUI
 import NoticeFeatures
@@ -6,7 +11,7 @@ import ComposableArchitecture
 
 public struct BookmarkList: View {
     @Bindable var store: StoreOf<BookmarkListFeature>
-    
+
     public var body: some View {
         ZStack(alignment: .bottom) {
             List {
@@ -15,8 +20,8 @@ public struct BookmarkList: View {
                         NoticeRow(
                             notice: notice,
                             rowType: store.isEditing
-                            ? NoticeRow.NoticeRowType.none
-                            : nil
+                                ? NoticeRow.NoticeRowType.none
+                                : nil
                         )
                         .background {
                             NavigationLink(
@@ -29,7 +34,7 @@ public struct BookmarkList: View {
                             .opacity(0)
                         }
                         .disabled(store.editMode != .none)
-                        
+
                         if store.isEditing {
                             Button {
                                 if store.selectedIDs.contains(notice.id) {
@@ -40,23 +45,22 @@ public struct BookmarkList: View {
                             } label: {
                                 Image(
                                     systemName: store.selectedIDs.contains(notice.id)
-                                    ? "checkmark.circle.fill"
-                                    : "circle"
+                                        ? "checkmark.circle.fill"
+                                        : "circle"
                                 )
                                 .foregroundStyle(
                                     store.selectedIDs.contains(notice.id)
-                                    ? Color.accentColor
-                                    : Color.caption1.opacity(0.15)
+                                        ? Color.accentColor
+                                        : Color.caption1.opacity(0.15)
                                 )
                             }
                         }
                     }
                 }
                 .listRowSeparator(.hidden)
-                
             }
             .listStyle(.plain)
-            
+
             if store.editMode != .none {
                 Button {
                     store.send(.deleteButtonTapped)
@@ -64,11 +68,11 @@ public struct BookmarkList: View {
                     topBlurButton(
                         "삭제하기",
                         fontColor: store.selectedIDs.isEmpty
-                        ? Color.accentColor.opacity(0.4)
-                        : .white,
+                            ? Color.accentColor.opacity(0.4)
+                            : .white,
                         backgroundColor: store.selectedIDs.isEmpty
-                        ? Color.accentColor.opacity(0.15)
-                        : Color.accentColor
+                            ? Color.accentColor.opacity(0.15)
+                            : Color.accentColor
                     )
                 }
                 .padding(.horizontal, 20)
@@ -93,14 +97,14 @@ public struct BookmarkList: View {
                 Button {
                     store.send(
                         store.isEditing
-                        ? .selectAllButtonTapped
-                        : .editButtonTapped
+                            ? .selectAllButtonTapped
+                            : .editButtonTapped
                     )
                 } label: {
                     Text(
                         store.isEditing
-                        ? "전체 선택"
-                        : "편집"
+                            ? "전체 선택"
+                            : "편집"
                     )
                 }
                 .disabled(store.bookmarkedNotices.isEmpty)
@@ -108,7 +112,7 @@ public struct BookmarkList: View {
             }
         }
     }
-    
+
     // TODO: 디자인 시스템 분리 - 상단에 블러가 존재하는 버튼
     @ViewBuilder
     private func topBlurButton(_ title: String, fontColor: Color, backgroundColor: Color) -> some View {
@@ -143,7 +147,7 @@ public struct BookmarkList: View {
         }
         .tabItem {
             Image(systemName: "archivebox")
-            
+
             Text("공지보관함")
         }
     }

--- a/KuringPackage/Sources/UIKit/ColorSet/Color.UIKit.swift
+++ b/KuringPackage/Sources/UIKit/ColorSet/Color.UIKit.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 
 extension Color {

--- a/KuringPackage/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/KuringPackage/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import DepartmentFeatures
@@ -5,9 +10,9 @@ import ComposableArchitecture
 
 public struct DepartmentEditor: View {
     @Bindable var store: StoreOf<DepartmentEditorFeature>
-    
+
     @FocusState private var focus: DepartmentEditorFeature.State.Field?
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             Text("학과를 추가하거나\n삭제할 수 있어요")
@@ -15,16 +20,16 @@ public struct DepartmentEditor: View {
                 .foregroundStyle(Color(red: 0.1, green: 0.12, blue: 0.15))
                 .padding(.top, 28)
                 .padding(.bottom, 24)
-            
+
             HStack(alignment: .center, spacing: 12) {
                 Image(systemName: "magnifyingglass")
                     .frame(width: 16, height: 16)
                     .foregroundStyle(Color.caption1.opacity(0.6))
-                
+
                 TextField("추가할 학과를 검색해 주세요", text: $store.searchText)
                     .focused($focus, equals: .search)
                     .bind($store.focus, to: self.$focus)
-                
+
                 if !store.searchText.isEmpty {
                     Image(systemName: "xmark")
                         .frame(width: 16, height: 16)
@@ -40,13 +45,13 @@ public struct DepartmentEditor: View {
             .background(Color(red: 0.95, green: 0.95, blue: 0.96))
             .cornerRadius(20)
             .padding(.bottom, 16)
-            
+
             Text(store.searchText.isEmpty ? "내 학과" : "검색 결과")
                 .font(.system(size: 14))
                 .foregroundStyle(Color.caption1.opacity(0.6))
                 .padding(.horizontal, 4)
                 .padding(.vertical, 10)
-            
+
             if store.searchText.isEmpty {
                 // 내학과
                 ScrollView {
@@ -78,7 +83,7 @@ public struct DepartmentEditor: View {
                     }
                 }
             }
-            
+
             Spacer()
         }
         .padding(.horizontal, 20)
@@ -92,13 +97,13 @@ public struct DepartmentEditor: View {
             }
         }
         .alert(
-            store: self.store.scope(
+            store: store.scope(
                 state: \.$alert,
                 action: \.alert
             )
         )
     }
-    
+
     public init(store: StoreOf<DepartmentEditorFeature>, focus: DepartmentEditorFeature.State.Field? = nil) {
         self.store = store
         self.focus = focus
@@ -112,12 +117,12 @@ public struct DepartmentEditor: View {
                 initialState: DepartmentEditorFeature.State(
                     myDepartments: [
                         NoticeProvider.departments[0],
-                        NoticeProvider.departments[1]
+                        NoticeProvider.departments[1],
                     ],
                     results: [
                         NoticeProvider.departments[0],
                         NoticeProvider.departments[1],
-                        NoticeProvider.departments[2]
+                        NoticeProvider.departments[2],
                     ]
                 ),
                 reducer: { DepartmentEditorFeature() }

--- a/KuringPackage/Sources/UIKit/DepartmentUI/DepartmentRow.swift
+++ b/KuringPackage/Sources/UIKit/DepartmentUI/DepartmentRow.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import ColorSet
@@ -7,18 +12,18 @@ struct DepartmentRow: View {
     let department: NoticeProvider
     let style: ButtonStyle
     let action: () -> Void
-    
+
     enum ButtonStyle {
         case delete
         case radio(Bool)
     }
-    
+
     var body: some View {
         HStack(alignment: .center) {
             Text(department.korName)
-            
+
             Spacer()
-            
+
             switch style {
             case .delete:
                 Button(action: action) {
@@ -29,13 +34,13 @@ struct DepartmentRow: View {
                 Button(action: action) {
                     Image(
                         systemName: isSelected
-                        ? "checkmark.circle.fill"
-                        : "plus.circle"
+                            ? "checkmark.circle.fill"
+                            : "plus.circle"
                     )
                     .foregroundStyle(
                         isSelected
-                        ? Color.accentColor
-                        : Color.black.opacity(0.1)
+                            ? Color.accentColor
+                            : Color.black.opacity(0.1)
                     )
                 }
             }
@@ -48,9 +53,9 @@ struct DepartmentRow: View {
 #Preview {
     Group {
         DepartmentRow(department: .국제, style: .delete) { }
-    
+
         DepartmentRow(department: .국제, style: .radio(true)) { }
-        
+
         DepartmentRow(department: .국제, style: .radio(false)) { }
     }
 }

--- a/KuringPackage/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
+++ b/KuringPackage/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import DepartmentFeatures
@@ -5,7 +10,7 @@ import ComposableArchitecture
 
 public struct DepartmentSelector: View {
     @Bindable var store: StoreOf<DepartmentSelectorFeature>
-    
+
     public var body: some View {
         VStack {
             HStack(alignment: .center, spacing: 10) {
@@ -17,25 +22,25 @@ public struct DepartmentSelector: View {
             .padding(.top, 24)
             .padding(.bottom, 12)
             .frame(width: 375, alignment: .leading)
-            
+
             ScrollView {
                 ForEach(store.addedDepartment) { department in
                     HStack {
                         Text(department.korName)
                             .font(.system(size: 16, weight: .medium))
                             .foregroundStyle(.black)
-                        
+
                         Spacer()
-                        
+
                         Image(
                             systemName: department == store.currentDepartment
-                            ? "checkmark.circle.fill"
-                            : "circle"
+                                ? "checkmark.circle.fill"
+                                : "circle"
                         )
                         .foregroundStyle(
                             department == store.currentDepartment
-                            ? Color.accentColor
-                            : Color.black.opacity(0.1)
+                                ? Color.accentColor
+                                : Color.black.opacity(0.1)
                         )
                         .frame(width: 20, height: 20)
                     }
@@ -47,7 +52,7 @@ public struct DepartmentSelector: View {
                     }
                 }
             }
-            
+
             Button {
                 store.send(.editDepartmentsButtonTapped)
             } label: {
@@ -60,7 +65,7 @@ public struct DepartmentSelector: View {
             .padding(.horizontal, 20)
         }
     }
-    
+
     // TODO: 디자인 시스템 분리 - 상단에 블러가 존재하는 버튼
     @ViewBuilder
     private func topBlurButton(_ title: String, fontColor: Color, backgroundColor: Color) -> some View {
@@ -81,7 +86,7 @@ public struct DepartmentSelector: View {
                 .offset(x: 0, y: -32)
         }
     }
-    
+
     public init(store: StoreOf<DepartmentSelectorFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/NoticeUI/Bundle.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/Bundle.swift
@@ -1,5 +1,10 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
-public extension Bundle {
-    static var notices: Bundle { .module }
+extension Bundle {
+    public static var notices: Bundle { .module }
 }

--- a/KuringPackage/Sources/UIKit/NoticeUI/DepartmentSelectorLink.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/DepartmentSelectorLink.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 
@@ -5,15 +10,15 @@ struct DepartmentSelectorLink: View {
     let department: NoticeProvider
     @Binding var isLoading: Bool
     let action: () -> Void
-    
+
     var body: some View {
         HStack {
             Text(department.korName)
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(Color.black.opacity(0.8))
-            
+
             Spacer()
-            
+
             if isLoading {
                 ProgressView()
             } else {

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import SearchUI
 import DepartmentUI
@@ -8,7 +13,7 @@ import ComposableArchitecture
 
 public struct NoticeApp: View {
     @Bindable var store: StoreOf<NoticeAppFeature>
-    
+
     public var body: some View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             NoticeContentView(
@@ -22,9 +27,10 @@ public struct NoticeApp: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Image("appIconLabel", bundle: Bundle.notices)
                 }
-                
+
                 ToolbarItem(placement: .navigationBarTrailing) {
                     // MARK: 검색창 진입
+
                     NavigationLink(
                         state: NoticeAppFeature.Path.State.search(
                             SearchFeature.State()
@@ -34,9 +40,10 @@ public struct NoticeApp: View {
                             .foregroundStyle(Color.black)
                     }
                 }
-                
+
                 ToolbarItem(placement: .navigationBarTrailing) {
                     // MARK: 푸시 알림 선택 진입
+
                     Button {
                         store.send(.changeSubscriptionButtonTapped)
                     } label: {
@@ -74,7 +81,7 @@ public struct NoticeApp: View {
             }
         }
     }
-    
+
     public init(store: StoreOf<NoticeAppFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeContentView.NoDepartment.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeContentView.NoDepartment.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import NoticeFeatures
@@ -9,14 +14,14 @@ extension NoticeContentView {
     func NoDepartmentView() -> some View {
         VStack(spacing: 0) {
             Spacer()
-            
+
             Text("아직 추가된 학과가 없어요.\n관심 학과를 추가하고 공지를 확인해 보세요!")
                 .font(.system(size: 15, weight: .medium))
                 .multilineTextAlignment(.center)
                 .foregroundColor(.black.opacity(0.36))
-            
+
             Spacer()
-            
+
             NavigationLink(
                 state: NoticeAppFeature.Path.State.departmentEditor(
                     // TODO: - Mock 데이터 추후 제거
@@ -38,18 +43,18 @@ extension NoticeContentView {
             }
         }
     }
-    
+
     // TODO: 디자인 시스템 분리
     /// 상단에 블러가 존재하는 버튼
     @ViewBuilder
     func OverlayButton(_ title: String) -> some View {
         HStack(alignment: .center, spacing: 10) {
             Spacer()
-            
+
             Text(title)
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(Color.white)
-            
+
             Spacer()
         }
         .padding(.horizontal, 50)

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeContentView.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeContentView.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import DepartmentUI
@@ -7,13 +12,13 @@ import ComposableArchitecture
 
 struct NoticeContentView: View {
     @Bindable var store: StoreOf<NoticeListFeature>
-    
+
     /// - NOTE: NoticeList 만 제외하고 나머지는 NotiecApp 단으로 옮겨야 하는가?
-    
+
     var body: some View {
         VStack(spacing: 0) {
             NoticeCategoryPicker(selection: $store.provider.sending(\.providerChanged))
-            
+
             if self.store.provider == .emptyDepartment {
                 NoDepartmentView()
             } else {

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import NoticeFeatures
@@ -5,44 +10,44 @@ import ComposableArchitecture
 
 public struct NoticeDetailView: View {
     @Bindable var store: StoreOf<NoticeDetailFeature>
-    
+
     public var body: some View {
         List {
             Section {
                 Text(self.store.notice.articleId)
-                
+
                 Text("`notice.articleId`")
             } header: {
                 Text("고유번호")
             }
-            
+
             Section {
                 Text(self.store.notice.category)
-                
+
                 Text("`notice.category`")
             } header: {
                 Text("공지 카테고리")
             }
-            
+
             Section {
                 Text(self.store.notice.postedDate)
-                
+
                 Text("`notice.postedDate`")
             } header: {
                 Text("Posted date")
             }
-            
+
             Section {
                 Text(self.store.notice.subject)
-                
+
                 Text("`notice.subject`")
             } header: {
                 Text("공지 제목")
             }
-            
+
             Section {
                 Text(self.store.state.notice.url)
-                
+
                 Text("`notice.url`")
             } header: {
                 Text("URL")
@@ -56,14 +61,14 @@ public struct NoticeDetailView: View {
                 } label: {
                     Image(
                         systemName: self.store.isBookmarked
-                        ? "bookmark.fill"
-                        : "bookmark"
+                            ? "bookmark.fill"
+                            : "bookmark"
                     )
                 }
             }
         }
     }
-    
+
     public init(store: StoreOf<NoticeDetailFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeList.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeList.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import DepartmentUI
 import NoticeFeatures
@@ -5,7 +10,7 @@ import ComposableArchitecture
 
 struct NoticeList: View {
     @Bindable var store: StoreOf<NoticeListFeature>
-    
+
     var body: some View {
         Section {
             List(self.store.currentNotices, id: \.id) { notice in
@@ -19,7 +24,7 @@ struct NoticeList: View {
                         .onAppear {
                             let type = self.store.provider
                             let noticeInfo = self.store.noticeDictionary[type]
-                            
+
                             /// 마지막 공지가 보이면 update
                             if noticeInfo?.notices.last == notice {
                                 self.store.send(.fetchNotices)

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeRow.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeRow.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Caches
 import Models
 import SwiftUI
@@ -6,10 +11,10 @@ import ComposableArchitecture
 public struct NoticeRow: View {
     var rowType: NoticeRowType
     let notice: Notice
-    
+
     public init(notice: Notice, rowType: NoticeRowType? = nil) {
         self.notice = notice
-        
+
         var isBookmarked: Bool
         @Dependency(\.bookmarks) var bookmarks
         do {
@@ -18,12 +23,12 @@ public struct NoticeRow: View {
         } catch {
             isBookmarked = false
         }
-        
+
         if let rowType {
             self.rowType = rowType
             return
         }
-        
+
         if notice.important {
             if isBookmarked { self.rowType = .importantAndBookmark }
             else { self.rowType = .important }
@@ -32,7 +37,7 @@ public struct NoticeRow: View {
             else { self.rowType = .none }
         }
     }
-    
+
     public enum NoticeRowType {
         /// 중요이면서 북마크
         case importantAndBookmark
@@ -43,7 +48,7 @@ public struct NoticeRow: View {
         /// 기본
         case none
     }
-    
+
     public var body: some View {
         ZStack {
             switch rowType {
@@ -52,7 +57,7 @@ public struct NoticeRow: View {
             default:
                 Color.clear
             }
-            
+
             switch rowType {
             case .importantAndBookmark:
                 VStack(alignment: .leading, spacing: 4) {
@@ -104,7 +109,7 @@ public struct NoticeRow: View {
             }
         }
     }
-    
+
     @ViewBuilder
     private var importantTagView: some View {
         Text("중요")
@@ -120,14 +125,14 @@ public struct NoticeRow: View {
                     .stroke(Color.accentColor, lineWidth: 0.5)
             )
     }
-    
+
     @ViewBuilder
     private var titleView: some View {
         Text(notice.subject)
             .font(.system(size: 15, weight: .medium))
             .foregroundStyle(Color.caption1)
     }
-    
+
     @ViewBuilder
     private var dateView: some View {
         // TODO: - 정보 재구성
@@ -135,7 +140,7 @@ public struct NoticeRow: View {
             .font(.system(size: 14))
             .foregroundStyle(Color.caption1.opacity(0.6))
     }
-    
+
     @ViewBuilder
     private var bookmarkView: some View {
         // TODO: 디자인 시스템 분리 - 북마크
@@ -144,7 +149,7 @@ public struct NoticeRow: View {
                 .compositingGroup()
                 .foregroundStyle(Color.accentColor)
                 .frame(width: 16, height: 21)
-            
+
             RoundedRectangle(cornerRadius: 2)
                 .rotation(.degrees(45))
                 .frame(width: 16, height: 16)

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeTypeColumn.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeTypeColumn.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import ComposableArchitecture
@@ -5,11 +10,11 @@ import ComposableArchitecture
 public struct NoticeTypeColumn: View {
     public let noticeType: NoticeType
     public let selectedID: NoticeType.ID
-    
+
     public var body: some View {
-        let itemSize: CGSize = CGSize(width: 64, height: 48)
+        let itemSize = CGSize(width: 64, height: 48)
         let lineHeight: CGFloat = 3
-        
+
         Text(noticeType.rawValue)
             .font(.system(size: 16, weight: noticeType.id == selectedID ? .semibold : .regular))
             .padding(.vertical, 8)
@@ -17,7 +22,7 @@ public struct NoticeTypeColumn: View {
             .overlay {
                 VStack {
                     Spacer()
-                    
+
                     RoundedRectangle(cornerRadius: lineHeight / 2)
                         .frame(width: itemSize.width, height: lineHeight)
                         .opacity(noticeType.id == selectedID ? 1 : 0)
@@ -25,12 +30,12 @@ public struct NoticeTypeColumn: View {
             }
             .foregroundStyle(
                 noticeType.id == selectedID
-                ? Color.accentColor
-                : Color.black.opacity(0.3)
+                    ? Color.accentColor
+                    : Color.black.opacity(0.3)
             )
             .id(noticeType.id)
     }
-    
+
     public init(noticeType: NoticeType, selectedID: NoticeType.ID) {
         self.noticeType = noticeType
         self.selectedID = selectedID

--- a/KuringPackage/Sources/UIKit/NoticeUI/NoticeTypePicker.swift
+++ b/KuringPackage/Sources/UIKit/NoticeUI/NoticeTypePicker.swift
@@ -1,10 +1,15 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import ComposableArchitecture
 
 public struct NoticeCategoryPicker: View {
     @Binding var selection: NoticeProvider
-    
+
     public var body: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {

--- a/KuringPackage/Sources/UIKit/SearchUI/SearchDetailView.swift
+++ b/KuringPackage/Sources/UIKit/SearchUI/SearchDetailView.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 import SearchFeatures
@@ -5,32 +10,32 @@ import ComposableArchitecture
 
 public struct StaffDetailView: View {
     @Bindable var store: StoreOf<StaffDetailFeature>
-    
+
     public var body: some View {
         List {
             Text(store.staff.name)
                 .font(.system(size: 20, weight: .bold))
                 .listRowSeparator(.hidden)
-            
+
             Text("\(store.staff.deptName) · \(store.staff.collegeName)")
                 .foregroundStyle(.secondary)
                 .listRowSeparator(.hidden)
-            
+
             Label(store.staff.email, systemImage: "envelope")
                 .listRowSeparator(.hidden)
-            
+
             Label(store.staff.lab, systemImage: "mappin.and.ellipse")
                 .listRowSeparator(.hidden)
-            
+
             Label(store.staff.phone, systemImage: "phone")
                 .listRowSeparator(.hidden)
-            
+
             Label(store.staff.major, systemImage: "book")
                 .listRowSeparator(.hidden)
         }
         .listStyle(.plain)
     }
-    
+
     public init(store: StoreOf<StaffDetailFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/SearchUI/SearchView.swift
+++ b/KuringPackage/Sources/UIKit/SearchUI/SearchView.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import ColorSet
 import NoticeFeatures
@@ -18,7 +23,7 @@ import ComposableArchitecture
 public struct SearchView: View {
     @Bindable var store: StoreOf<SearchFeature>
     @FocusState var focus: SearchFeature.State.Field?
-    
+
     public var body: some View {
         VStack(spacing: 0) {
             ZStack {
@@ -28,11 +33,11 @@ public struct SearchView: View {
                     Image(systemName: "magnifyingglass")
                         .frame(width: 16, height: 16)
                         .foregroundStyle(Color.caption1.opacity(0.6))
-                    
+
                     TextField("검색어를 입력해주세요", text: $store.searchInfo.text)
                         .focused($focus, equals: .search)
                         .onSubmit { store.send(.search) }
-                    
+
                     if store.searchInfo.searchPhase == .searching {
                         /// 검색 중 로딩 인디케이터
                         ProgressView()
@@ -54,16 +59,16 @@ public struct SearchView: View {
                 .background(Color(red: 0.95, green: 0.95, blue: 0.96))
                 .cornerRadius(20)
             }
-            
+
             if !store.recents.isEmpty {
                 HStack {
                     /// 최근 검색어
                     Text("최근검색어")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(Color.caption1.opacity(0.6))
-                    
+
                     Spacer()
-                    
+
                     /// 전체 삭제
                     Button {
                         store.send(.deleteAllRecentsButtonTapped)
@@ -76,7 +81,7 @@ public struct SearchView: View {
                 }
                 .padding(.top, 20)
                 .padding(.bottom, 12)
-                
+
                 /// 최근 검색어 목록
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack {
@@ -94,23 +99,22 @@ public struct SearchView: View {
                                         .cornerRadius(20)
                                 }
                             }
-                            
                         }
                     }
                 }
                 .frame(height: 30)
             }
-            
+
             HStack {
                 Text("검색결과")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundStyle(Color.caption1.opacity(0.6))
                     .padding(.top, 20)
                     .padding(.bottom, 12)
-                
+
                 Spacer()
             }
-            
+
             /// 검색타입 세그먼트
             Rectangle()
                 .foregroundColor(.clear)
@@ -125,7 +129,7 @@ public struct SearchView: View {
                         } label: {
                             SegmentView("공지", isSelect: store.searchInfo.searchType == .notice)
                         }
-                        
+
                         Button {
                             store.send(.selectSearchType(.staff))
                         } label: {
@@ -134,7 +138,7 @@ public struct SearchView: View {
                     }
                     .padding(5)
                 }
-            
+
             /// 검색결과
             switch store.searchInfo.searchType {
             case .notice:
@@ -147,10 +151,10 @@ public struct SearchView: View {
                         ) {
                             VStack(alignment: .leading) {
                                 Text(notice.subject)
-                                
+
                                 HStack {
                                     Text(notice.postedDate)
-                                    
+
                                     Spacer()
                                 }
                             }
@@ -175,10 +179,9 @@ public struct SearchView: View {
                     beforePhaseView
                 }
             }
-            
         }
         .padding(.horizontal, 20)
-        .bind($store.focus, to: self.$focus)
+        .bind($store.focus, to: $focus)
         .sheet(
             item: $store.scope(
                 state: \.staffDetail,
@@ -189,7 +192,7 @@ public struct SearchView: View {
                 .presentationDetents([.medium])
         }
     }
-    
+
     @ViewBuilder
     private func SegmentView(_ title: String, isSelect: Bool) -> some View {
         RoundedRectangle(cornerRadius: 10)
@@ -203,12 +206,12 @@ public struct SearchView: View {
                     .font(.system(size: 16, weight: isSelect ? .bold : .medium))
                     .foregroundStyle(
                         isSelect
-                        ? Color.accentColor
-                        : Color.caption1.opacity(0.6)
+                            ? Color.accentColor
+                            : Color.caption1.opacity(0.6)
                     )
             }
     }
-    
+
     @ViewBuilder
     private var beforePhaseView: some View {
         VStack {
@@ -217,12 +220,12 @@ public struct SearchView: View {
             }
             .foregroundColor(Color(red: 0.56, green: 0.56, blue: 0.56))
             .font(.system(size: 16))
-            
+
             Spacer()
         }
         .padding(.top, 72)
     }
-    
+
     public init(store: StoreOf<SearchFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/SearchUI/StaffRow.swift
+++ b/KuringPackage/Sources/UIKit/SearchUI/StaffRow.swift
@@ -1,16 +1,21 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Models
 import SwiftUI
 
 struct StaffRow: View {
     let staff: Staff
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(staff.name)
                 .font(.subheadline)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
-            
+
             Text("\(staff.deptName) · \(staff.collegeName)")
                 .font(.caption)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/KuringPackage/Sources/UIKit/SettingsUI/AppIconSelector.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/AppIconSelector.swift
@@ -1,10 +1,15 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import SettingsFeatures
 import ComposableArchitecture
 
 public struct AppIconSelector: View {
     @Bindable var store: StoreOf<AppIconSelectorFeature>
-    
+
     public var body: some View {
         List(store.appIcons) { icon in
             HStack {
@@ -16,17 +21,17 @@ public struct AppIconSelector: View {
                         .shadow(radius: 0.5)
                 }
                 .padding(.trailing)
-                
+
                 Button {
                     store.send(.appIconSelected(icon))
                 } label: {
                     Text(icon.korValue)
                         .foregroundStyle(.black)
                 }
-                
+
                 if icon == store.state.selectedIcon {
                     Spacer()
-                    
+
                     Image(systemName: "checkmark.circle.fill")
                         .font(.title3)
                         .foregroundStyle(.tint)
@@ -44,7 +49,7 @@ public struct AppIconSelector: View {
             }
         }
     }
-    
+
     public init(store: StoreOf<AppIconSelectorFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/SettingsUI/Bundle.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/Bundle.swift
@@ -1,5 +1,10 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
-public extension Bundle {
-    static var settings: Bundle { .module }
+extension Bundle {
+    public static var settings: Bundle { .module }
 }

--- a/KuringPackage/Sources/UIKit/SettingsUI/FeedbackView.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/FeedbackView.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import ColorSet
 import SettingsFeatures
@@ -6,7 +11,7 @@ import ComposableArchitecture
 public struct FeedbackView: View {
     @Bindable var store: StoreOf<FeedbackFeature>
     @FocusState private var isFocused: Bool
-    
+
     public var body: some View {
         VStack(spacing: 0) {
             if !store.isTopHidden {
@@ -15,18 +20,18 @@ public struct FeedbackView: View {
                     .frame(width: 120, height: 120)
                     .clipped()
                     .padding(.top, 56)
-                
+
                 Text("피드백을 보내주시면\n앱 성장에 많은 도움이 됩니다.😇")
                     .lineLimit(2)
                     .multilineTextAlignment(.center)
             }
-            
+
             VStack {
                 TextEditor(text: $store.text)
                     .foregroundStyle(
                         store.text == store.placeholder
-                        ? Color.caption1.opacity(0.6)
-                        : .primary
+                            ? Color.caption1.opacity(0.6)
+                            : .primary
                     )
                     .focused($isFocused)
                     .padding(20)
@@ -35,21 +40,21 @@ public struct FeedbackView: View {
                         RoundedRectangle(cornerRadius: 8)
                             .stroke(
                                 store.text == store.placeholder
-                                ? Color.caption1.opacity(0.6)
-                                : Color.accentColor,
+                                    ? Color.caption1.opacity(0.6)
+                                    : Color.accentColor,
                                 lineWidth: 1
                             )
                             .foregroundColor(.clear)
                     )
-                
+
                 HStack {
                     Spacer()
-                    
+
                     Text(store.guideline)
                         .foregroundStyle(
                             store.isSendable
-                            ? Color.accentColor
-                            : Color.red // TODO: error color 적용
+                                ? Color.accentColor
+                                : Color.red // TODO: error color 적용
                         )
                         .padding(.trailing, 8)
                 }
@@ -57,11 +62,11 @@ public struct FeedbackView: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
             .padding(.top, store.isTopHidden ? 32 : 27)
-            
+
             if !store.isTopHidden {
                 Spacer()
             }
-            
+
             Button {
                 guard store.isSendable else { return }
                 store.send(.sendFeedback)
@@ -69,44 +74,44 @@ public struct FeedbackView: View {
                 topBlurButton(
                     "피드백 보내기",
                     fontColor: store.isSendable
-                    ? .white
-                    : Color.accentColor.opacity(0.4),
+                        ? .white
+                        : Color.accentColor.opacity(0.4),
                     backgroundColor: store.isSendable
-                    ? Color.accentColor
-                    : Color.accentColor.opacity(0.15)
+                        ? Color.accentColor
+                        : Color.accentColor.opacity(0.15)
                 )
             }
             .allowsHitTesting(store.isSendable)
             .padding(.horizontal, 20)
             .padding(.bottom)
             .padding(.top, 24)
-            
+
             if store.isTopHidden {
                 Spacer()
             }
         }
         .bind($store.isFocused, to: $isFocused)
-        .onChange(of: isFocused) { oldValue, newValue in
+        .onChange(of: isFocused) { _, newValue in
             withAnimation {
                 store.isTopHidden = newValue
             }
         }
     }
-    
+
     public init(store: StoreOf<FeedbackFeature>) {
         self.store = store
     }
-    
+
     // TODO: 디자인 시스템 분리 - 상단에 블러가 존재하는 버튼
     @ViewBuilder
     private func topBlurButton(_ title: String, fontColor: Color, backgroundColor: Color) -> some View {
         HStack(alignment: .center, spacing: 10) {
             Spacer()
-            
+
             Text(title)
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(fontColor)
-            
+
             Spacer()
         }
         .padding(.horizontal, 50)
@@ -129,4 +134,3 @@ public struct FeedbackView: View {
         .navigationTitle("피드백 보내기")
     }
 }
-

--- a/KuringPackage/Sources/UIKit/SettingsUI/InformationWebView.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/InformationWebView.swift
@@ -1,14 +1,19 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import SettingsFeatures
 import ComposableArchitecture
 
 public struct InformationWebView: View {
     @Bindable public var store: StoreOf<InformationWebFeature>
-    
+
     public var body: some View {
         WebView(urlToLoad: store.url ?? URLLink.team.rawValue)
     }
-    
+
     public init(store: StoreOf<InformationWebFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/SettingsUI/OpenSourceList.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/OpenSourceList.swift
@@ -1,10 +1,15 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import SettingsFeatures
 import ComposableArchitecture
 
 public struct OpenSourceList: View {
     @Bindable public var store: StoreOf<OpenSourceListFeature>
-    
+
     public var body: some View {
         List(store.opensources) { opensource in
             VStack(alignment: .leading) {
@@ -12,7 +17,7 @@ public struct OpenSourceList: View {
                     .font(.title3)
                     .fontWeight(.bold)
                     .padding(.bottom)
-                
+
                 Button {
                     store.send(.linkTapped(opensource.link))
                 } label: {
@@ -22,7 +27,7 @@ public struct OpenSourceList: View {
             }
         }
     }
-    
+
     public init(store: StoreOf<OpenSourceListFeature>) {
         self.store = store
     }
@@ -36,4 +41,3 @@ public struct OpenSourceList: View {
         )
     )
 }
-

--- a/KuringPackage/Sources/UIKit/SettingsUI/SettingList.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/SettingList.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Caches
 import SwiftUI
 import SettingsFeatures
@@ -6,7 +11,7 @@ import ComposableArchitecture
 public struct SettingList: View {
     @Bindable public var store: StoreOf<SettingListFeature>
     @Dependency(\.leLabo) var leLabo
-    
+
     public var body: some View {
         List {
             Section {
@@ -15,12 +20,12 @@ public struct SettingList: View {
                 } label: {
                     Label("공지 구독하기", systemImage: "bell")
                 }
-                
+
                 HStack {
                     Label("기타 알림 받기", systemImage: "bell")
-                    
+
                     Spacer()
-                    
+
                     Toggle("", isOn: $store.isCustomAlarmOn)
                         .labelsHidden()
                         .tint(Color.accentColor)
@@ -29,34 +34,34 @@ public struct SettingList: View {
                 Text("공지구독")
             }
             .tint(.black)
-            
+
             Section {
                 HStack {
                     Text("앱 버전")
-                    
+
                     Spacer()
-                    
+
                     Text("2.0.0")
                 }
-                
+
                 Button {
                     store.send(.delegate(.showTeam))
                 } label: {
                     Text("쿠링 팀")
                 }
-                
+
                 Button {
                     store.send(.delegate(.showPrivacyPolicy))
                 } label: {
                     Text("개인정보 처리방침")
                 }
-                
+
                 Button {
                     store.send(.delegate(.showTermsOfService))
                 } label: {
                     Text("서비스 이용약관")
                 }
-                
+
                 NavigationLink(
                     state: SettingsAppFeature.Path.State.openSourceList(
                         OpenSourceListFeature.State()
@@ -70,14 +75,14 @@ public struct SettingList: View {
                 Text("Designed by 이소영, 김예은.\nDeveloped by 이재성, 이건우, 박성수.\nManaged by 조병관, 채수빈")
             }
             .tint(.black)
-            
+
             Section {
                 Button {
                     store.send(.delegate(.showLabs))
                 } label: {
                     Label("쿠링 실험실", systemImage: "flask")
                 }
-                
+
                 NavigationLink(
                     state: SettingsAppFeature.Path.State.appIconSelector(
                         AppIconSelectorFeature.State()
@@ -85,35 +90,35 @@ public struct SettingList: View {
                 ) {
                     HStack {
                         Text("앱 아이콘 바꾸기")
-                        
+
                         Spacer()
-                        
+
                         Text(store.state.currentAppIcon?.korValue ?? KuringIcon.kuring_app.korValue)
                     }
                 }
             } header: {
                 Text("쿠링 실험실")
             }
-            
+
             Section {
                 Button {
                     store.send(.delegate(.showInstagram))
                 } label: {
                     Text("인스타그램")
                 }
-                
+
             } header: {
                 Text("SNS")
             }
             .tint(.black)
-            
+
             Section {
                 Button {
                     store.send(.delegate(.showFeedback))
                 } label: {
                     Label("피드백 보내기", systemImage: "bell")
                 }
-                
+
             } header: {
                 Text("피드백")
             }
@@ -122,7 +127,7 @@ public struct SettingList: View {
         .navigationTitle("더보기")
         .navigationBarTitleDisplayMode(.inline)
     }
-    
+
     public init(store: StoreOf<SettingListFeature>) {
         self.store = store
     }
@@ -130,7 +135,7 @@ public struct SettingList: View {
 
 #Preview {
     NavigationStack {
-        SettingList (
+        SettingList(
             store: Store(
                 initialState: SettingListFeature.State(),
                 reducer: { SettingListFeature() }

--- a/KuringPackage/Sources/UIKit/SettingsUI/SettingsApp.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/SettingsApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Labs
 import SwiftUI
 import SubscriptionUI
@@ -6,7 +11,7 @@ import ComposableArchitecture
 
 public struct SettingsApp: View {
     @Bindable var store: StoreOf<SettingsAppFeature>
-    
+
     public var body: some View {
         NavigationStack(
             path: $store.scope(state: \.path, action: \.path)
@@ -74,7 +79,7 @@ public struct SettingsApp: View {
             InformationWebView(store: store)
         }
     }
-    
+
     public init(store: StoreOf<SettingsAppFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/SettingsUI/WebView.swift
+++ b/KuringPackage/Sources/UIKit/SettingsUI/WebView.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import UIKit
 import WebKit
 import SwiftUI
@@ -5,20 +10,18 @@ import SwiftUI
 // TODO: Common UIKit
 public struct WebView: UIViewRepresentable {
     public var urlToLoad: String
-    
+
     public func makeUIView(context: Context) -> WKWebView {
-        guard let url = URL(string: self.urlToLoad) else {
+        guard let url = URL(string: urlToLoad) else {
             return WKWebView()
         }
         let webView = WKWebView()
         webView.load(URLRequest(url: url))
         return webView
     }
-    
-    public func updateUIView(_ uiView: WKWebView, context: UIViewRepresentableContext<WebView>) {
-        
-    }
-    
+
+    public func updateUIView(_ uiView: WKWebView, context: UIViewRepresentableContext<WebView>) { }
+
     public init(urlToLoad: String) {
         self.urlToLoad = urlToLoad
     }

--- a/KuringPackage/Sources/UIKit/SubscriptionUI/Bundle.swift
+++ b/KuringPackage/Sources/UIKit/SubscriptionUI/Bundle.swift
@@ -1,5 +1,10 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import Foundation
 
-public extension Bundle {
-    static var subscriptions: Bundle { .module }
+extension Bundle {
+    public static var subscriptions: Bundle { .module }
 }

--- a/KuringPackage/Sources/UIKit/SubscriptionUI/SubscriptionApp.swift
+++ b/KuringPackage/Sources/UIKit/SubscriptionUI/SubscriptionApp.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import DepartmentUI
 import SubscriptionFeatures
@@ -5,7 +10,7 @@ import ComposableArchitecture
 
 public struct SubscriptionApp: View {
     @Bindable var store: StoreOf<SubscriptionAppFeature>
-    
+
     public var body: some View {
         NavigationStack(
             path: $store.scope(state: \.path, action: \.path)
@@ -29,7 +34,7 @@ public struct SubscriptionApp: View {
             }
         }
     }
-    
+
     public init(store: StoreOf<SubscriptionAppFeature>) {
         self.store = store
     }

--- a/KuringPackage/Sources/UIKit/SubscriptionUI/SubscriptionSegment.swift
+++ b/KuringPackage/Sources/UIKit/SubscriptionUI/SubscriptionSegment.swift
@@ -1,17 +1,22 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 
 struct SubscriptionSegment: View {
     let title: String
     let isSelected: Bool
-    
+
     var body: some View {
         VStack {
             Text(title)
                 .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(
                     isSelected
-                    ? Color.accentColor
-                    : Color.black.opacity(0.3)
+                        ? Color.accentColor
+                        : Color.black.opacity(0.3)
                 )
 
             Rectangle()

--- a/KuringPackage/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
+++ b/KuringPackage/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import SwiftUI
 import DepartmentFeatures
 import SubscriptionFeatures
@@ -5,7 +10,7 @@ import ComposableArchitecture
 
 struct SubscriptionView: View {
     @Bindable var store: StoreOf<SubscriptionFeature>
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
@@ -15,7 +20,7 @@ struct SubscriptionView: View {
             }
             .padding(.top, 32)
             .padding(.bottom, 60)
-            
+
             // TODO: 디자인 시스템 분리 - 칩 (Search 랑 합쳐서 KuringPicker) 같은거 있으면 좋을 것 같아요.
             /// 일반 / 학과 카테고리 세그먼트
             LazyVGrid(columns: Array(repeating: .init(.flexible()), count: 2)) {
@@ -27,7 +32,7 @@ struct SubscriptionView: View {
                         isSelected: store.subscriptionType == .university
                     )
                 }
-                
+
                 Button {
                     store.send(.segmentSelected(.department))
                 } label: {
@@ -38,7 +43,7 @@ struct SubscriptionView: View {
                 }
             }
             .padding(.bottom, 33)
-            
+
             // TODO: TCA 하위 도메인으로 분리 + 뷰 분리
             /// 카테고리 목록
             switch store.subscriptionType {
@@ -48,7 +53,7 @@ struct SubscriptionView: View {
                     LazyVGrid(columns: Array(repeating: .init(.flexible()), count: 3)) {
                         ForEach(store.univNoticeTypes) { univNoticeType in
                             let isSelected = store.selectedUnivNoticeType.contains(univNoticeType)
-                            
+
                             ZStack {
                                 RoundedRectangle(cornerRadius: 8)
                                     .inset(by: 1)
@@ -58,19 +63,19 @@ struct SubscriptionView: View {
                                     )
                                     .fill(
                                         isSelected
-                                        ? Color.accentColor.opacity(0.1)
-                                        : Color.black.opacity(0.03)
+                                            ? Color.accentColor.opacity(0.1)
+                                            : Color.black.opacity(0.03)
                                     )
-                                
+
                                 VStack {
                                     Image(univNoticeType.name, bundle: Bundle.subscriptions)
-                                    
+
                                     Text(univNoticeType.korName)
                                         .font(.system(size: 16, weight: .semibold))
                                         .foregroundStyle(
                                             isSelected
-                                            ? Color.accentColor
-                                            : Color(red: 0.32, green: 0.32, blue: 0.32)
+                                                ? Color.accentColor
+                                                : Color(red: 0.32, green: 0.32, blue: 0.32)
                                         )
                                 }
                                 .padding()
@@ -78,29 +83,28 @@ struct SubscriptionView: View {
                             .onTapGesture {
                                 store.send(.univNoticeTypeSelected(univNoticeType))
                             }
-                            
                         }
                     }
                     Spacer()
                 }
-                
+
             case .department:
                 /// 빈 페이지 (내 학과 목록이 없을 때)
                 if store.myDepartments.isEmpty {
                     VStack(alignment: .center) {
                         Spacer()
-                        
+
                         HStack {
                             Spacer()
-                            
+
                             Text("아직 추가된 학과가 없어요.\n관심 학과를 추가하고 공지를 확인해 보세요!")
                                 .font(.system(size: 16, weight: .medium))
                                 .multilineTextAlignment(.center)
                                 .foregroundStyle(Color(red: 0.68, green: 0.69, blue: 0.71))
-                            
+
                             Spacer()
                         }
-                        
+
                         Spacer()
                     }
                 } else {
@@ -109,15 +113,15 @@ struct SubscriptionView: View {
                         ScrollView(showsIndicators: false) {
                             ForEach(store.myDepartments) { department in
                                 let isSelected = store.selectedDepartment.contains(department)
-                                
+
                                 VStack(spacing: 0) {
                                     HStack {
                                         Text(department.korName)
                                             .font(.system(size: 16, weight: .semibold))
                                             .foregroundStyle(.black)
-                                        
+
                                         Spacer()
-                                        
+
                                         Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                                             .foregroundStyle(isSelected ? Color.accentColor : Color.black.opacity(0.1))
                                             .frame(width: 20, height: 20)
@@ -129,7 +133,7 @@ struct SubscriptionView: View {
                                     .onTapGesture {
                                         store.send(.departmentSelected(department))
                                     }
-                                    
+
                                     // 밑줄
                                     if store.myDepartments.last != department {
                                         Rectangle()
@@ -147,7 +151,7 @@ struct SubscriptionView: View {
                         }
                     }
                 }
-                
+
                 // TODO: 디자인 시스템 분리 - 상단에 블러가 존재하는 버튼
                 /// 학과 추가/편집하기 버튼 - `DepartmentEditor` 로 이동
                 NavigationLink(
@@ -160,11 +164,11 @@ struct SubscriptionView: View {
                 ) {
                     HStack(alignment: .center, spacing: 10) {
                         Spacer()
-                        
+
                         Text(store.myDepartments.isEmpty ? "학과 추가하기" : "학과 편집하기")
                             .font(.system(size: 16, weight: .semibold))
                             .foregroundStyle(Color.white)
-                        
+
                         Spacer()
                     }
                     .padding(.horizontal, 50)
@@ -181,8 +185,6 @@ struct SubscriptionView: View {
                     }
                 }
             }
-            
-            
         }
         .padding(.horizontal, 20)
         // TODO: TCA에 따라 외부에서 구현

--- a/KuringPackage/Tests/BookmarkFeaturesTests/BookmarkListTests.swift
+++ b/KuringPackage/Tests/BookmarkFeaturesTests/BookmarkListTests.swift
@@ -1,8 +1,13 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import XCTest
-import ComposableArchitecture
 @testable import Caches
 @testable import Models
 @testable import BookmarkFeatures
+import ComposableArchitecture
 
 @MainActor
 final class BookmarkListTests: XCTestCase {
@@ -10,7 +15,7 @@ final class BookmarkListTests: XCTestCase {
         try Bookmarks.default.remove(Notice.random.id)
         try Bookmarks.default.add(Notice.random)
     }
-    
+
     /// 북마크 리스트 가져오기
     func test_onAppear() async throws {
         let store = TestStore(
@@ -21,12 +26,12 @@ final class BookmarkListTests: XCTestCase {
             }
         )
         let notice = Notice.random
-        
+
         await store.send(.onAppear) {
             $0.bookmarkedNotices = IdentifiedArray(uniqueElements: [notice])
         }
     }
-    
+
     /// 편집 버튼 누르기
     func test_editButtonTapped() async throws {
         let store = TestStore(
@@ -36,12 +41,12 @@ final class BookmarkListTests: XCTestCase {
                 $0.bookmarks = Bookmarks.default
             }
         )
-        
+
         await store.send(.editButtonTapped) {
             $0.editMode = .editing(deletable: false)
         }
     }
-    
+
     /// 편집 버튼 누르고 선택
     /// 삭제 가능 상태인지 체크
     func test_editButtonTappedAndSelectedIDsUpdated() async throws {
@@ -52,19 +57,19 @@ final class BookmarkListTests: XCTestCase {
                 $0.bookmarks = Bookmarks.default
             }
         )
-        
+
         store.exhaustivity = .off(showSkippedAssertions: true)
-        
+
         await store.send(.editButtonTapped) {
             $0.editMode = .editing(deletable: false)
         }
-        
+
         await store.send(.set(\.selectedIDs, [Notice.random.id])) {
             $0.selectedIDs = [Notice.random.id]
             $0.editMode = .editing(deletable: true)
         }
     }
-    
+
     /// 삭제 요청
     /// 편집모드 업데이트 되는지 확인
     func test_editButtonTappedAndDeleteButtonTapped() async throws {
@@ -75,18 +80,18 @@ final class BookmarkListTests: XCTestCase {
                 $0.bookmarks = Bookmarks.default
             }
         )
-        
+
         store.exhaustivity = .off
-        
+
         await store.send(.editButtonTapped) {
             $0.editMode = .editing(deletable: false)
         }
-        
+
         await store.send(.set(\.selectedIDs, [Notice.random.id])) {
             $0.selectedIDs = [Notice.random.id]
             $0.editMode = .editing(deletable: true)
         }
-        
+
         await store.send(.deleteButtonTapped) {
             $0.bookmarkedNotices = []
             $0.editMode = .none

--- a/KuringPackage/Tests/LabsTests/LabAppTests.swift
+++ b/KuringPackage/Tests/LabsTests/LabAppTests.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import XCTest
 import ComposableArchitecture
 @testable import Labs
@@ -14,18 +19,18 @@ final class LabAppTests: XCTestCase {
         let betaAStateForPath = LabAppFeature.Path.State.betaA(
             BetaADetailFeature.State()
         )
-        
+
         /// 스택 네비게이션 동작
         await store.send(.path(.push(id: 0, state: betaAStateForPath))) {
             $0.path[id: 0] = betaAStateForPath
             $0.path[id: 0, case: \.betaA]?.isEnabled = false
         }
-        
+
         /// 베타A 기능 활성화
         await store.send(.path(.element(id: 0, action: .betaA(.binding(.set(\.isEnabled, true)))))) {
             $0.path[id: 0, case: \.betaA]?.isEnabled = true
         }
-        
+
         /// 디펜던시에 값이 업데이트 되었는지 확인
         withDependencies {
             $0.leLabo = leLabo

--- a/KuringPackage/Tests/NoticeFeaturesTests/NoticeAppTests.swift
+++ b/KuringPackage/Tests/NoticeFeaturesTests/NoticeAppTests.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import XCTest
 import ComposableArchitecture
 @testable import NoticeFeatures
@@ -13,7 +18,7 @@ final class NoticeAppTests: XCTestCase {
             ),
             reducer: { NoticeAppFeature() }
         )
-        
+
         // 푸시 액션: 검색 버튼 눌렀을 때
         await store.send(
             .path(

--- a/KuringPackage/Tests/NoticeFeaturesTests/NoticeDetailTests.swift
+++ b/KuringPackage/Tests/NoticeFeaturesTests/NoticeDetailTests.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import XCTest
 import Models
 import Caches
@@ -17,8 +22,7 @@ final class NoticeDetailTests: XCTestCase {
         await store.send(.bookmarkButtonTapped) {
             $0.isBookmarked = !isNoticeBookmarked
         }
-        
+
         await store.receive(.delegate(.bookmarkUpdated(!isNoticeBookmarked)))
     }
-
 }

--- a/KuringPackage/Tests/SubscriptionFeaturesTests/SubscriptionAppTests.swift
+++ b/KuringPackage/Tests/SubscriptionFeaturesTests/SubscriptionAppTests.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import XCTest
 import ComposableArchitecture
 @testable import Models
@@ -19,7 +24,7 @@ class SubscriptionAppTests: XCTestCase {
             korName: "체육교육과",
             category: .학과
         )
-        
+
         let store = TestStore(
             initialState: SubscriptionAppFeature.State(
                 root: SubscriptionFeature.State(myDepartments: [컴퓨터공학부])
@@ -33,7 +38,7 @@ class SubscriptionAppTests: XCTestCase {
         await store.send(.path(.push(id: 0, state: departmentEditorState))) {
             $0.path[id: 0] = departmentEditorState
         }
-        
+
         await store.send(
             .path(
                 .element(
@@ -48,13 +53,13 @@ class SubscriptionAppTests: XCTestCase {
                 ButtonState(role: .cancel) {
                     TextState("취소하기")
                 }
-                
+
                 ButtonState(role: .destructive, action: .confirmDelete(id: 컴퓨터공학부.id)) {
                     TextState("삭제하기")
                 }
             }
         }
-        
+
         await store.send(
             .path(
                 .element(
@@ -66,7 +71,7 @@ class SubscriptionAppTests: XCTestCase {
             $0.path[id: 0, case: /SubscriptionAppFeature.Path.State.departmentEditor]?.alert = nil
             $0.path[id: 0, case: /SubscriptionAppFeature.Path.State.departmentEditor]?.myDepartments = []
         }
-        
+
         await store.send(
             .path(
                 .element(

--- a/KuringPackage/Tests/SubscriptionFeaturesTests/SubscriptionTests.swift
+++ b/KuringPackage/Tests/SubscriptionFeaturesTests/SubscriptionTests.swift
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
 import XCTest
 import ComposableArchitecture
 @testable import Models
@@ -7,7 +12,7 @@ import ComposableArchitecture
 @MainActor
 class SubscriptionTests: XCTestCase {
     func test_tapConfirmButton() async throws {
-        let dismissed = self.expectation(description: "dismissed")
+        let dismissed = expectation(description: "dismissed")
 
         let store = TestStore(
             initialState: SubscriptionFeature.State(),
@@ -19,14 +24,14 @@ class SubscriptionTests: XCTestCase {
         await store.send(.confirmButtonTapped) {
             $0.isWaitingResponse = true
         }
-        
+
         await store.receive(.subscriptionResponse(true)) {
             $0.isWaitingResponse = false
         }
-        
-        await self.fulfillment(of: [dismissed])
+
+        await fulfillment(of: [dismissed])
     }
-    
+
     func test_selectSegment() async throws {
         let store = TestStore(
             initialState: SubscriptionFeature.State(),
@@ -34,18 +39,18 @@ class SubscriptionTests: XCTestCase {
         )
         let university = SubscriptionFeature.State.SubscriptionType.university
         let department = SubscriptionFeature.State.SubscriptionType.department
-        
+
         XCTAssertEqual(store.state.subscriptionType, .university)
-        
+
         await store.send(.segmentSelected(department)) {
             $0.subscriptionType = .department
         }
-        
+
         await store.send(.segmentSelected(university)) {
             $0.subscriptionType = .university
         }
     }
-    
+
     func test_selectDepartment() async throws {
         let department = NoticeProvider(
             name: "computer_science",
@@ -57,7 +62,7 @@ class SubscriptionTests: XCTestCase {
             initialState: SubscriptionFeature.State(myDepartments: [department]),
             reducer: { SubscriptionFeature() }
         )
-        
+
         // 학과 선택
         await store.send(.departmentSelected(department)) {
             $0.selectedDepartment = [department]


### PR DESCRIPTION
# SwiftFormat

https://github.com/nicklockwood/SwiftFormat

`.github/scripts` 경로에 있는 `Format.sh` 파일을 실행시키면 [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) 플러그인을 사용하여 코드 정리 및 저작권 명시를 위한 헤더 커멘트를 추가해줍니다.

```bash
cd .github/scripts.    # 스크립트 경로 이동
chmod +x Format.sh     # 작성권한 제공
./Format.sh            # 쉘 스크립트 실행
```

## SwiftFormat 적용 규칙
`KuringPackage/.swiftformat` 파일 참고

### 헤더
```swift
//
// Copyright (c) 2024 쿠링
// See the 'License.txt' file for licensing information.
//
```

### 규칙
```yml
--self init-only  # 생성자에서만 self 사용 허용
--semicolons never  # 세미콜론 금지
--extensionacl on-declarations # 확장자에 액세스 컨트롤 금지, 프로퍼티에만 액세스 컨트롤 할 것
--importgrouping length # import 할 때 길이순으로 정렬

--xcodeindentation enabled # Xcode 의 Indent 설정 따르기

--guardelse same-line # guard else 키워드는 같은 라인에
--stripunusedargs closure-only # 언더스코어(_)는 클로져의 arg 에만 적용
--emptybraces spaced # 구현부가 비어있는 경우 `{ }` 로 띄어쓰기 있는 한 줄 brace 형태로 처리
--wrapternary before-operators # 한 줄 길이 초과시 오퍼레이터 앞에서 엔터

--disable redundantRawValues # case와 동일한 raw 값 명시 허용
--disable redundantFileprivate # fileprivate 허용
--disable redundantClosure # `{ }()` 형태의 선언방식 허용
```