### PR TITLE
[2.0.0] 푸시 알림 처리 & 1주일 공지 미확인 알림

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-KuringModulePackage/Sources/Network/KuringLink/Resources/KuringLink-Info.plist
+GoogleService-Info.plist
 
 # Xcode
 #

--- a/KuringApp/KuringApp.xcodeproj/project.pbxproj
+++ b/KuringApp/KuringApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A9DAFA562AB1F04B0064F748 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAFA552AB1F04B0064F748 /* ContentView.swift */; };
 		A9DAFA582AB1F04C0064F748 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9DAFA572AB1F04C0064F748 /* Assets.xcassets */; };
 		A9DAFA5B2AB1F04C0064F748 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9DAFA5A2AB1F04C0064F748 /* Preview Assets.xcassets */; };
+		CACC2F4D2B7E63B0003142E2 /* PushNotifications in Frameworks */ = {isa = PBXBuildFile; productRef = CACC2F4C2B7E63B0003142E2 /* PushNotifications */; };
 		CAE658662B3992A800CD8A63 /* App in Frameworks */ = {isa = PBXBuildFile; productRef = CAE658652B3992A800CD8A63 /* App */; };
 		CAE94A9A2B5EA3B000F73A7E /* App in Frameworks */ = {isa = PBXBuildFile; productRef = CAE94A992B5EA3B000F73A7E /* App */; };
 		CAE94A9C2B5EA3B000F73A7E /* Labs in Frameworks */ = {isa = PBXBuildFile; productRef = CAE94A9B2B5EA3B000F73A7E /* Labs */; };
@@ -37,6 +38,7 @@
 		A9DAFA572AB1F04C0064F748 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A9DAFA5A2AB1F04C0064F748 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		CA52DF2F2AD58DF2009B9272 /* KuringAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KuringAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CACC2F4B2B7E638C003142E2 /* KuringApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KuringApp.entitlements; sourceTree = "<group>"; };
 		DF062D4A2AC87B6D00FC48C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DF331DA72AC917E000D0BB08 /* kuring_app.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = kuring_app.png; sourceTree = "<group>"; };
 		DF331DA82AC917E000D0BB08 /* kuring_app_classic.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = kuring_app_classic.png; sourceTree = "<group>"; };
@@ -52,6 +54,7 @@
 				CAE94A9A2B5EA3B000F73A7E /* App in Frameworks */,
 				CAE94A9C2B5EA3B000F73A7E /* Labs in Frameworks */,
 				CAE658662B3992A800CD8A63 /* App in Frameworks */,
+				CACC2F4D2B7E63B0003142E2 /* PushNotifications in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,6 +97,7 @@
 		A9DAFA522AB1F04B0064F748 /* KuringApp */ = {
 			isa = PBXGroup;
 			children = (
+				CACC2F4B2B7E638C003142E2 /* KuringApp.entitlements */,
 				DF062D4A2AC87B6D00FC48C0 /* Info.plist */,
 				DFE7AB132AC332D200230934 /* Setting */,
 				A9DAFA532AB1F04B0064F748 /* KuringApp.swift */,
@@ -158,6 +162,7 @@
 				CAE658652B3992A800CD8A63 /* App */,
 				CAE94A992B5EA3B000F73A7E /* App */,
 				CAE94A9B2B5EA3B000F73A7E /* Labs */,
+				CACC2F4C2B7E63B0003142E2 /* PushNotifications */,
 			);
 			productName = KuringApp;
 			productReference = A9DAFA502AB1F04B0064F748 /* KuringApp.app */;
@@ -397,6 +402,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = KuringApp/KuringApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"KuringApp/Preview Content\"";
@@ -429,6 +435,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = KuringApp/KuringApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"KuringApp/Preview Content\"";
@@ -540,6 +547,11 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		CACC2F4C2B7E63B0003142E2 /* PushNotifications */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CAE94A982B5EA3B000F73A7E /* XCLocalSwiftPackageReference "../package-kuring" */;
+			productName = PushNotifications;
+		};
 		CAE658652B3992A800CD8A63 /* App */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = App;

--- a/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,93 @@
 {
   "pins" : [
     {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3e464dad87dad2d29bb29a97836789bf0f8f67d2",
+        "version" : "10.18.1"
+      }
+    },
+    {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
         "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "f91c8167141d0279726c6f6d9d4a47c026785cbc",
+        "version" : "10.21.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "cb8617fab75d181270a1d8f763f26b15c73e2e1e",
+        "version" : "10.21.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "a732a4b47f59e4f725a2ea10f0c77e93a7131117",
+        "version" : "9.3.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "bc27fad73504f3d4af235de451f02ee22586ebd3",
+        "version" : "7.12.1"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
+        "version" : "1.49.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "76135c9f4e1ac85459d5fec61b6f76ac47ab3a4c",
+        "version" : "3.3.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
       }
     },
     {
@@ -19,12 +100,39 @@
       }
     },
     {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "9d108e9112aa1d65ce508facf804674546116d9c",
+        "version" : "1.22.3"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
       "identity" : "package-activityui",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ku-ring/package-activityui",
       "state" : {
         "branch" : "main",
         "revision" : "a8404f0e2d72873eace8f192589d542cbddea0b9"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
+        "version" : "2.3.1"
       }
     },
     {
@@ -106,6 +214,15 @@
       "state" : {
         "revision" : "42240120b2a8797595433288ab4118f8042214c3",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
+        "version" : "1.25.2"
       }
     },
     {

--- a/KuringApp/KuringApp/Info.plist
+++ b/KuringApp/KuringApp/Info.plist
@@ -3,43 +3,47 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIcons</key>
-    <dict>
-        <key>CFBundleAlternateIcons</key>
-        <dict>
-            <key>kuring_app</key>
-            <dict>
-                <key>CFBundleIconFiles</key>
-                <array>
-                    <string>kuring_app</string>
-                </array>
-            </dict>
-            <key>kuring_app_classic</key>
-            <dict>
-                <key>CFBundleIconFiles</key>
-                <array>
-                    <string>kuring_app_classic</string>
-                </array>
-            </dict>
-            <key>kuring_app_blueprint</key>
-            <dict>
-                <key>CFBundleIconFiles</key>
-                <array>
-                    <string>kuring_app_blueprint</string>
-                </array>
-            </dict>
-            <key>kuring_app_sketch</key>
-            <dict>
-                <key>CFBundleIconFiles</key>
-                <array>
-                    <string>kuring_app_sketch</string>
-                </array>
-            </dict>
-        </dict>
-    </dict>
+	<dict>
+		<key>CFBundleAlternateIcons</key>
+		<dict>
+			<key>kuring_app</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>kuring_app</string>
+				</array>
+			</dict>
+			<key>kuring_app_blueprint</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>kuring_app_blueprint</string>
+				</array>
+			</dict>
+			<key>kuring_app_classic</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>kuring_app_classic</string>
+				</array>
+			</dict>
+			<key>kuring_app_sketch</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>kuring_app_sketch</string>
+				</array>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/KuringApp/KuringApp/KuringApp.entitlements
+++ b/KuringApp/KuringApp/KuringApp.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>production</string>
+</dict>
+</plist>

--- a/KuringApp/KuringApp/KuringApp.swift
+++ b/KuringApp/KuringApp/KuringApp.swift
@@ -82,7 +82,7 @@ struct KuringApp: App {
 //                            .custom(
 //                                title: "[건대교지] 건빵레터 #47",
 //                                body: "#47 [당근알바] 광화문 한복판에서 5미터 ‘천공’ 굴리기",
-//                                link: "https://stibee.com/api/v1.0/emails/share/1oXWNovPHiqH-CiArIVZn8tOQmkmHVU"
+//                                url: "https://stibee.com/api/v1.0/emails/share/1oXWNovPHiqH-CiArIVZn8tOQmkmHVU"
 //                            )
 //                        )
 //                    }

--- a/KuringApp/KuringApp/KuringApp.swift
+++ b/KuringApp/KuringApp/KuringApp.swift
@@ -71,23 +71,23 @@ struct KuringApp: App {
                 }
             
                 // MARK: - 테스트: 새 공지
-                #if DEBUG
-                .onAppear {
-                    Task { @MainActor in
-                        try await Task.sleep(for: .seconds(1.5))
-                        let notice = Notice.random
-                        newMessagePublisher.send(.notice(notice))
-                        try await Task.sleep(for: .seconds(1.5))
-                        newMessagePublisher.send(
-                            .custom(
-                                title: "[건대교지] 건빵레터 #47",
-                                body: "#47 [당근알바] 광화문 한복판에서 5미터 ‘천공’ 굴리기",
-                                link: "https://stibee.com/api/v1.0/emails/share/1oXWNovPHiqH-CiArIVZn8tOQmkmHVU"
-                            )
-                        )
-                    }
-                }
-                #endif
+//                #if DEBUG
+//                .onAppear {
+//                    Task { @MainActor in
+//                        try await Task.sleep(for: .seconds(1.5))
+//                        let notice = Notice.random
+//                        newMessagePublisher.send(.notice(notice))
+//                        try await Task.sleep(for: .seconds(1.5))
+//                        newMessagePublisher.send(
+//                            .custom(
+//                                title: "[건대교지] 건빵레터 #47",
+//                                body: "#47 [당근알바] 광화문 한복판에서 5미터 ‘천공’ 굴리기",
+//                                link: "https://stibee.com/api/v1.0/emails/share/1oXWNovPHiqH-CiArIVZn8tOQmkmHVU"
+//                            )
+//                        )
+//                    }
+//                }
+//                #endif
         }
     }
 }

--- a/KuringApp/KuringApp/KuringApp.swift
+++ b/KuringApp/KuringApp/KuringApp.swift
@@ -5,14 +5,89 @@
 //  Created by Jaesung Lee on 2023/09/13.
 //
 
+import Models
 import SwiftUI
+import CommonUI
+import NoticeUI
+import NoticeFeatures
+import PushNotifications
 import ComposableArchitecture
 
 @main
 struct KuringApp: App {
+    @State private var newNotice: Notice?
+    @Environment(\.scenePhase) private var scenePhase
+    @UIApplicationDelegateAdaptor(Notifications.self) var appDelegate
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                // MARK: 앱 업데이트 알림
+                .versionUpdateAlert()
+                // MARK: 새 공지 보여주기 (알림 탭했을 때)
+                .fullScreenCover(item: $newNotice) { notice in
+                    NavigationStack {
+                        NoticeDetailView(
+                            store: Store(
+                                initialState: NoticeDetailFeature.State(
+                                    notice: notice,
+                                    isBookmarked: false
+                                ),
+                                reducer: { NoticeDetailFeature() }
+                            )
+                        )
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button {
+                                    self.newNotice = nil
+                                } label: {
+                                    Image(systemName: "xmark")
+                                }
+                            }
+                        }
+                    }
+                }
+                // MARK: 새 공지 알림을 탭 했을 때 호출
+                .onReceive(newMessagePublisher) { message in
+                    switch message {
+                    // 새 공지
+                    case let .notice(notice):
+                        self.newNotice = notice
+                    
+                    // 커스텀 알림
+                    case let .custom(title, body, link):
+                        guard let link else { return }
+                        guard let url = URL(string: link) else { return }
+                        guard UIApplication.shared.canOpenURL(url) else { return }
+                        UIApplication.shared.open(url)
+                    }
+                }
+                // MARK: - 일주일 동안 공지를 확인하지 않았어요
+                .onChange(of: scenePhase) { _, scenePhase in
+                    guard scenePhase == .active else { return }
+                    Task {
+                        await appDelegate.requestOneWeekInactiveNotification()
+                    }
+                }
+            
+                // MARK: - 테스트: 새 공지
+                #if DEBUG
+                .onAppear {
+                    Task { @MainActor in
+                        try await Task.sleep(for: .seconds(1.5))
+                        let notice = Notice.random
+                        newMessagePublisher.send(.notice(notice))
+                        try await Task.sleep(for: .seconds(1.5))
+                        newMessagePublisher.send(
+                            .custom(
+                                title: "[건대교지] 건빵레터 #47",
+                                body: "#47 [당근알바] 광화문 한복판에서 5미터 ‘천공’ 굴리기",
+                                link: "https://stibee.com/api/v1.0/emails/share/1oXWNovPHiqH-CiArIVZn8tOQmkmHVU"
+                            )
+                        )
+                    }
+                }
+                #endif
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@
 chmod +x FIRST_ACTION.sh
 ```
 
+### FCM 을 위한 GoogleService-Info.plist 추가하기
+
+> **Note**: 푸시 알림 테스트를 위해서 필요합니다.
+
+1. [GoogleService-Info.plist 다운로드하기](https://github.com/ku-ring/ios-certificates/blob/main/GoogleService-Info.plist)
+2. KuringApp.xcproj 를 엽니다
+3. KuringApp 폴더 하위에 Info.plist 와 같은 경로에 다운로드 받은 plist 를 드래그앤드랍 합니다.
+
 ### 패키지 기반 모듈화 (Package Based Modularization)
 
 `KuringApp.xcodeproj` 열기

--- a/package-kuring/.swiftpm/xcode/xcshareddata/xcschemes/package-kuring-Package.xcscheme
+++ b/package-kuring/.swiftpm/xcode/xcshareddata/xcschemes/package-kuring-Package.xcscheme
@@ -104,6 +104,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PushNotifications"
+               BuildableName = "PushNotifications"
+               BlueprintName = "PushNotifications"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/package-kuring/Package.resolved
+++ b/package-kuring/Package.resolved
@@ -1,12 +1,93 @@
 {
   "pins" : [
     {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3e464dad87dad2d29bb29a97836789bf0f8f67d2",
+        "version" : "10.18.1"
+      }
+    },
+    {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
         "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "f91c8167141d0279726c6f6d9d4a47c026785cbc",
+        "version" : "10.21.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "cb8617fab75d181270a1d8f763f26b15c73e2e1e",
+        "version" : "10.21.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "a732a4b47f59e4f725a2ea10f0c77e93a7131117",
+        "version" : "9.3.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "bc27fad73504f3d4af235de451f02ee22586ebd3",
+        "version" : "7.12.1"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
+        "version" : "1.49.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "76135c9f4e1ac85459d5fec61b6f76ac47ab3a4c",
+        "version" : "3.3.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
       }
     },
     {
@@ -25,6 +106,33 @@
       "state" : {
         "branch" : "main",
         "revision" : "a8404f0e2d72873eace8f192589d542cbddea0b9"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "9d108e9112aa1d65ce508facf804674546116d9c",
+        "version" : "1.22.3"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
+        "version" : "2.3.1"
       }
     },
     {
@@ -106,6 +214,15 @@
       "state" : {
         "revision" : "42240120b2a8797595433288ab4118f8042214c3",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
+        "version" : "1.25.2"
       }
     },
     {

--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -20,7 +20,12 @@ let package = Package(
                 "SettingsUI",
                 "CampusUI",
                 "CommonUI",
+                "PushNotifications",
             ]
+        ),
+        .library(
+            name: "PushNotifications",
+            targets: ["PushNotifications"]
         ),
         .library(
             name: "Labs",
@@ -33,7 +38,8 @@ let package = Package(
         .package(url: "https://github.com/ku-ring/the-satellite", branch: "main"),
         .package(url: "https://github.com/ku-ring/ios-maps", branch: "main"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),
-        .package(url: "https://github.com/ku-ring/package-activityui", branch: "main")
+        .package(url: "https://github.com/ku-ring/package-activityui", branch: "main"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.21.0"),
     ],
     targets: [
         // MARK: App Library Dependencies
@@ -184,6 +190,15 @@ let package = Package(
             name: "Labs",
             dependencies: [
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+            ]
+        ),
+        
+        // MARK: - Push Notifications
+        .target(
+            name: "PushNotifications",
+            dependencies: [
+                "Models",
+                .product(name: "FirebaseMessaging", package: "firebase-ios-sdk")
             ]
         ),
         

--- a/package-kuring/Sources/Models/Notice.swift
+++ b/package-kuring/Sources/Models/Notice.swift
@@ -23,6 +23,15 @@ public struct Notice: Codable, Hashable, Identifiable, Equatable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(url)
     }
+    
+    public init(articleId: String, postedDate: String, subject: String, url: String, category: String, important: Bool) {
+        self.articleId = articleId
+        self.postedDate = postedDate
+        self.subject = subject
+        self.url = url
+        self.category = category
+        self.important = important
+    }
 }
 
 extension Notice {

--- a/package-kuring/Sources/Models/Notice.swift
+++ b/package-kuring/Sources/Models/Notice.swift
@@ -34,6 +34,63 @@ public struct Notice: Codable, Hashable, Identifiable, Equatable {
     }
 }
 
+// MARK: - Push Notification
+extension Notice {
+    public init(userInfo: [String: Any]) throws {
+        guard let articleID = userInfo["articleId"] as? String else {
+            throw DecodingError.noArticleID
+        }
+        guard let postedDate = userInfo["postedDate"] as? String else {
+            throw DecodingError.noPostedDate
+        }
+        guard let subject = userInfo["subject"] as? String else {
+            throw DecodingError.noSubject
+        }
+        guard let baseUrl = userInfo["baseUrl"] as? String else {
+            throw DecodingError.noURL
+        }
+        guard let category = userInfo["category"] as? String else {
+            throw DecodingError.noCategory
+        }
+        let important = userInfo["important"] as? Bool
+        
+        self.init(
+            articleId: articleID,
+            postedDate: postedDate,
+            subject: subject,
+            url: baseUrl,
+            category: category,
+            important: important ?? false
+        )
+    }
+    
+    public enum DecodingError: Error {
+        case noArticleID
+        case noSubject
+        case noCategory
+        case noPostedDate
+        case noURL
+    }
+}
+
+extension Notice.DecodingError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .noArticleID:
+            "\"articleId\" 키에 해당하는 값이 없습니다"
+        case .noSubject:
+            "\"subject\" 키에 해당하는 값이 없습니다"
+        case .noCategory:
+            "\"category\" 키에 해당하는 값이 없습니다"
+        case .noPostedDate:
+            "\"postedDate\" 키에 해당하는 값이 없습니다"
+        case .noURL:
+            "\"baseUrl\" 키에 해당하는 값이 없습니다"
+        }
+    }
+}
+
+// MARK: - Test Mock
 extension Notice {
     public static var random: Notice {
         Notice(

--- a/package-kuring/Sources/PushNotifications/Errors/MessageError.swift
+++ b/package-kuring/Sources/PushNotifications/Errors/MessageError.swift
@@ -1,0 +1,10 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+public enum MessageError: Error {
+    case failedParsing
+    case notSupported
+    case notAllowedType
+}

--- a/package-kuring/Sources/PushNotifications/Extensions/DateComponents.swift
+++ b/package-kuring/Sources/PushNotifications/Extensions/DateComponents.swift
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import Foundation
+
+extension DateComponents {
+    static var notificationDate: Self {
+        var date = Self()
+        let currentWeekday = Calendar.current.component(.weekday, from: Date())
+        // weekday 1 ~ 7 == 월 ~ 일
+        date.weekday = currentWeekday == 1
+        ? 7
+        : currentWeekday - 1
+        date.hour = 12
+        date.minute = 0
+        return date
+    }
+}

--- a/package-kuring/Sources/PushNotifications/Message/Message.swift
+++ b/package-kuring/Sources/PushNotifications/Message/Message.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import Models
+
+public enum Message {
+    case notice(Notice)
+    case custom(title: String, body: String, link: String?)
+}
+
+extension Message {
+    init(userInfo: [String: Any]) throws {
+        guard let type = userInfo["type"] as? String else {
+            throw MessageError.failedParsing
+        }
+        switch type {
+        case "admin":
+            guard Notifications.isCustomNotificationEnabled else {
+                throw MessageError.notAllowedType
+            }
+            guard let title = userInfo["title"] as? String else {
+                throw MessageError.failedParsing
+            }
+            let body = userInfo["body"] as? String
+            let link = userInfo["link"] as? String
+            
+            self = .custom(title: title, body: body ?? "", link: link)
+        default:
+            // TODO: Notice
+            throw MessageError.notSupported
+        }
+    }
+}

--- a/package-kuring/Sources/PushNotifications/Message/Message.swift
+++ b/package-kuring/Sources/PushNotifications/Message/Message.swift
@@ -7,7 +7,7 @@ import Models
 
 public enum Message {
     case notice(Notice)
-    case custom(title: String, body: String, link: String?)
+    case custom(title: String, body: String, url: String?)
 }
 
 extension Message {
@@ -16,6 +16,13 @@ extension Message {
             throw MessageError.failedParsing
         }
         switch type {
+        // 공지사항
+        case "notice":
+            self = .notice(
+                try Notice(userInfo: userInfo)
+            )
+            
+        // 커스텀 알림
         case "admin":
             guard Notifications.isCustomNotificationEnabled else {
                 throw MessageError.notAllowedType
@@ -24,23 +31,12 @@ extension Message {
                 throw MessageError.failedParsing
             }
             let body = userInfo["body"] as? String
-            let link = userInfo["link"] as? String
+            let url = userInfo["url"] as? String
             
-            self = .custom(title: title, body: body ?? "", link: link)
-            
-        case "notice":
-            let notice = Notice(
-                articleId: "123",
-                postedDate: "124",
-                subject: "125",
-                url: "126",
-                category: "127",
-                important: false
-            )
-            self = .notice(notice)
-            
+            self = .custom(title: title, body: body ?? "", url: url)
+        
+        // 지원하지 않는 알림
         default:
-            // TODO: Notice
             throw MessageError.notSupported
         }
     }

--- a/package-kuring/Sources/PushNotifications/Message/Message.swift
+++ b/package-kuring/Sources/PushNotifications/Message/Message.swift
@@ -27,6 +27,18 @@ extension Message {
             let link = userInfo["link"] as? String
             
             self = .custom(title: title, body: body ?? "", link: link)
+            
+        case "notice":
+            let notice = Notice(
+                articleId: "123",
+                postedDate: "124",
+                subject: "125",
+                url: "126",
+                category: "127",
+                important: false
+            )
+            self = .notice(notice)
+            
         default:
             // TODO: Notice
             throw MessageError.notSupported

--- a/package-kuring/Sources/PushNotifications/Notifications/Notifications.MessagingDelegate.swift
+++ b/package-kuring/Sources/PushNotifications/Notifications/Notifications.MessagingDelegate.swift
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import Firebase
+
+extension Notifications: MessagingDelegate {
+    func configureFirebase() {
+        FirebaseApp.configure()
+        Messaging.messaging().delegate = self
+    }
+    
+    /// FCM 등록 토큰을 받았을 때 호출되는 이벤트
+    public func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let fcmToken else { return }
+        self.fcmToken = fcmToken
+    }
+}

--- a/package-kuring/Sources/PushNotifications/Notifications/Notifications.UIApplicationDelegate.swift
+++ b/package-kuring/Sources/PushNotifications/Notifications/Notifications.UIApplicationDelegate.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import UIKit
+import Firebase
+
+extension Notifications {
+    public func applicationDidFinishLaunching(_ application: UIApplication) {
+        // TODO: `didFinishLaunchingWithOptions` 와 차이점?
+        configureFirebase()
+        registerRemoteNotification(for: application)
+    }
+    
+    
+    /// 푸시알림 디바이스 토큰 등록되었을 때 호출되는 이벤트
+    public func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+    
+    /// 푸시 알림을 위한 등록에 실패했을 때 호출되는 이벤트
+    public func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        
+    }
+}

--- a/package-kuring/Sources/PushNotifications/Notifications/Notifications.UIApplicationDelegate.swift
+++ b/package-kuring/Sources/PushNotifications/Notifications/Notifications.UIApplicationDelegate.swift
@@ -7,10 +7,14 @@ import UIKit
 import Firebase
 
 extension Notifications {
-    public func applicationDidFinishLaunching(_ application: UIApplication) {
-        // TODO: `didFinishLaunchingWithOptions` 와 차이점?
+    /// - Note: `applicationDidFinishLaunching` 와의 차이점: The default Firebase app has not yet been configured. Add `FirebaseApp.configure()` to your application initialization. This can be done in in the App Delegate's application(_:didFinishLaunchingWithOptions:)` (or the `@main` struct's initializer in SwiftUI). Read more: https://goo.gl/ctyzm8.
+    public func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
         configureFirebase()
         registerRemoteNotification(for: application)
+        return true
     }
     
     

--- a/package-kuring/Sources/PushNotifications/Notifications/Notifications.UNUserNotificationCenterDelegate.swift
+++ b/package-kuring/Sources/PushNotifications/Notifications/Notifications.UNUserNotificationCenterDelegate.swift
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import UIKit
+import Firebase
+import UserNotifications
+
+extension Notifications: UNUserNotificationCenterDelegate {
+    func registerRemoteNotification(for application: UIApplication) {
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: [.alert, .badge, .sound],
+            completionHandler: { isSucceed, error in }
+        )
+        application.registerForRemoteNotifications()
+    }
+    
+    /// 포어그라운드에서 푸시 알림을 받은 경우
+    public func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        let userInfo = notification.request.content.userInfo
+        
+        /// you only need to call this if you set the `FirebaseAppDelegateProxyEnabled` flag to `NO` in your `Info.plist`. If `FirebaseAppDelegateProxyEnabled` is either missing or set to `YES` in your `Info.plist`, the library will call this automatically.
+        Messaging.messaging().appDidReceiveMessage(userInfo)
+        
+        // TODO: 로컬 알림을 띄워줘야 하는가?
+        
+        guard let userInfo = userInfo as? [String: Any] else { return [] }
+        do {
+            let _ = try Message(userInfo: userInfo)
+            return [.banner, .sound]
+        } catch {
+            // 커스텀 알림 수신 미동의 인데 커스텀 알림이 온 경우
+            return []
+        }
+    }
+    
+    /// 푸시 알림을 탭 했을 때
+    /// - Important: ``newMessagePublisher`` 를 구독하여 ``Message`` 객체를 이벤트로 전달받을 수 있습니다.
+    public func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let userInfo = response.notification.request.content.userInfo
+        guard let userInfo = userInfo as? [String: Any] else { return }
+        do {
+            try onTapRemoteNotification(with: userInfo)
+        } catch {
+            return
+        }
+    }
+    
+    /// 앱이 백그라운드 상태일 때 푸시 알림을 탭한 경우
+    /// 만약 앱이 백그라운드 상태인 동안 푸시 알림을 받는다면, 알림을 탭하여 앱을 실행할 때까지 호출되지 않는 이벤트
+    /// - Important: ``newMessagePublisher`` 를 구독하여 ``Message`` 객체를 이벤트로 전달받을 수 있습니다.
+    public func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable : Any]
+    ) async -> UIBackgroundFetchResult {
+        Messaging.messaging().appDidReceiveMessage(userInfo)
+        
+        // Kuring.application(application, didReceiveRemoteNotification: userInfo)
+        guard let userInfo = userInfo as? [String: Any] else { return .failed }
+        do {
+            try onTapRemoteNotification(with: userInfo)
+            return .newData
+        } catch {
+            return .failed
+        }
+    }
+}

--- a/package-kuring/Sources/PushNotifications/Notifications/Notifications.swift
+++ b/package-kuring/Sources/PushNotifications/Notifications/Notifications.swift
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import UIKit
+import Models
+import SwiftUI
+import UserNotifications
+
+/// 푸시 알림 처리를 담당하는 클래스. `AppDelegate` 역할.
+/// ```swift
+/// struct MyApp: App {
+///     @UIApplicationDelegateAdaptor(Notifications.self) 
+///     var appDelegate
+///     // ...
+/// }
+/// ```
+public class Notifications: NSObject, UIApplicationDelegate {
+    @AppStorage("com.kuring.sdk.notification.custom")
+    static var isCustomNotificationEnabled: Bool = true
+    
+    @AppStorage("com.kuring.sdk.token.fcm")
+    var fcmToken: String = ""
+    
+    func onTapRemoteNotification(with userInfo: [String: Any]) throws {
+        let message = try Message(userInfo: userInfo)
+        Task { @MainActor in
+            // 종료된 앱을 시작시키는 경우를 고려하여 2초 딜레이.
+            try await Task.sleep(for: .seconds(1.5))
+            newMessagePublisher.send(message)
+        }
+    }
+}
+
+// MARK: - 공지를 일주일 동안 확인하지 않을 경우
+extension Notifications {
+    /// 공지를 일주일 동안 확인하지 않을 경우 알림을 띄우도록 합니다
+    public func requestOneWeekInactiveNotification() async {
+        guard Notifications.isCustomNotificationEnabled else { return }
+        
+        let trigger = UNCalendarNotificationTrigger(dateMatching: DateComponents.notificationDate, repeats: false)
+        let content = UNMutableNotificationContent()
+        content.title = "공지를 일주일 동안 확인하지 않았어요!"
+        content.body = "놓친 공지가 있는지 확인해보세요 🔔"
+        content.sound = .default
+        
+        let request = UNNotificationRequest(identifier: "alarm", content: content, trigger: trigger)
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+        } catch {
+            // TODO: 에러 처리
+            return
+        }
+    }
+}

--- a/package-kuring/Sources/PushNotifications/Publishers/Publishers.swift
+++ b/package-kuring/Sources/PushNotifications/Publishers/Publishers.swift
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import Combine
+
+/// 새 공지 알림을 탭했을 때 퍼블리싱 하는 퍼블리셔.
+/// ```swift
+/// .onReceive(newMessagePublisher) { message in
+///     switch message {
+///     case let .notice(notice):
+///         self.newNotice = notice
+///     case let .custom(title, body, link):
+///         // handle custom notification
+///     }
+/// }
+/// ```
+public let newMessagePublisher = PassthroughSubject<Message, Never>()


### PR DESCRIPTION
### 1. `PushNotifications` 라이브러리 추가
```swift
import PushNotifications
```
### 2. `KuringApp` 에 푸시 알림 탭 했을 때 동작 처리
```swift
ContentView()
    .fullScreenCover(item: $newNotice) { notice in ... } // 새 공지 보여주기
    .onReceive(newMessagePublisher) { message in ... }    // 새 공지 알림을 탭 했을 때 호출

```
### 3. 일주일 미확인 알림
```swift
ContentView()
    .onChange(of: scenePhase) { _, scenePhase in
        guard scenePhase == .active else { return }
        Task {
            await appDelegate.requestOneWeekInactiveNotification()
        }
    }
```

| 푸시 알림 | 새 공지 알림 탭 했을 때 | 커스텀알림 탭 했을 때 |
| --- | --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-17 at 21 57 52](https://github.com/ku-ring/ios-app/assets/53814741/d5c89b49-e3da-4315-bec7-85fcf7c64653) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-16 at 01 39 10](https://github.com/ku-ring/ios-app/assets/53814741/e946a1a5-9789-47fe-8719-6d1be388161a) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-16 at 01 39 12](https://github.com/ku-ring/ios-app/assets/53814741/0137d9f0-b91d-4c0e-a88f-cd868dda6338) |
