### PR TITLE
[2.0.0] 스포트라이트 검색 기능

### DIFF
--- a/package-kuring/Sources/Caches/Bookmarks.swift
+++ b/package-kuring/Sources/Caches/Bookmarks.swift
@@ -53,7 +53,7 @@ extension Bookmarks {
             try encoder.encode(notice).write(to: fileURL)
             
             @Dependency(\.spotlight) var spotlight
-            try spotlight.add(notice)
+            spotlight.add(notice)
         },
         remove: { noticeID in
             let fileURL = try FileManager.default.url(

--- a/package-kuring/Sources/Caches/Bookmarks.swift
+++ b/package-kuring/Sources/Caches/Bookmarks.swift
@@ -51,6 +51,9 @@ extension Bookmarks {
             let encoder = JSONEncoder()
             encoder.outputFormatting = .prettyPrinted
             try encoder.encode(notice).write(to: fileURL)
+            
+            @Dependency(\.spotlight) var spotlight
+            try spotlight.add(notice)
         },
         remove: { noticeID in
             let fileURL = try FileManager.default.url(

--- a/package-kuring/Sources/Caches/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Spotlight.swift
@@ -36,6 +36,10 @@ extension Spotlight {
 
 extension Spotlight {
     public static let liveValue: Spotlight = .default
+    
+    public static let testValue: Spotlight = .init(
+        add: { _ in }
+    )
 }
 
 extension DependencyValues {

--- a/package-kuring/Sources/Caches/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Spotlight.swift
@@ -6,6 +6,7 @@
 import Models
 import CoreSpotlight
 import ComposableArchitecture
+import UIKit
 
 public struct Spotlight: DependencyKey {
     public var add: (_ notice: Notice) throws -> Void
@@ -21,6 +22,14 @@ extension Spotlight {
     public static let `default` = Spotlight(
         add: { notice in
             let attributeSet = CSSearchableItemAttributeSet(contentType: .text)
+            attributeSet.displayName = notice.subject
+            attributeSet.thumbnailData = UIImage(systemName: "AppIcon")?.pngData()
+            
+            let searchableItem = CSSearchableItem(uniqueIdentifier: notice.id,
+                                                  domainIdentifier: "Kuring",
+                                                  attributeSet: attributeSet)
+            
+            CSSearchableIndex.default().indexSearchableItems([searchableItem]) { _ in }
         }
     )
 }

--- a/package-kuring/Sources/Caches/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Spotlight.swift
@@ -3,13 +3,13 @@
 // See the 'License.txt' file for licensing information.
 //
 
+import UIKit
 import Models
 import CoreSpotlight
 import ComposableArchitecture
-import UIKit
 
 public struct Spotlight: DependencyKey {
-    public var add: (_ notice: Notice) throws -> Void
+    public var add: (_ notice: Notice) -> Void
     
     public init(
         add: @escaping (_: Notice) -> Void

--- a/package-kuring/Sources/Caches/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Spotlight.swift
@@ -1,0 +1,37 @@
+//
+//  Spotlight.swift
+//
+//
+//  Created by Geon Woo lee on 2/13/24.
+//
+
+import Models
+
+public struct Spotlight: DependencyKey {
+    public var add: (_ notice: Notice) throws -> Void
+    
+    public init(
+        add: @escaping (_: Notice) -> Void
+    ) {
+        self.add = add
+    }
+}
+
+extension Spotlight {
+    public static let `default` = Spotlight(
+        add: { notice in
+            let attributeSet = CSSearchableItemAttributeSet(contentType: .text)
+        }
+    )
+}
+
+extension Spotlight {
+    public static let liveValue: Spotlight = .default
+}
+
+extension DependencyValues {
+    public var spotlight: Spotlight {
+        get { self[Spotlight.self] }
+        set { self[Spotlight.self] = newValue }
+    }
+}

--- a/package-kuring/Sources/Caches/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Spotlight.swift
@@ -6,6 +6,8 @@
 //
 
 import Models
+import CoreSpotlight
+import ComposableArchitecture
 
 public struct Spotlight: DependencyKey {
     public var add: (_ notice: Notice) throws -> Void

--- a/package-kuring/Sources/Caches/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Spotlight.swift
@@ -26,7 +26,7 @@ extension Spotlight {
             attributeSet.thumbnailData = UIImage(systemName: "AppIcon")?.pngData()
             
             let searchableItem = CSSearchableItem(uniqueIdentifier: notice.id,
-                                                  domainIdentifier: "Kuring",
+                                                  domainIdentifier: "com.kuring.service.bookmarks",
                                                   attributeSet: attributeSet)
             
             CSSearchableIndex.default().indexSearchableItems([searchableItem]) { _ in }

--- a/package-kuring/Sources/Caches/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Spotlight.swift
@@ -1,8 +1,6 @@
 //
-//  Spotlight.swift
-//
-//
-//  Created by Geon Woo lee on 2/13/24.
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
 //
 
 import Models

--- a/package-kuring/Sources/Caches/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Spotlight.swift
@@ -5,8 +5,8 @@
 
 import UIKit
 import Models
+import Dependencies
 import CoreSpotlight
-import ComposableArchitecture
 
 public struct Spotlight: DependencyKey {
     public var add: (_ notice: Notice) -> Void

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -56,6 +56,7 @@ public struct NoticeAppFeature {
     }
 
     @Dependency(\.bookmarks) var bookmarks
+    @Dependency(\.spotlight) var spotlight
     
     public var body: some ReducerOf<Self> {
         Scope(state: \.noticeList, action: \.noticeList) {
@@ -79,6 +80,7 @@ public struct NoticeAppFeature {
                 do {
                     if isBookmarked {
                         try bookmarks.add(notice)
+                        try spotlight.add(notice)
                     } else {
                         try bookmarks.remove(notice.id)
                     }

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -56,7 +56,6 @@ public struct NoticeAppFeature {
     }
 
     @Dependency(\.bookmarks) var bookmarks
-    @Dependency(\.spotlight) var spotlight
     
     public var body: some ReducerOf<Self> {
         Scope(state: \.noticeList, action: \.noticeList) {
@@ -80,7 +79,6 @@ public struct NoticeAppFeature {
                 do {
                     if isBookmarked {
                         try bookmarks.add(notice)
-                        try spotlight.add(notice)
                     } else {
                         try bookmarks.remove(notice.id)
                     }


### PR DESCRIPTION
## 내용
v1에 존재하는 스포트라이트 기능을 `2.0.0`에 맞게 추가했습니다.
 - `cache` 모듈 안에 넣는게 우선 변화가 가장 적어 보여서 해당 모듈 하위에 추가했습니다.
 - 공지 add시 함께 add할 수 있습니다.
 - 현재는 북마크 시, 스포트라이트 검색 가능한 형태로 add하고 있습니다. 추후에는 읽은 공지, 알림 받은 공지 등으로 확장 가능성을 등록하는 장소를 noticeList에서 처리합니다.