### PR TITLE
[2.0.0] TCA 버전 1.7 로 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | ---- | ---- | ------ | ----- |
 | The Satellite | https://github.com/ku-ring/the-satellite | main | iOS API 통신모듈  |
 | Swift Collections | https://github.com/apple/swift-collections | main | OrderedSet |  
-| Composable Architecture | https://github.com/pointfreeco/swift-composable-architecture | observation-beta | TCA 구조를 위한 스위프트 패키지 |
+| Composable Architecture | https://github.com/pointfreeco/swift-composable-architecture | main | TCA 구조를 위한 스위프트 패키지 |
 | SwiftFormat | https://github.com/nicklockwood/SwiftFormat | 0.50.4 | 코드 스타일 관리 |
 
 ## 기여

--- a/package-kuring/Package.resolved
+++ b/package-kuring/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "branch" : "observation-beta",
-        "revision" : "abd8e3a7dba9512c0d1bea21766b8a91eb5758a9"
+        "branch" : "main",
+        "revision" : "94faadf363dc5074b5b6f30b9dc1631d01d68418"
       }
     },
     {
@@ -88,6 +88,15 @@
       "state" : {
         "revision" : "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "42240120b2a8797595433288ab4118f8042214c3",
+        "version" : "1.1.1"
       }
     },
     {
@@ -131,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
-        "version" : "1.0.2"
+        "revision" : "b58e6627149808b40634c4552fcf2f44d0b3ca87",
+        "version" : "1.1.0"
       }
     }
   ],

--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", branch: "observation-beta"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", branch: "main"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.1.5"),
         .package(url: "https://github.com/ku-ring/the-satellite", branch: "main"),
         .package(url: "https://github.com/ku-ring/ios-maps", branch: "main"),


### PR DESCRIPTION
`observation-beta` 브랜치가 `main` 브랜치로 머지 되고 **1.7** 버전이 배포됨에 따라
패키지 디펜던시의 브랜치를 `main` 으로 수정합니다.