### PR TITLE
[2.0.0] 공지 리스트와 디테일 간의 북마크 싱크 안 맞는 이슈 해결

### DIFF
--- a/package-kuring/Sources/Features/DepartmentFeatures/DepartmentSelector.swift
+++ b/package-kuring/Sources/Features/DepartmentFeatures/DepartmentSelector.swift
@@ -26,7 +26,7 @@ public struct DepartmentSelectorFeature {
         case editDepartmentsButtonTapped
         case delegate(Delegate)
 
-        public enum Delegate {
+        public enum Delegate: Equatable {
             case editDepartment
         }
     }

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.Path.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.Path.swift
@@ -18,7 +18,7 @@ extension NoticeAppFeature {
             case departmentEditor(DepartmentEditorFeature.State)
         }
 
-        public enum Action {
+        public enum Action: Equatable {
             case detail(NoticeDetailFeature.Action)
             case search(SearchFeature.Action)
             case departmentEditor(DepartmentEditorFeature.Action)

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -62,23 +62,22 @@ public struct NoticeAppFeature {
 
         Reduce { state, action in
             switch action {
-            case let .path(.element(id: id, action: .detail(.bookmarkButtonTapped))):
-                guard case let .detail(detailState) = state.path[id: id] else {
+            case let .path(.element(id: _, action: .detail(.delegate(action)))):
+                switch action {
+                case let .bookmarkUpdated(notice, isBookmarked):
+                    do {
+                        if isBookmarked {
+                            state.noticeList.bookmarkIDs.remove(notice.id)
+                            try bookmarks.remove(notice.id)
+                        } else {
+                            state.noticeList.bookmarkIDs.insert(notice.id)
+                            try bookmarks.add(notice)
+                        }
+                    } catch {
+                        print("북마크 업데이트에 실패했습니다: \(error.localizedDescription)")
+                    }
                     return .none
                 }
-                let noticeID = detailState.notice.id
-                do {
-                    if detailState.isBookmarked {
-                        state.noticeList.bookmarkIDs.insert(noticeID)
-                        try bookmarks.add(detailState.notice)
-                    } else {
-                        state.noticeList.bookmarkIDs.remove(noticeID)
-                        try bookmarks.remove(noticeID)
-                    }
-                } catch {
-                    print("북마크 업데이트에 실패했습니다: \(error.localizedDescription)")
-                }
-                return .none
 
             case let .noticeList(.delegate(delegate)):
                 switch delegate {

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -39,7 +39,7 @@ public struct NoticeAppFeature {
         }
     }
 
-    public enum Action {
+    public enum Action: Equatable {
         /// 루트(``NoticeListFeature``) 액션
         case noticeList(NoticeListFeature.Action)
 
@@ -67,11 +67,12 @@ public struct NoticeAppFeature {
                 case let .bookmarkUpdated(notice, isBookmarked):
                     do {
                         if isBookmarked {
-                            state.noticeList.bookmarkIDs.remove(notice.id)
-                            try bookmarks.remove(notice.id)
-                        } else {
+                            
                             state.noticeList.bookmarkIDs.insert(notice.id)
                             try bookmarks.add(notice)
+                        } else {
+                            state.noticeList.bookmarkIDs.remove(notice.id)
+                            try bookmarks.remove(notice.id)
                         }
                     } catch {
                         print("북마크 업데이트에 실패했습니다: \(error.localizedDescription)")

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
@@ -17,50 +17,20 @@ public struct NoticeDetailFeature {
 
         public init(notice: Notice, isBookmarked: Bool = false) {
             self.notice = notice
-            @Dependency(\.bookmarks) var bookmarks
-            do {
-                self.isBookmarked = try bookmarks().contains(notice)
-            } catch {
-                self.isBookmarked = false
-            }
+            self.isBookmarked = isBookmarked
         }
     }
 
     public enum Action: Equatable {
         case bookmarkButtonTapped
-
-        case delegate(Delegate)
-
-        public enum Delegate: Equatable {
-            case bookmarkUpdated(Bool)
-        }
     }
-
-    @Dependency(\.bookmarks) var bookmarks
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .bookmarkButtonTapped:
-                do {
-                    if state.isBookmarked {
-                        try bookmarks.remove(state.notice.id)
-                    } else {
-                        try bookmarks.add(state.notice)
-                    }
-                    state.isBookmarked.toggle()
-                } catch {
-                    print("북마크 업데이트에 실패했습니다: \(error.localizedDescription)")
-                }
+                state.isBookmarked.toggle()
                 return .none
-
-            case .delegate:
-                return .none
-            }
-        }
-        .onChange(of: \.isBookmarked) { _, newValue in
-            Reduce { _, _ in
-                .send(.delegate(.bookmarkUpdated(newValue)))
             }
         }
     }

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
@@ -23,17 +23,31 @@ public struct NoticeDetailFeature {
 
     public enum Action: Equatable {
         case bookmarkButtonTapped
-    }
+        
+        case delegate(Delegate)
 
+        public enum Delegate: Equatable {
+            case bookmarkUpdated(_ notice: Notice, _ isBookmarkd: Bool)
+        }
+    }
+    
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .bookmarkButtonTapped:
                 state.isBookmarked.toggle()
                 return .none
+                
+            case .delegate:
+                return .none
+            }
+        }
+        .onChange(of: \.isBookmarked) { _, newValue in
+            Reduce { state, _ in
+                return .send(.delegate(.bookmarkUpdated(state.notice, newValue)))
             }
         }
     }
-
+    
     public init() { }
 }

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
@@ -98,6 +98,8 @@ public struct NoticeListFeature {
         public enum Delegate: Equatable {
             /// 학과 편집 버튼을 선택한 경우
             case editDepartment
+            /// 북마크 업데이트 발생한 경우
+            case bookmarkUpdated(Notice)
         }
         
         public struct NoticesResult: Equatable {
@@ -206,7 +208,7 @@ public struct NoticeListFeature {
                 } else {
                     state.bookmarkIDs.insert(notice.id)
                 }
-                return .none
+                return .send(.delegate(.bookmarkUpdated(notice)))
 
             case let .loadingChanged(isLoading):
                 state.isLoading = isLoading

--- a/package-kuring/Sources/Features/SearchFeatures/Search.swift
+++ b/package-kuring/Sources/Features/SearchFeatures/Search.swift
@@ -26,7 +26,7 @@ public struct SearchFeature {
             public var searchType: SearchType = .notice
             public var searchPhase: SearchPhase = .before
 
-            public enum SearchType: String {
+            public enum SearchType: String, Equatable {
                 case notice
                 case staff
             }
@@ -74,7 +74,7 @@ public struct SearchFeature {
         }
     }
 
-    public enum Action: BindableAction {
+    public enum Action: BindableAction, Equatable {
         /// 트리 네비게이션 - ``StaffDetailFeature`` 액션
         case staffDetail(PresentationAction<StaffDetailFeature.Action>)
         /// 세그먼트에서 검색 타입 선택
@@ -94,15 +94,34 @@ public struct SearchFeature {
 
         case binding(BindingAction<State>)
 
-        public enum SearchResult {
+        public enum SearchResult: Equatable {
             case notices([Notice])
             case staffs([Staff])
         }
     }
 
-    public enum SearchError: Error {
+    public enum SearchError: Error, Equatable {
         case notice(Error)
         case staff(Error)
+        
+        public static func == (lhs: SearchFeature.SearchError, rhs: SearchFeature.SearchError) -> Bool {
+            switch lhs {
+            case let .notice(lError):
+                switch rhs {
+                case let .notice(rError):
+                    return lError.localizedDescription == rError.localizedDescription
+                default:
+                    return false
+                }
+            case let .staff(lError):
+                switch rhs {
+                case let .staff(rError):
+                    return lError.localizedDescription == rError.localizedDescription
+                default:
+                    return false
+                }
+            }
+        }
     }
 
     @Dependency(\.kuringLink) var kuringLink

--- a/package-kuring/Sources/Features/SearchFeatures/StaffDetail.swift
+++ b/package-kuring/Sources/Features/SearchFeatures/StaffDetail.swift
@@ -17,7 +17,7 @@ public struct StaffDetailFeature {
         }
     }
 
-    public enum Action {
+    public enum Action: Equatable {
         case emailAddressTapped
         case phoneNumberTapped
     }

--- a/package-kuring/Sources/Models/NoticeProvider.swift
+++ b/package-kuring/Sources/Models/NoticeProvider.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public enum NoticeType: String, Hashable, CaseIterable, Identifiable {
+public enum NoticeType: String, Hashable, CaseIterable, Identifiable, Equatable {
     case 학과, 학사, 장학, 도서관, 취창업, 국제, 학생, 산학, 일반
 
     public var id: Self { self }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeList.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeList.swift
@@ -16,29 +16,37 @@ struct NoticeList: View {
             List(self.store.currentNotices, id: \.id) { notice in
                 NavigationLink(
                     state: NoticeAppFeature.Path.State.detail(
-                        NoticeDetailFeature.State(notice: notice)
+                        NoticeDetailFeature.State(
+                            notice: notice,
+                            isBookmarked: self.store.bookmarkIDs.contains(notice.id)
+                        )
                     )
                 ) {
-                    NoticeRow(notice: notice)
-                        .listRowInsets(EdgeInsets())
-                        .onAppear {
-                            let type = self.store.provider
-                            let noticeInfo = self.store.noticeDictionary[type]
-
-                            /// 마지막 공지가 보이면 update
-                            if noticeInfo?.notices.last == notice {
-                                self.store.send(.fetchNotices)
-                            }
+                    NoticeRow(
+                        notice: notice,
+                        bookmarked: self.store.bookmarkIDs.contains(notice.id)
+                    )
+                    .listRowInsets(EdgeInsets())
+                    .onAppear {
+                        let type = self.store.provider
+                        let noticeInfo = self.store.noticeDictionary[type]
+                        
+                        /// 마지막 공지가 보이면 update
+                        if noticeInfo?.notices.last == notice {
+                            self.store.send(.fetchNotices)
                         }
-                        .swipeActions(edge: .leading) {
-                            Button {
-                                self.store.send(.bookmarkTapped(notice))
-                            } label: {
-                                Image(systemName: "bookmark.slash")
-                                // Image(systemName: isBookmark ? "bookmark.slash" : "bookmark")
-                            }
-                            .tint(Color.accentColor)
+                    }
+                    .swipeActions(edge: .leading) {
+                        Button {
+                            self.store.send(.bookmarkTapped(notice))
+                        } label: {
+                             Image(systemName: self.store.bookmarkIDs.contains(notice.id)
+                                   ? "bookmark.slash"
+                                   : "bookmark"
+                             )
                         }
+                        .tint(Color.accentColor)
+                    }
                 }
             }
             .listStyle(.plain)

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeRow.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeRow.swift
@@ -12,17 +12,8 @@ public struct NoticeRow: View {
     var rowType: NoticeRowType
     let notice: Notice
 
-    public init(notice: Notice, rowType: NoticeRowType? = nil) {
+    public init(notice: Notice, bookmarked: Bool = false, rowType: NoticeRowType? = nil) {
         self.notice = notice
-
-        var isBookmarked: Bool
-        @Dependency(\.bookmarks) var bookmarks
-        do {
-            let bookmarkedNotices = try bookmarks()
-            isBookmarked = bookmarkedNotices.contains(self.notice)
-        } catch {
-            isBookmarked = false
-        }
 
         if let rowType {
             self.rowType = rowType
@@ -30,10 +21,10 @@ public struct NoticeRow: View {
         }
 
         if notice.important {
-            if isBookmarked { self.rowType = .importantAndBookmark }
+            if bookmarked { self.rowType = .importantAndBookmark }
             else { self.rowType = .important }
         } else {
-            if isBookmarked { self.rowType = .bookmark }
+            if bookmarked { self.rowType = .bookmark }
             else { self.rowType = .none }
         }
     }

--- a/package-kuring/Tests/NoticeFeaturesTests/NoticeAppTests.swift
+++ b/package-kuring/Tests/NoticeFeaturesTests/NoticeAppTests.swift
@@ -4,19 +4,27 @@
 //
 
 import XCTest
+import Caches
+import Models
 import ComposableArchitecture
 @testable import NoticeFeatures
 @testable import SearchFeatures
 
 @MainActor
 final class NoticeAppTests: XCTestCase {
+    override func setUpWithError() throws {
+        try Bookmarks.default.remove(Notice.random.id)
+        try Bookmarks.default.add(Notice.random)
+    }
+    
     /// 푸시 액션 테스트: 검색 버튼 눌렀을 때
     func test_editDepartment() async {
         let store = TestStore(
             initialState: NoticeAppFeature.State(
                 noticeList: NoticeListFeature.State()
             ),
-            reducer: { NoticeAppFeature() }
+            reducer: { NoticeAppFeature() },
+            withDependencies: { $0.bookmarks = Bookmarks.default }
         )
 
         // 푸시 액션: 검색 버튼 눌렀을 때
@@ -29,6 +37,58 @@ final class NoticeAppTests: XCTestCase {
             )
         ) {
             $0.path[id: 0] = .search(SearchFeature.State())
+        }
+    }
+    
+    // 리스트와 디테일간 북마크 싱크 테스트
+    func test_bookmarkOnList_and_cancelOnDetail() async {
+        let notice = Notice.random
+        let store = TestStore(
+            initialState: NoticeAppFeature.State(
+                noticeList: NoticeListFeature.State(
+                    provider: .일반,
+                    noticeDictionary: [.일반: .init(notices: [notice], page: 0, hasNextList: false)]
+                )
+            ),
+            reducer: { NoticeAppFeature() },
+            withDependencies: { $0.bookmarks = Bookmarks.default }
+        )
+        let detailState = NoticeDetailFeature.State(
+            notice: notice,
+            isBookmarked: true
+        )
+        // 공지리스트의 북마크 리스트 초기화
+        await store.send(.noticeList(.set(\.bookmarkIDs, []))) {
+            $0.noticeList.bookmarkIDs = []
+        }
+        
+        // 공지리스트에서 공지 북마크
+        await store.send(.noticeList(.bookmarkTapped(notice))) {
+            $0.noticeList.bookmarkIDs = [notice.id]
+        }
+        
+        // 푸시 액션: 공지 디테일
+        await store.send(
+            .path(.push(id: 0, state: .detail(detailState)))
+        ) {
+            $0.path[id: 0] = .detail(detailState)
+        }
+        
+        // 공지디테일에서 공지 북마크 해지
+        await store.send(.path(.element(id: 0, action: .detail(.bookmarkButtonTapped)))) {
+            $0.path[id: 0, case: \.detail]?.isBookmarked = false
+        }
+        
+        // 싱크를 위한 공지디테일 Delegate 호출
+        await store.receive(
+            .path(
+                .element(
+                    id: 0, 
+                    action: .detail(.delegate(.bookmarkUpdated(notice, false)))
+                )
+            )
+        ) {
+            $0.noticeList.bookmarkIDs = []
         }
     }
 }

--- a/package-kuring/Tests/NoticeFeaturesTests/NoticeAppTests.swift
+++ b/package-kuring/Tests/NoticeFeaturesTests/NoticeAppTests.swift
@@ -67,6 +67,10 @@ final class NoticeAppTests: XCTestCase {
             $0.noticeList.bookmarkIDs = [notice.id]
         }
         
+        await store.receive(.noticeList(.delegate(.bookmarkUpdated(notice))))
+        
+        await store.receive(.updateBookmarks(notice, true))
+        
         // 푸시 액션: 공지 디테일
         await store.send(
             .path(.push(id: 0, state: .detail(detailState)))
@@ -90,5 +94,7 @@ final class NoticeAppTests: XCTestCase {
         ) {
             $0.noticeList.bookmarkIDs = []
         }
+        
+        await store.receive(.updateBookmarks(notice, false))
     }
 }

--- a/package-kuring/Tests/NoticeFeaturesTests/NoticeDetailTests.swift
+++ b/package-kuring/Tests/NoticeFeaturesTests/NoticeDetailTests.swift
@@ -13,8 +13,9 @@ import ComposableArchitecture
 @MainActor
 final class NoticeDetailTests: XCTestCase {
     func test_bookmarkButtonTapped() async throws {
+        let notice = Notice.random
         let store = TestStore(
-            initialState: NoticeDetailFeature.State(notice: Notice.random),
+            initialState: NoticeDetailFeature.State(notice: notice),
             reducer: { NoticeDetailFeature() },
             withDependencies: { $0.bookmarks = Bookmarks.default }
         )

--- a/package-kuring/Tests/NoticeFeaturesTests/NoticeDetailTests.swift
+++ b/package-kuring/Tests/NoticeFeaturesTests/NoticeDetailTests.swift
@@ -23,6 +23,6 @@ final class NoticeDetailTests: XCTestCase {
             $0.isBookmarked = !isNoticeBookmarked
         }
 
-        await store.receive(.delegate(.bookmarkUpdated(!isNoticeBookmarked)))
+        await store.receive(.delegate(.bookmarkUpdated(notice, !isNoticeBookmarked)))
     }
 }


### PR DESCRIPTION
- `@Dependency(\.bookmark)` 에 새 북마크를 추가한다고 뷰가 업데이트 되는 것은 아니기 때문에,
공지리스트와 공지디테일에 관련 프로퍼티를 추가하고 자식이 부모의 값으로 부터 주입될 수 있게 처리
- 디펜던시는 NoticeAppFeature 이 소유
- NoticeAppFeature의 생성자에서 NoticeListFeature.State 객체의 bookmarkIDs 값을 업데이트

