### PR TITLE
[2.0.0] 피드백 글자수 max 제한 미적용

### DIFF
--- a/package-kuring/Sources/Features/SettingsFeatures/Feedback.swift
+++ b/package-kuring/Sources/Features/SettingsFeatures/Feedback.swift
@@ -29,15 +29,16 @@ public struct FeedbackFeature {
 
         /// TextEditor 하단에 보여질 안내문구
         public var guideline: String {
-            isSendable
-                ? "글자수: \(text.count)/\(maxLimit)"
-                : "\(minLimit)글자 이상 입력 해주세요"
+            text.count >= 4
+            ? "글자수: \(text.count)/\(maxLimit)"
+            : "\(minLimit)글자 이상 입력 해주세요"
         }
 
         /// `text` 가 `placeholder` 가 아니고, 글자수가 `minLimit` 이상일 때
         public var isSendable: Bool {
             text != placeholder
                 && text.count >= minLimit
+                && text.count <= maxLimit
         }
 
         public init(text: String = "") {

--- a/package-kuring/Sources/Features/SettingsFeatures/Feedback.swift
+++ b/package-kuring/Sources/Features/SettingsFeatures/Feedback.swift
@@ -29,7 +29,7 @@ public struct FeedbackFeature {
 
         /// TextEditor 하단에 보여질 안내문구
         public var guideline: String {
-            text.count >= 4
+            text.count >= minLimit
             ? "글자수: \(text.count)/\(maxLimit)"
             : "\(minLimit)글자 이상 입력 해주세요"
         }


### PR DESCRIPTION
### 피드백 글자수 max 제한 UI

 - 기존로직의 변경을 최소화하는 방향으로 수정하였습니다.
 - 글자 수 초과시 sendable하지 않고, 글자수를 red로 변경
 - 4 <= textCount <= 256  
    - 블루컬러 및 전송 가능
 - 4 > textCount인 경우
    - 4자 이상 전송 가능하단 문구 & 레드컬러
 - 256 < textCount인 경우
    - {현재 글자수} / 256 & 레드컬러

 - 레드컬러는 버튼 비활성화 상태
 
<p align="center">
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/f5ae4aec-8a2e-4266-bf03-5925f0f20fb0" width="30%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/078cf000-c999-416c-9b00-b8d5c4131891" width="30%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/89ab5fd3-bf5a-4528-be7f-0c25905b22d3" width="30%"/>
</p>

<p align="center">
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/3fa9e92b-a432-4400-9291-69f152dd345c" width="30%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/2b359d78-9c1c-4832-8cbc-f6b4ac629056" width="30%"/>
</p>


