### PR TITLE
[2.0.0] 공지 카테고리 관련 API 요청 인터페이스 추가 및 구현

### DIFF
--- a/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -156,10 +156,10 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
-        "version" : "1.0.6"
+        "branch" : "main",
+        "revision" : "ca8b4ab855f4b8075c1fd29eb50db756b1688e61"
       }
     },
     {

--- a/KuringApp/KuringApp/KuringApp.swift
+++ b/KuringApp/KuringApp/KuringApp.swift
@@ -22,6 +22,13 @@ struct KuringApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .kuringLink(
+                    onRequest: {
+                        print("onRequest")
+                    }, onCompletion: { result in
+                        print("onCompletion: \(result)")
+                    }
+                )
                 // MARK: 앱 업데이트 알림
                 .versionUpdateAlert()
                 // MARK: 새 공지 보여주기 (알림 탭했을 때)

--- a/package-kuring/Package.resolved
+++ b/package-kuring/Package.resolved
@@ -100,15 +100,6 @@
       }
     },
     {
-      "identity" : "package-activityui",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ku-ring/package-activityui",
-      "state" : {
-        "branch" : "main",
-        "revision" : "a8404f0e2d72873eace8f192589d542cbddea0b9"
-      }
-    },
-    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
@@ -124,6 +115,15 @@
       "state" : {
         "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
         "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "package-activityui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ku-ring/package-activityui",
+      "state" : {
+        "branch" : "main",
+        "revision" : "a8404f0e2d72873eace8f192589d542cbddea0b9"
       }
     },
     {
@@ -156,10 +156,10 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
-        "version" : "1.0.5"
+        "branch" : "main",
+        "revision" : "ca8b4ab855f4b8075c1fd29eb50db756b1688e61"
       }
     },
     {

--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -35,6 +35,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", branch: "main"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.1.5"),
+        .package(
+              url: "https://github.com/apple/swift-collections.git", branch: "main"),
         .package(url: "https://github.com/ku-ring/the-satellite", branch: "main"),
         .package(url: "https://github.com/ku-ring/ios-maps", branch: "main"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),
@@ -226,6 +228,7 @@ let package = Package(
                 "Models",
                 .product(name: "Satellite", package: "the-satellite"),
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+                .product(name: "Collections", package: "swift-collections"),
             ],
             path: "Sources/Networks",
             resources: [.process("Resources/KuringLink-Info.plist")]

--- a/package-kuring/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
+++ b/package-kuring/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
@@ -10,13 +10,13 @@ import ComposableArchitecture
 public struct DepartmentEditorFeature {
     @ObservableState
     public struct State: Equatable {
-        public var myDepartments: IdentifiedArrayOf<NoticeProvider> = []
-        public var results: IdentifiedArrayOf<NoticeProvider> = []
+        public var myDepartments: IdentifiedArrayOf<NoticeProvider>
+        public var results: IdentifiedArrayOf<NoticeProvider>
 
-        public var searchText: String = ""
-        public var focus: Field? = .search
+        public var searchText: String
+        public var focus: Field?
 
-        public var displayOption: Display = .myDepartment
+        public var displayOption: Display
 
         public enum Field {
             case search
@@ -32,8 +32,12 @@ public struct DepartmentEditorFeature {
         @Presents public var alert: AlertState<Action.Alert>?
 
         public init(
-            myDepartments: IdentifiedArrayOf<NoticeProvider> = [],
-            results: IdentifiedArrayOf<NoticeProvider> = [],
+            myDepartments: IdentifiedArrayOf<NoticeProvider> = .init(
+                uniqueElements: NoticeProvider.addedDepartments
+            ),
+            results: IdentifiedArrayOf<NoticeProvider> = .init(
+                uniqueElements: NoticeProvider.departments
+            ),
             searchText: String = "",
             focus: Field? = .search,
             displayOption: Display = .myDepartment,
@@ -147,14 +151,16 @@ public struct DepartmentEditorFeature {
                 switch alertAction {
                 case let .confirmAdd(department: department):
                     state.myDepartments.append(department)
-                    return .none
+                    
                 case let .confirmDelete(id: id):
                     state.myDepartments.remove(id: id)
-                    return .none
+                    
                 case .confirmDeleteAll:
                     state.myDepartments.removeAll()
-                    return .none
                 }
+                
+                NoticeProvider.addedDepartments = state.myDepartments.elements
+                return .none
 
             case .alert(.dismiss):
                 return .none

--- a/package-kuring/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
+++ b/package-kuring/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
@@ -77,6 +77,13 @@ public struct DepartmentEditorFeature {
             /// 전체 삭제 알림 시 삭제 버튼 눌렀을 때
             case confirmDeleteAll
         }
+        
+        /// 델리게이트
+        case delegate(Delegate)
+        
+        public enum Delegate: Equatable {
+            case addedDepartmentsUpdated
+        }
     }
 
     public var body: some ReducerOf<Self> {
@@ -158,15 +165,24 @@ public struct DepartmentEditorFeature {
                 case .confirmDeleteAll:
                     state.myDepartments.removeAll()
                 }
-                
                 NoticeProvider.addedDepartments = state.myDepartments.elements
                 return .none
 
             case .alert(.dismiss):
                 return .none
+                
+                // MARK: Delegate
+                
+            case .delegate:
+                return .none
             }
         }
         .ifLet(\.$alert, action: \.alert)
+        .onChange(of: \.myDepartments) { oldValue, newValue in
+            Reduce { state, _ in
+                return .send(.delegate(.addedDepartmentsUpdated))
+            }
+        }
     }
 
     public init() { }

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -111,6 +111,13 @@ public struct NoticeAppFeature {
             case .changeSubscriptionButtonTapped:
                 state.changeSubscription = SubscriptionAppFeature.State()
                 return .none
+                
+            case let .path(.element(id: id, action: .departmentEditor(.delegate(.addedDepartmentsUpdated)))):
+                guard case let .departmentEditor(departmentEditorState) = state.path[id: id] else {
+                    return .none
+                }
+                state.noticeList.provider = departmentEditorState.myDepartments.first ?? .emptyDepartment
+                return .none
 
             case .path, .noticeList, .changeSubscription:
                 return .none

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -93,11 +93,7 @@ public struct NoticeAppFeature {
                     state.path.removeAll()
                     state.path.append(
                         Path.State.departmentEditor(
-                            // TODO: init parameter 수정 (현재는 테스트용)
-                            DepartmentEditorFeature.State(
-                                myDepartments: IdentifiedArray(uniqueElements: NoticeProvider.departments),
-                                results: IdentifiedArray(uniqueElements: NoticeProvider.departments)
-                            )
+                            DepartmentEditorFeature.State()
                         )
                     )
                     return .none

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
@@ -222,13 +222,9 @@ public struct NoticeListFeature {
                 return .none
 
             case let .providerChanged(provider):
-                state.provider = provider
-                if provider.category == .학과 {
-                    NoticeProvider.allNamesForPicker.updateValue(
-                        provider,
-                        forKey: "학과"
-                    )
-                }
+                state.provider = provider.category == .학과
+                ? NoticeProvider.allNamesForPicker["학과"] ?? NoticeProvider.emptyDepartment
+                : provider
                 return .send(.fetchNotices)
 
             case .binding, .delegate, .changeDepartment:

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
@@ -119,6 +119,7 @@ public struct NoticeListFeature {
 
         Reduce { state, action in
             switch action {
+                // TODO: 이니셜라이저로
             case .onAppear:
                 return .send(.fetchNotices)
 
@@ -182,18 +183,18 @@ public struct NoticeListFeature {
                 .cancellable(id: CancelID.fetchNotices, cancelInFlight: true)
 
             case let .noticesResponse(.success(noticesResult)):
-                let noticeType = noticesResult.provider
+                let provider = noticesResult.provider
                 let notices = noticesResult.notices
-                if state.noticeDictionary[noticeType] == nil {
-                    state.noticeDictionary[noticeType] = State.NoticeInfo()
+                if state.noticeDictionary[provider] == nil {
+                    state.noticeDictionary[provider] = State.NoticeInfo()
                 }
-                guard var noticeInfo = state.noticeDictionary[noticeType] else { return .none }
+                guard var noticeInfo = state.noticeDictionary[provider] else { return .none }
 
                 noticeInfo.hasNextList = notices.count >= noticeInfo.loadLimit
                 noticeInfo.page += 1
                 noticeInfo.notices += notices
 
-                state.noticeDictionary[noticeType] = noticeInfo
+                state.noticeDictionary[provider] = noticeInfo
                 state.isLoading = false
                 return .none
 

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
@@ -126,7 +126,7 @@ public struct NoticeListFeature {
             case .changeDepartmentButtonTapped:
                 state.changeDepartment = DepartmentSelectorFeature.State(
                     currentDepartment: state.provider,
-                    addedDepartment: IdentifiedArray(uniqueElements: NoticeProvider.departments) // TODO: Dependency
+                    addedDepartment: IdentifiedArray(uniqueElements: NoticeProvider.addedDepartments)
                 )
                 return .none
 
@@ -143,6 +143,10 @@ public struct NoticeListFeature {
                     return .none
                 }
                 state.provider = selectedDepartment
+                NoticeProvider.allNamesForPicker.updateValue(
+                    state.provider,
+                    forKey: "학과"
+                )
                 return .none
 
             case .changeDepartment(.dismiss):
@@ -168,7 +172,9 @@ public struct NoticeListFeature {
                             TaskResult {
                                 let notices = try await kuringLink.fetchNotices(
                                     retrievalInfo.loadLimit,
-                                    provider.category == .학과 ? "dep" : provider.hostPrefix, // TODO: korean name 도 쓸 거 고려해서 문자열 말고 좀 더 나은걸로
+                                    provider.category == .학과 
+                                    ? "dep" // TODO: korean name 도 쓸 거 고려해서 문자열 말고 좀 더 나은걸로
+                                    : provider.hostPrefix,
                                     department,
                                     retrievalInfo.page
                                 )
@@ -217,6 +223,12 @@ public struct NoticeListFeature {
 
             case let .providerChanged(provider):
                 state.provider = provider
+                if provider.category == .학과 {
+                    NoticeProvider.allNamesForPicker.updateValue(
+                        provider,
+                        forKey: "학과"
+                    )
+                }
                 return .send(.fetchNotices)
 
             case .binding, .delegate, .changeDepartment:

--- a/package-kuring/Sources/Features/SubscriptionFeatures/Subscription.swift
+++ b/package-kuring/Sources/Features/SubscriptionFeatures/Subscription.swift
@@ -14,14 +14,16 @@ public struct SubscriptionFeature {
         public var subscriptionType: SubscriptionType = .university
 
         /// 대학 공지 리스트
-        public let univNoticeTypes: IdentifiedArrayOf<NoticeProvider> = IdentifiedArray(uniqueElements: NoticeProvider.univNoticeTypes)
+        public let univNoticeTypes: IdentifiedArrayOf<NoticeProvider> = IdentifiedArray(
+            uniqueElements: NoticeProvider.univNoticeTypes
+        )
         /// 대학 공지 리스트 중 내가 구독한 공지
-        public var selectedUnivNoticeType: IdentifiedArrayOf<NoticeProvider> = []
+        public var selectedUnivNoticeType: IdentifiedArrayOf<NoticeProvider>
 
         /// 내가 추가한 공지 리스트
-        public var myDepartments: IdentifiedArrayOf<NoticeProvider> = IdentifiedArray(uniqueElements: NoticeProvider.departments)
+        public var myDepartments: IdentifiedArrayOf<NoticeProvider>
         /// 내가 추가한 공지 리스트 중 지금 선택한 학과
-        public var selectedDepartment: IdentifiedArrayOf<NoticeProvider> = []
+        public var selectedDepartment: IdentifiedArrayOf<NoticeProvider>
 
         public var isWaitingResponse: Bool = false
 
@@ -32,8 +34,12 @@ public struct SubscriptionFeature {
 
         public init(
             subscriptionType: SubscriptionType = .university,
-            selectedUnivNoticeType: IdentifiedArrayOf<NoticeProvider> = [],
-            myDepartments: IdentifiedArrayOf<NoticeProvider> = IdentifiedArray(uniqueElements: NoticeProvider.departments),
+            selectedUnivNoticeType: IdentifiedArrayOf<NoticeProvider> = IdentifiedArray(
+                uniqueElements: NoticeProvider.subscribedUnivNoticeTypes
+            ),
+            myDepartments: IdentifiedArrayOf<NoticeProvider> = IdentifiedArray(
+                uniqueElements: NoticeProvider.addedDepartments
+            ),
             selectedDepartment: IdentifiedArrayOf<NoticeProvider> = [],
             isWaitingResponse: Bool = false
         ) {

--- a/package-kuring/Sources/Models/Notice.swift
+++ b/package-kuring/Sources/Models/Notice.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 
+/// 공지
 public struct Notice: Codable, Hashable, Identifiable, Equatable {
     public var id: String { "\(category)_\(articleId)" }
     /// e.g., `"5b45b56"`
@@ -36,6 +37,14 @@ public struct Notice: Codable, Hashable, Identifiable, Equatable {
 
 // MARK: - Push Notification
 extension Notice {
+    /// 푸시 알림으로 부터 공지를 생성합니다
+    /// ```swift
+    /// let userInfo = resposne.notification.request.content.userInfo as? [String: Any]
+    /// guard let userInfo else { return }
+    /// guard userInfo["type"] == "notice" else { return }
+    ///
+    /// try Notice(userInfo: userInfo)
+    /// ```
     public init(userInfo: [String: Any]) throws {
         guard let articleID = userInfo["articleId"] as? String else {
             throw DecodingError.noArticleID
@@ -64,11 +73,18 @@ extension Notice {
         )
     }
     
+    /// 서버값으로 부터 공지 알림을 디코딩 하지 못했을 때 던지는 에러.
+    /// - Note: 현재는 푸시 알림 디코딩에만 사용되고 있습니다.
     public enum DecodingError: Error {
+        /// `articleId` 없음
         case noArticleID
+        /// `subject` 없음
         case noSubject
+        /// `category` 없음
         case noCategory
+        /// `postedDate`  없음
         case noPostedDate
+        /// URL 정보 없음
         case noURL
     }
 }
@@ -104,6 +120,8 @@ extension Notice {
     }
 }
 
+/// 검색된 공지
+/// - Note: 서버의 json 데이터의 depth 가 달라 추가된 모델
 public struct SearchedNotice: Codable, Hashable {
     public var id: String { baseUrl }
     /// e.g., `"5b45b56"`

--- a/package-kuring/Sources/Models/NoticeProvider.swift
+++ b/package-kuring/Sources/Models/NoticeProvider.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import OrderedCollections
 
 /// 공지 제공자 카테고리
 public enum NoticeType: String, Hashable, CaseIterable, Identifiable, Equatable {
@@ -16,9 +17,17 @@ public enum NoticeType: String, Hashable, CaseIterable, Identifiable, Equatable 
     public var provider: NoticeProvider {
         switch self {
         case .학과:
-            return NoticeProvider.departments.first ?? NoticeProvider.emptyDepartment
+            return NoticeProvider.addedDepartments.first ?? NoticeProvider.emptyDepartment
         case .대학:
             return NoticeProvider.학사
+        case .세팅하지않음:
+            // Invalid value
+            return NoticeProvider(
+                name: "", 
+                hostPrefix: "",
+                korName: "",
+                category: .세팅하지않음
+            )
         }
     }
 }
@@ -62,6 +71,33 @@ public struct NoticeProvider: Identifiable, Equatable, Hashable, Decodable {
         self.korName = try container.decode(String.self, forKey: .korName)
         self.category = .세팅하지않음
     }
+}
+
+extension NoticeProvider {
+    /// 공지 카테고리들 (`학과 학사 취창업 도서관 ...`)
+    /// - Important: 학과 카테고리에서 보여질 학과 값을 저장하기 위해 학과의 경우 선택될 때마다 `allNamesForPicker["학과"]`값이 변경되어야 합니다.
+    public static var allNamesForPicker: OrderedDictionary<String, NoticeProvider> = [
+        "학과": addedDepartments.first ?? .emptyDepartment,
+        "학사": .학사,
+        "취창업": .취창업,
+        "도서관": .도서관,
+        "학생": .학생,
+        "국제": .국제,
+        "장학": .장학,
+        "산학": .산학,
+        "일반": .일반,
+    ] {
+        didSet {
+            print(allNamesForPicker)
+        }
+    }
+    
+    public static let invalid = NoticeProvider(
+        name: "",
+        hostPrefix: "",
+        korName: "",
+        category: .세팅하지않음
+    )
 }
 
 // MARK: - 대학 공지
@@ -139,6 +175,7 @@ extension NoticeProvider {
     /// 앱 실행 시 모든 학과 정보를 가져와서 여기에 저장. 그 이후로 다음 앱 실행 전까지 로컬 값만 사용합니다.
     /// 네트워크 요청 실패시 로컬에 저장된 값을 default 값으로 사용합니다.
     public static var departments: [NoticeProvider] = [
+        // TODO: remove mock
         NoticeProvider(
             name: "education",
             hostPrefix: "edu",
@@ -158,15 +195,52 @@ extension NoticeProvider {
             category: .학과
         ),
     ]
-    /// 추가한 학과 (구독여부와 상관없음)
-    public static var addedDepartments: [NoticeProvider]
-    /// 구독한 학과
-    public static var subscribedDepartments: [NoticeProvider] = []
     
+    // TODO: UserDefaults 저장
+    /// 추가한 학과 (구독여부와 상관없음)
+    public static var addedDepartments: [NoticeProvider] = [
+        // TODO: remove mock
+        NoticeProvider(
+            name: "education",
+            hostPrefix: "edu",
+            korName: "교직과",
+            category: .학과
+        ),
+        NoticeProvider(
+            name: "physical_education",
+            hostPrefix: "kupe",
+            korName: "체육교육과",
+            category: .학과
+        ),
+        NoticeProvider(
+            name: "computer_science",
+            hostPrefix: "cse",
+            korName: "컴퓨터공학부",
+            category: .학과
+        ),
+    ]
+    /// 구독한 학과
+    public static var subscribedDepartments: [NoticeProvider] = [
+        // TODO: remove mock
+        NoticeProvider(
+            name: "education",
+            hostPrefix: "edu",
+            korName: "교직과",
+            category: .학과
+        ),
+    ]
+    /// 빈 학과
+    /// - Note: `departmentType(_:)` 인자에 이 값을 넣으면 학과 추가하기 떠야 합니다.
     public static let emptyDepartment = NoticeProvider(
         name: "",
         hostPrefix: "",
-        korName: "",
+        korName: "학과",
         category: .학과
     )
+    
+    /// 공지 카테고리 리스트에 쓰이는 학과 카테고리
+    /// - Parameter department: 보여질 학과 학과
+    public static func departmentTypes(_ department: NoticeProvider?) -> NoticeProvider {
+        department ?? .emptyDepartment
+    }
 }

--- a/package-kuring/Sources/Models/NoticeProvider.swift
+++ b/package-kuring/Sources/Models/NoticeProvider.swift
@@ -110,6 +110,7 @@ extension NoticeProvider {
         .학사, .취창업, .도서관, .학생, .국제, .장학, .산학, .일반,
     ]
     
+    // TODO: UserDefaults 저장
     public static var subscribedUnivNoticeTypes: [NoticeProvider] = []
     
     public static let 학사 = NoticeProvider(
@@ -176,49 +177,51 @@ extension NoticeProvider {
     /// 네트워크 요청 실패시 로컬에 저장된 값을 default 값으로 사용합니다.
     public static var departments: [NoticeProvider] = [
         // TODO: remove mock
-        NoticeProvider(
-            name: "education",
-            hostPrefix: "edu",
-            korName: "교직과",
-            category: .학과
-        ),
-        NoticeProvider(
-            name: "physical_education",
-            hostPrefix: "kupe",
-            korName: "체육교육과",
-            category: .학과
-        ),
-        NoticeProvider(
-            name: "computer_science",
-            hostPrefix: "cse",
-            korName: "컴퓨터공학부",
-            category: .학과
-        ),
+//        NoticeProvider(
+//            name: "education",
+//            hostPrefix: "edu",
+//            korName: "교직과",
+//            category: .학과
+//        ),
+//        NoticeProvider(
+//            name: "physical_education",
+//            hostPrefix: "kupe",
+//            korName: "체육교육과",
+//            category: .학과
+//        ),
+//        NoticeProvider(
+//            name: "computer_science",
+//            hostPrefix: "cse",
+//            korName: "컴퓨터공학부",
+//            category: .학과
+//        ),
     ]
     
     // TODO: UserDefaults 저장
     /// 추가한 학과 (구독여부와 상관없음)
     public static var addedDepartments: [NoticeProvider] = [
         // TODO: remove mock
-        NoticeProvider(
-            name: "education",
-            hostPrefix: "edu",
-            korName: "교직과",
-            category: .학과
-        ),
-        NoticeProvider(
-            name: "physical_education",
-            hostPrefix: "kupe",
-            korName: "체육교육과",
-            category: .학과
-        ),
-        NoticeProvider(
-            name: "computer_science",
-            hostPrefix: "cse",
-            korName: "컴퓨터공학부",
-            category: .학과
-        ),
+//        NoticeProvider(
+//            name: "education",
+//            hostPrefix: "edu",
+//            korName: "교직과",
+//            category: .학과
+//        ),
+//        NoticeProvider(
+//            name: "physical_education",
+//            hostPrefix: "kupe",
+//            korName: "체육교육과",
+//            category: .학과
+//        ),
+//        NoticeProvider(
+//            name: "computer_science",
+//            hostPrefix: "cse",
+//            korName: "컴퓨터공학부",
+//            category: .학과
+//        ),
     ]
+    
+    // TODO: UserDefaults 저장
     /// 구독한 학과
     public static var subscribedDepartments: [NoticeProvider] = [
         // TODO: remove mock

--- a/package-kuring/Sources/Models/NoticeProvider.swift
+++ b/package-kuring/Sources/Models/NoticeProvider.swift
@@ -5,42 +5,48 @@
 
 import Foundation
 
+/// 공지 제공자 카테고리
 public enum NoticeType: String, Hashable, CaseIterable, Identifiable, Equatable {
-    case 학과, 학사, 장학, 도서관, 취창업, 국제, 학생, 산학, 일반
+    case 학과, 대학, 세팅하지않음
 
     public var id: Self { self }
 
+    // TODO: defaultProvider
+    /// 카테고리 별 첫번째(기본) 제공자
     public var provider: NoticeProvider {
         switch self {
         case .학과:
             return NoticeProvider.departments.first ?? NoticeProvider.emptyDepartment
-        case .학사:
-            return .학사
-        case .장학:
-            return .장학
-        case .도서관:
-            return .도서관
-        case .취창업:
-            return .취창업
-        case .국제:
-            return .국제
-        case .학생:
-            return .학생
-        case .산학:
-            return .산학
-        case .일반:
-            return .일반
+        case .대학:
+            return NoticeProvider.학사
         }
     }
 }
 
-public struct NoticeProvider: Identifiable, Equatable, Hashable {
+/// 공지 제공자.
+/// 일반, 학사, 장학과 같은 대학 공지 카테고리, 전기전자공학부, 컴퓨터공학부, 산업디자인학과와 같은 학과들처럼 공지를 제공하는 주체.
+/// - Note: ``NoticeProvider/category`` 프로퍼티로 상위 카테고리를 관리합니다.
+public struct NoticeProvider: Identifiable, Equatable, Hashable, Decodable {
+    /// ``hostPrefix`` 를 식별자로 사용합니다.
     public var id: String { hostPrefix }
 
+    /// 공지 제공자 이름 (영문)
+    /// - Note: 국문 이름은 ``korName``.
     public let name: String
+    /// 공지 제공자 호스트 Prefix.
+    /// - Important: ID 로 사용합니다.
     public let hostPrefix: String
+    /// 공지 제공자 이름 (국문)
     public let korName: String
+    /// 상위 카테고리. 예) 대학공지, 학과공지
+    /// - Note: 서버값으로 부터 디코딩을 하지 않는 값이므로 직접 세팅해줘야 합니다.
     public var category: NoticeType
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case hostPrefix
+        case korName
+    }
 
     public init(name: String, hostPrefix: String, korName: String, category: NoticeType) {
         self.name = name
@@ -48,80 +54,91 @@ public struct NoticeProvider: Identifiable, Equatable, Hashable {
         self.korName = korName
         self.category = category
     }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.hostPrefix = try container.decode(String.self, forKey: .hostPrefix)
+        self.korName = try container.decode(String.self, forKey: .korName)
+        self.category = .세팅하지않음
+    }
 }
 
+// MARK: - 대학 공지
 extension NoticeProvider {
-    public static let emptyDepartment = NoticeProvider(
-        name: "",
-        hostPrefix: "",
-        korName: "",
-        category: .학과
-    )
-
+    // TODO: Swift Data 에서 가져오기
+    // TODO: 순서는?
+    /// 앱 실행 시 모든 학과 정보를 가져와서 여기에 저장. 그 이후로 다음 앱 실행 전까지 로컬 값만 사용합니다.
+    /// 네트워크 요청 실패시 로컬에 저장된 값을 default 값으로 사용합니다.
+    public static var univNoticeTypes: [NoticeProvider] = [
+        .학사, .취창업, .도서관, .학생, .국제, .장학, .산학, .일반,
+    ]
+    
+    public static var subscribedUnivNoticeTypes: [NoticeProvider] = []
+    
     public static let 학사 = NoticeProvider(
         name: "bachelor",
         hostPrefix: "bch",
         korName: "학사",
-        category: .학사
+        category: .대학
     )
 
     public static let 취창업 = NoticeProvider(
         name: "employment",
         hostPrefix: "emp",
         korName: "취창업",
-        category: .취창업
+        category: .대학
     )
 
     public static let 도서관 = NoticeProvider(
         name: "library",
         hostPrefix: "lib",
         korName: "도서관",
-        category: .도서관
+        category: .대학
     )
 
     public static let 학생 = NoticeProvider(
         name: "student",
         hostPrefix: "stu",
         korName: "학생",
-        category: .학생
+        category: .대학
     )
 
     public static let 국제 = NoticeProvider(
         name: "national",
         hostPrefix: "nat",
         korName: "국제",
-        category: .국제
+        category: .대학
     )
 
     public static let 장학 = NoticeProvider(
         name: "scholarship",
         hostPrefix: "sch",
         korName: "장학",
-        category: .장학
+        category: .대학
     )
 
     public static let 산학 = NoticeProvider(
         name: "industry_university",
         hostPrefix: "ind",
         korName: "산학",
-        category: .산학
+        category: .대학
     )
 
     public static let 일반 = NoticeProvider(
         name: "normal",
         hostPrefix: "nor",
         korName: "일반",
-        category: .일반
+        category: .대학
     )
-
-    public static let univNoticeTypes: [NoticeProvider] = [
-        .학사, .취창업, .도서관, .학생, .국제, .장학, .산학, .일반,
-    ]
 }
 
-/// Mock 데이터
+// MARK: - 학과 공지
 extension NoticeProvider {
-    public static let departments: [NoticeProvider] = [
+    // TODO: Swift Data 에서 가져오기
+    /// 앱 실행 시 모든 학과 정보를 가져와서 여기에 저장. 그 이후로 다음 앱 실행 전까지 로컬 값만 사용합니다.
+    /// 네트워크 요청 실패시 로컬에 저장된 값을 default 값으로 사용합니다.
+    public static var departments: [NoticeProvider] = [
         NoticeProvider(
             name: "education",
             hostPrefix: "edu",
@@ -141,4 +158,15 @@ extension NoticeProvider {
             category: .학과
         ),
     ]
+    /// 추가한 학과 (구독여부와 상관없음)
+    public static var addedDepartments: [NoticeProvider]
+    /// 구독한 학과
+    public static var subscribedDepartments: [NoticeProvider] = []
+    
+    public static let emptyDepartment = NoticeProvider(
+        name: "",
+        hostPrefix: "",
+        korName: "",
+        category: .학과
+    )
 }

--- a/package-kuring/Sources/Models/Staff.swift
+++ b/package-kuring/Sources/Models/Staff.swift
@@ -5,13 +5,21 @@
 
 import Foundation
 
+/// 교직원
 public struct Staff: Codable, Hashable, Equatable {
+    /// 교직원 이름
     public let name: String
+    /// 교직원 소속 단과대학
     public let collegeName: String
+    /// 교직원 소속 학부
     public let deptName: String
+    /// 교직원 세부 전공
     public let major: String
+    /// 교직원 연구실 위치
     public let lab: String
+    /// 교직원 전화번호
     public let phone: String
+    /// 교직원 이메일주소
     public let email: String
 }
 

--- a/package-kuring/Sources/Models/Subscription.swift
+++ b/package-kuring/Sources/Models/Subscription.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 
+/// 서버로 전송하는 **대학공지** 구독 정보 값
 public struct UnivNoticeSubscription: Codable {
     public let categories: [String]
 
@@ -13,6 +14,7 @@ public struct UnivNoticeSubscription: Codable {
     }
 }
 
+/// 서버로 전송하는 **학과** 구독 정보 값
 public struct DepartmentSubscription: Codable {
     public let departments: [String]
 

--- a/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
+++ b/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
@@ -102,6 +102,69 @@ extension KuringLink: DependencyKey {
                 )
             let isSucceed = (200 ..< 300) ~= response.code
             return isSucceed
+        },
+        getSubscribedUnivNotices: {
+            let response: Response<[NoticeProvider]> = try await satellite
+                .response(
+                    for: Path.getSubscribedUnivNotices.path,
+                    httpMethod: .get,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "User-Token": fcmToken
+                    ]
+                )
+            // 로컬 값 갱신
+            NoticeProvider.subscribedUnivNoticeTypes = response.data
+                .compactMap { $0.category = .대학 }
+            return NoticeProvider.subscribedUnivNoticeTypes
+        },
+        getSubscribedDepartments: {
+            let response: Response<[NoticeProvider]> = try await satellite
+                .response(
+                    for: Path.getSubscribedDepartments.path,
+                    httpMethod: .get,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "User-Token": fcmToken
+                    ]
+                )
+            
+            // 로컬 값 갱신
+            NoticeProvider.subscribedDepartments = response.data
+                .compactMap { $0.category = .학과 }
+            return NoticeProvider.subscribedDepartments
+        },
+        getAllUnivNoticeType: {
+            let response: Response<[NoticeProvider]> = try await satellite
+                .response(
+                    for: Path.getAllUnivNoticeType.path,
+                    httpMethod: .get,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "User-Token": fcmToken
+                    ]
+                )
+            
+            // 로컬 값 갱신
+            NoticeProvider.univNoticeTypes = response.data
+                .compactMap { $0.category = .대학}
+            return NoticeProvider.univNoticeTypes
+        },
+        getAllDepartments: {
+            let response: Response<[NoticeProvider]> = try await satellite
+                .response(
+                    for: Path.getAllDepartments.path,
+                    httpMethod: .get,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "User-Token": fcmToken
+                    ]
+                )
+            
+            // 로컬 값 갱신
+            NoticeProvider.departments = response.data
+                .compactMap { $0.category = .학과 }
+            return NoticeProvider.departments
         }
     )
 }
@@ -125,6 +188,64 @@ extension KuringLink {
         },
         subscribeDepartments: { _ in
             true
+        },
+        getSubscribedUnivNotices: {
+            [
+                NoticeProvider.학사,
+                NoticeProvider.도서관
+            ]
+        },
+        getSubscribedDepartments: {
+            NoticeProvider(
+                name: "education",
+                hostPrefix: "edu",
+                korName: "교직과",
+                category: .학과
+            ),
+            NoticeProvider(
+                name: "physical_education",
+                hostPrefix: "kupe",
+                korName: "체육교육과",
+                category: .학과
+            ),
+            NoticeProvider(
+                name: "computer_science",
+                hostPrefix: "cse",
+                korName: "컴퓨터공학부",
+                category: .학과
+            )
+        },
+        getAllUnivNoticeType: {
+            [
+                NoticeProvider.학사,
+                NoticeProvider.취창업,
+                NoticeProvider.도서관,
+                NoticeProvider.학생,
+                NoticeProvider.국제,
+                NoticeProvider.장학,
+                NoticeProvider.산학,
+                NoticeProvider.일반,
+            ]
+        },
+        getAllDepartments: {
+            NoticeProvider(
+                name: "education",
+                hostPrefix: "edu",
+                korName: "교직과",
+                category: .학과
+            ),
+            NoticeProvider(
+                name: "physical_education",
+                hostPrefix: "kupe",
+                korName: "체육교육과",
+                category: .학과
+            ),
+            NoticeProvider(
+                name: "computer_science",
+                hostPrefix: "cse",
+                korName: "컴퓨터공학부",
+                category: .학과
+            )
         }
     )
 }

--- a/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
+++ b/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
@@ -5,6 +5,7 @@
 
 import Models
 import Foundation
+import OrderedCollections
 import ComposableArchitecture
 
 extension DependencyValues {
@@ -115,7 +116,14 @@ extension KuringLink: DependencyKey {
                 )
             // 로컬 값 갱신
             NoticeProvider.subscribedUnivNoticeTypes = response.data
-                .compactMap { $0.category = .대학 }
+                .compactMap {
+                    NoticeProvider(
+                        name: $0.name,
+                        hostPrefix: $0.hostPrefix,
+                        korName: $0.korName,
+                        category: .대학
+                    )
+                }
             return NoticeProvider.subscribedUnivNoticeTypes
         },
         getSubscribedDepartments: {
@@ -131,7 +139,14 @@ extension KuringLink: DependencyKey {
             
             // 로컬 값 갱신
             NoticeProvider.subscribedDepartments = response.data
-                .compactMap { $0.category = .학과 }
+                .compactMap {
+                    NoticeProvider(
+                        name: $0.name, 
+                        hostPrefix: $0.hostPrefix,
+                        korName: $0.korName,
+                        category: .학과
+                    )
+                }
             return NoticeProvider.subscribedDepartments
         },
         getAllUnivNoticeType: {
@@ -147,7 +162,23 @@ extension KuringLink: DependencyKey {
             
             // 로컬 값 갱신
             NoticeProvider.univNoticeTypes = response.data
-                .compactMap { $0.category = .대학}
+                .compactMap {
+                    NoticeProvider(
+                        name: $0.name,
+                        hostPrefix: $0.hostPrefix,
+                        korName: $0.korName,
+                        category: .대학
+                    )
+                }
+            var namesForPicker: OrderedDictionary<String, NoticeProvider> = [:]
+            namesForPicker.updateValue(
+                NoticeProvider.addedDepartments.first ?? .emptyDepartment,
+                forKey: "학과"
+            )
+            NoticeProvider.univNoticeTypes.forEach {
+                namesForPicker.updateValue($0, forKey: $0.korName)
+            }
+            NoticeProvider.allNamesForPicker = namesForPicker
             return NoticeProvider.univNoticeTypes
         },
         getAllDepartments: {
@@ -163,7 +194,14 @@ extension KuringLink: DependencyKey {
             
             // 로컬 값 갱신
             NoticeProvider.departments = response.data
-                .compactMap { $0.category = .학과 }
+                .compactMap {
+                    NoticeProvider(
+                        name: $0.name,
+                        hostPrefix: $0.hostPrefix,
+                        korName: $0.korName,
+                        category: .학과
+                    )
+                }
             return NoticeProvider.departments
         }
     )
@@ -196,24 +234,26 @@ extension KuringLink {
             ]
         },
         getSubscribedDepartments: {
-            NoticeProvider(
-                name: "education",
-                hostPrefix: "edu",
-                korName: "교직과",
-                category: .학과
-            ),
-            NoticeProvider(
-                name: "physical_education",
-                hostPrefix: "kupe",
-                korName: "체육교육과",
-                category: .학과
-            ),
-            NoticeProvider(
-                name: "computer_science",
-                hostPrefix: "cse",
-                korName: "컴퓨터공학부",
-                category: .학과
-            )
+            [
+                NoticeProvider(
+                    name: "education",
+                    hostPrefix: "edu",
+                    korName: "교직과",
+                    category: .학과
+                ),
+                NoticeProvider(
+                    name: "physical_education",
+                    hostPrefix: "kupe",
+                    korName: "체육교육과",
+                    category: .학과
+                ),
+                NoticeProvider(
+                    name: "computer_science",
+                    hostPrefix: "cse",
+                    korName: "컴퓨터공학부",
+                    category: .학과
+                )
+            ]
         },
         getAllUnivNoticeType: {
             [
@@ -228,24 +268,26 @@ extension KuringLink {
             ]
         },
         getAllDepartments: {
-            NoticeProvider(
-                name: "education",
-                hostPrefix: "edu",
-                korName: "교직과",
-                category: .학과
-            ),
-            NoticeProvider(
-                name: "physical_education",
-                hostPrefix: "kupe",
-                korName: "체육교육과",
-                category: .학과
-            ),
-            NoticeProvider(
-                name: "computer_science",
-                hostPrefix: "cse",
-                korName: "컴퓨터공학부",
-                category: .학과
-            )
+            [
+                NoticeProvider(
+                    name: "education",
+                    hostPrefix: "edu",
+                    korName: "교직과",
+                    category: .학과
+                ),
+                NoticeProvider(
+                    name: "physical_education",
+                    hostPrefix: "kupe",
+                    korName: "체육교육과",
+                    category: .학과
+                ),
+                NoticeProvider(
+                    name: "computer_science",
+                    hostPrefix: "cse",
+                    korName: "컴퓨터공학부",
+                    category: .학과
+                )
+            ]
         }
     )
 }

--- a/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
+++ b/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
@@ -170,14 +170,15 @@ extension KuringLink: DependencyKey {
                         category: .대학
                     )
                 }
-            var namesForPicker: OrderedDictionary<String, NoticeProvider> = [:]
+            var namesForPicker: OrderedDictionary<String, NoticeProvider> = ["학과": NoticeProvider.emptyDepartment] // 학과 순위 첫번째 보장
+            NoticeProvider.univNoticeTypes.forEach {
+                namesForPicker.updateValue($0, forKey: $0.korName)
+            }
+            // 서버에서 `hostPrefix: "dep"`, `korName: "학과"` 를 내려주기 때문에 업데이트 필요함
             namesForPicker.updateValue(
                 NoticeProvider.addedDepartments.first ?? .emptyDepartment,
                 forKey: "학과"
             )
-            NoticeProvider.univNoticeTypes.forEach {
-                namesForPicker.updateValue($0, forKey: $0.korName)
-            }
             NoticeProvider.allNamesForPicker = namesForPicker
             return NoticeProvider.univNoticeTypes
         },

--- a/package-kuring/Sources/Networks/KuringLink/KuringLink.swift
+++ b/package-kuring/Sources/Networks/KuringLink/KuringLink.swift
@@ -4,9 +4,11 @@
 //
 
 import Models
+import SwiftUI
 import Satellite
 import Foundation
 
+// TODO: 네이밍 통일: NoticeType vs NoticeProvider vs UnivNoticeProvider
 public typealias NoticeCount = Int
 public typealias NoticeType = String
 public typealias Department = String
@@ -38,24 +40,37 @@ public struct KuringLink {
         return iosVersion
     }()
 
-    // TODO: kuring.set(\.fcmToken, "{FCM.TOKEN}")
-    static var fcmToken: String = "cZSHjO4_bUjirvsrxWzig5:APA91bHPojABL5oEXi5AcjJ8v4Vcp3KpJfFUD_3b-HhfV8m23_R6czJa3PwqcVqBZSHBb2t7Z3odUeD0cFKaMSkMmrGxTqyjJPfEZVfTPvmewV-xiMTWbrk-QKuc4Nrxd_BhEArO7Svo"
+    @AppStorage("com.kuring.sdk.token.fcm")
+    static var fcmToken: String = ""
+    
+    static var testableFCMToken: String = "cZSHjO4_bUjirvsrxWzig5:APA91bHPojABL5oEXi5AcjJ8v4Vcp3KpJfFUD_3b-HhfV8m23_R6czJa3PwqcVqBZSHBb2t7Z3odUeD0cFKaMSkMmrGxTqyjJPfEZVfTPvmewV-xiMTWbrk-QKuc4Nrxd_BhEArO7Svo"
 
     // MARK: - Notices
-
+    /// 특정 카테고리에 대한 공지를 가져옵니다.
     public var fetchNotices: (NoticeCount, NoticeType, Department?, Page) async throws -> [Notice]
-
+    
+    // MARK: - Feedback
+    /// 피드백 전송
     public var sendFeedback: (String) async throws -> Bool
 
     // MARK: - Search
-
+    /// 공지 검색하기
     public var searchNotices: (_ keyword: String) async throws -> [Notice]
-
+    /// 교직원 검색하기
     public var searchStaffs: (_ keyword: String) async throws -> [Staff]
 
     // MARK: - Subscriptions
 
+    /// 대학 공지 카테고리를 구독하기
     public var subscribeUnivNotices: ([NoticeTypeName]) async throws -> Bool
-
+    /// 학과 공지 카테고리를 구독하기
     public var subscribeDepartments: ([DepartmentHostPrefix]) async throws -> Bool
+    /// 구독한 대학 공지 카테고리 리스트
+    public var getSubscribedUnivNotices: () async throws -> [NoticeProvider]
+    /// 구독한 학과 공지 카테고리 리스트
+    public var getSubscribedDepartments: () async throws -> [NoticeProvider]
+    /// 모든 대학 공지 카테고리 가져오기
+    public var getAllUnivNoticeType: () async throws -> [NoticeProvider]
+    /// 모든 학과 공지 카테고리 가져오기
+    public var getAllDepartments: () async throws -> [NoticeProvider]
 }

--- a/package-kuring/Sources/PushNotifications/Message/Message.swift
+++ b/package-kuring/Sources/PushNotifications/Message/Message.swift
@@ -5,8 +5,11 @@
 
 import Models
 
+/// 전달 받은 푸시 알림 메세지
 public enum Message {
+    /// 공지 알림
     case notice(Notice)
+    /// 커스텀 알림
     case custom(title: String, body: String, url: String?)
 }
 

--- a/package-kuring/Sources/UIKit/CommonUI/View.onFetchAllData.swift
+++ b/package-kuring/Sources/UIKit/CommonUI/View.onFetchAllData.swift
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import SwiftUI
+import Networks
+import Dependencies
+
+struct KuringLinkFetcher: ViewModifier {
+    @State private var showsNetworkError: Bool = false
+    @Dependency(\.kuringLink) private var kuringLink
+    
+    let onRequest: () -> Void
+    let onCompletion: (Result<Void, Error>) -> Void
+    
+    func body(content: Content) -> some View {
+        content
+            .task {
+                onRequest()
+                do {
+                    @Dependency(\.kuringLink) var kuringLink
+                    let _ = try await kuringLink.getAllUnivNoticeType()
+                    let _ = try await kuringLink.getAllDepartments()
+                    let _ = try await kuringLink.getSubscribedDepartments()
+                    let _ = try await kuringLink.getSubscribedUnivNotices()
+                    onCompletion(.success(()))
+                } catch {
+                    showsNetworkError = true
+                    onCompletion(.failure(error))
+                }
+            }
+            .alert("앗! 인터넷 연결이 좋지 않아요!", isPresented: $showsNetworkError) {
+                // 무시
+                Button(role: .cancel) {
+                    showsNetworkError = false
+                } label: {
+                    Text("이해했어요")
+                }
+            } message: {
+                Text("네트워크 연결이 좋지 않아서 서버 정보를 불러오는데에 실패했어요.")
+            }
+        
+    }
+}
+
+extension View {
+    /// 쿠링링크를 통해 서버에서 공지 카테고리와 구독 정보들을 가져옵니다.
+    /// ```swift
+    /// MyView()
+    ///     .kuringLink {
+    ///         // on request
+    ///         showsProgressView = true
+    ///     } onCompletion: { result in
+    ///         showsProgressView = false
+    ///         switch result {
+    ///         case .success:
+    ///             showsSuccessMark = true
+    ///         case let .failure(error):
+    ///             showsNetworkError = true
+    ///         }
+    ///     }
+    /// ```
+    public func kuringLink(
+        onRequest: @escaping () -> Void,
+        onCompletion: @escaping (Result<Void, Error>) -> Void
+    ) -> some View {
+        modifier(
+            KuringLinkFetcher(
+                onRequest: onRequest,
+                onCompletion: onCompletion
+            )
+        )
+    }
+}
+

--- a/package-kuring/Sources/UIKit/CommonUI/View.onFetchAllData.swift
+++ b/package-kuring/Sources/UIKit/CommonUI/View.onFetchAllData.swift
@@ -20,10 +20,13 @@ struct KuringLinkFetcher: ViewModifier {
                 onRequest()
                 do {
                     @Dependency(\.kuringLink) var kuringLink
-                    let _ = try await kuringLink.getAllUnivNoticeType()
-                    let _ = try await kuringLink.getAllDepartments()
-                    let _ = try await kuringLink.getSubscribedDepartments()
-                    let _ = try await kuringLink.getSubscribedUnivNotices()
+                    async let allUnivNoticeTypes = try kuringLink.getAllUnivNoticeType()
+                    async let allDepartments = try kuringLink.getAllDepartments()
+                    let _ = try await [allUnivNoticeTypes, allDepartments]
+                    
+                    async let subscribedDepartments = try kuringLink.getSubscribedDepartments()
+                    async let subscribedUnivNotices = try kuringLink.getSubscribedUnivNotices()
+                    let _ = try await [subscribedDepartments, subscribedUnivNotices]
                     onCompletion(.success(()))
                 } catch {
                     showsNetworkError = true

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -78,8 +78,6 @@ public struct DepartmentEditor: View {
                                 store.send(.addDepartmentButtonTapped(id: result.id))
                             }
                         }
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 10)
                     }
                 }
             }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeContentView.NoDepartment.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeContentView.NoDepartment.swift
@@ -24,18 +24,7 @@ extension NoticeContentView {
 
             NavigationLink(
                 state: NoticeAppFeature.Path.State.departmentEditor(
-                    // TODO: - Mock 데이터 추후 제거
-                    DepartmentEditorFeature.State(
-                        myDepartments: IdentifiedArray(uniqueElements: NoticeProvider.departments),
-                        results: [
-                            NoticeProvider(
-                                name: "education",
-                                hostPrefix: "edu",
-                                korName: "교직과",
-                                category: .학과
-                            ),
-                        ]
-                    )
+                    DepartmentEditorFeature.State()
                 )
             ) {
                 OverlayButton("학과 추가하기")

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeContentView.NoDepartment.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeContentView.NoDepartment.swift
@@ -12,15 +12,13 @@ import ComposableArchitecture
 extension NoticeContentView {
     @ViewBuilder
     func NoDepartmentView() -> some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 32) {
             Spacer()
 
             Text("아직 추가된 학과가 없어요.\n관심 학과를 추가하고 공지를 확인해 보세요!")
                 .font(.system(size: 15, weight: .medium))
                 .multilineTextAlignment(.center)
                 .foregroundColor(.black.opacity(0.36))
-
-            Spacer()
 
             NavigationLink(
                 state: NoticeAppFeature.Path.State.departmentEditor(
@@ -30,6 +28,8 @@ extension NoticeContentView {
                 OverlayButton("학과 추가하기")
                     .padding(.horizontal, 20)
             }
+            
+            Spacer()
         }
     }
 
@@ -37,26 +37,16 @@ extension NoticeContentView {
     /// 상단에 블러가 존재하는 버튼
     @ViewBuilder
     func OverlayButton(_ title: String) -> some View {
-        HStack(alignment: .center, spacing: 10) {
-            Spacer()
+        HStack(alignment: .center, spacing: 8) {
+            Image(systemName: "plus")
 
             Text(title)
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(Color.white)
-
-            Spacer()
         }
-        .padding(.horizontal, 50)
+        .foregroundStyle(Color.white)
+        .padding(.horizontal, 36)
         .padding(.vertical, 16)
-        .frame(height: 50, alignment: .center)
         .background(Color.accentColor)
         .cornerRadius(100)
-        .background {
-            LinearGradient(
-                gradient: Gradient(colors: [.white.opacity(0.1), .white]),
-                startPoint: .top, endPoint: .bottom
-            )
-            .offset(x: 0, y: -32)
-        }
     }
 }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeTypeColumn.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeTypeColumn.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import ComposableArchitecture
 
 public struct NoticeTypeColumn: View {
+    public let title: String
     public let provider: NoticeProvider
     public let selectedID: NoticeProvider.ID
 
@@ -15,7 +16,7 @@ public struct NoticeTypeColumn: View {
         let itemSize = CGSize(width: 64, height: 48)
         let lineHeight: CGFloat = 3
 
-        Text(provider.korName)
+        Text(title)
             .font(.system(size: 16, weight: provider.id == selectedID ? .semibold : .regular))
             .padding(.vertical, 8)
             .frame(width: itemSize.width, height: itemSize.height)
@@ -36,7 +37,9 @@ public struct NoticeTypeColumn: View {
             .id(provider.id)
     }
 
-    public init(provider: NoticeProvider, selectedID: NoticeProvider.ID) {
+    /// - Parameter key: 보여질 텍스트 값
+    public init(key: String, provider: NoticeProvider, selectedID: NoticeProvider.ID) {
+        self.title = key
         self.provider = provider
         self.selectedID = selectedID
     }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeTypeColumn.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeTypeColumn.swift
@@ -8,15 +8,15 @@ import SwiftUI
 import ComposableArchitecture
 
 public struct NoticeTypeColumn: View {
-    public let noticeType: NoticeType
-    public let selectedID: NoticeType.ID
+    public let provider: NoticeProvider
+    public let selectedID: NoticeProvider.ID
 
     public var body: some View {
         let itemSize = CGSize(width: 64, height: 48)
         let lineHeight: CGFloat = 3
 
-        Text(noticeType.rawValue)
-            .font(.system(size: 16, weight: noticeType.id == selectedID ? .semibold : .regular))
+        Text(provider.korName)
+            .font(.system(size: 16, weight: provider.id == selectedID ? .semibold : .regular))
             .padding(.vertical, 8)
             .frame(width: itemSize.width, height: itemSize.height)
             .overlay {
@@ -25,19 +25,19 @@ public struct NoticeTypeColumn: View {
 
                     RoundedRectangle(cornerRadius: lineHeight / 2)
                         .frame(width: itemSize.width, height: lineHeight)
-                        .opacity(noticeType.id == selectedID ? 1 : 0)
+                        .opacity(provider.id == selectedID ? 1 : 0)
                 }
             }
             .foregroundStyle(
-                noticeType.id == selectedID
+                provider.id == selectedID
                     ? Color.accentColor
                     : Color.black.opacity(0.3)
             )
-            .id(noticeType.id)
+            .id(provider.id)
     }
 
-    public init(noticeType: NoticeType, selectedID: NoticeType.ID) {
-        self.noticeType = noticeType
+    public init(provider: NoticeProvider, selectedID: NoticeProvider.ID) {
+        self.provider = provider
         self.selectedID = selectedID
     }
 }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeTypePicker.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeTypePicker.swift
@@ -14,13 +14,13 @@ public struct NoticeCategoryPicker: View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 0) {
-                    ForEach(NoticeType.allCases, id: \.self) { category in
+                    ForEach(NoticeProvider.univNoticeTypes) { provider in
                         Button {
-                            selection = category.provider
+                            selection = provider
                         } label: {
                             NoticeTypeColumn(
-                                noticeType: category,
-                                selectedID: selection.category.id
+                                provider: provider,
+                                selectedID: selection.provider.id
                             )
                         }
                         .buttonStyle(.plain)
@@ -29,7 +29,7 @@ public struct NoticeCategoryPicker: View {
                 .padding(.leading, 10)
                 .onChange(of: selection) { value in
                     withAnimation {
-                        proxy.scrollTo(value.category.id, anchor: .center)
+                        proxy.scrollTo(value.provider.id, anchor: .center)
                     }
                 }
             }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeTypePicker.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeTypePicker.swift
@@ -9,27 +9,31 @@ import ComposableArchitecture
 
 public struct NoticeCategoryPicker: View {
     @Binding var selection: NoticeProvider
-
+    
     public var body: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 0) {
-                    ForEach(NoticeProvider.univNoticeTypes) { provider in
+                    ForEach(
+                        NoticeProvider.allNamesForPicker.compactMap({ $0.key }),
+                        id: \.self
+                    ) { key in
                         Button {
-                            selection = provider
+                            selection = NoticeProvider.allNamesForPicker[key] ?? .invalid
                         } label: {
                             NoticeTypeColumn(
-                                provider: provider,
-                                selectedID: selection.provider.id
+                                key: key,
+                                provider: NoticeProvider.allNamesForPicker[key] ?? .invalid,
+                                selectedID: selection.id
                             )
                         }
                         .buttonStyle(.plain)
                     }
                 }
                 .padding(.leading, 10)
-                .onChange(of: selection) { value in
+                .onChange(of: selection) { _, value in
                     withAnimation {
-                        proxy.scrollTo(value.provider.id, anchor: .center)
+                        proxy.scrollTo(value.id, anchor: .center)
                     }
                 }
             }

--- a/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
+++ b/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
@@ -3,6 +3,7 @@
 // See the 'License.txt' file for licensing information.
 //
 
+import Models
 import SwiftUI
 import DepartmentFeatures
 import SubscriptionFeatures
@@ -156,10 +157,7 @@ struct SubscriptionView: View {
                 /// 학과 추가/편집하기 버튼 - `DepartmentEditor` 로 이동
                 NavigationLink(
                     state: SubscriptionAppFeature.Path.State.departmentEditor(
-                        // TODO: init parameter 값 수정 (현재는 테스트용)
-                        DepartmentEditorFeature.State(
-                            myDepartments: store.myDepartments
-                        )
+                        DepartmentEditorFeature.State()
                     )
                 ) {
                     HStack(alignment: .center, spacing: 10) {

--- a/package-kuring/Tests/SubscriptionFeaturesTests/SubscriptionAppTests.swift
+++ b/package-kuring/Tests/SubscriptionFeaturesTests/SubscriptionAppTests.swift
@@ -71,6 +71,17 @@ class SubscriptionAppTests: XCTestCase {
             $0.path[id: 0, case: /SubscriptionAppFeature.Path.State.departmentEditor]?.alert = nil
             $0.path[id: 0, case: /SubscriptionAppFeature.Path.State.departmentEditor]?.myDepartments = []
         }
+        
+        await store.receive(
+            .path(
+                .element(
+                    id: 0,
+                    action: .departmentEditor(
+                        .delegate(.addedDepartmentsUpdated)
+                    )
+                )
+            )
+        )
 
         await store.send(
             .path(
@@ -107,6 +118,17 @@ class SubscriptionAppTests: XCTestCase {
             $0.path[id: 0, case: /SubscriptionAppFeature.Path.State.departmentEditor]?.alert = nil
             $0.path[id: 0, case: /SubscriptionAppFeature.Path.State.departmentEditor]?.myDepartments = [체육교육과]
         }
+        
+        await store.receive(
+            .path(
+                .element(
+                    id: 0,
+                    action: .departmentEditor(
+                        .delegate(.addedDepartmentsUpdated)
+                    )
+                )
+            )
+        )
         
         await store.send(.path(.popFrom(id: 0))) {
             $0.path = .init()


### PR DESCRIPTION
### 스크린샷

| 추가된 학과 없을 때 | 학과 검색 | 학과 추가 |
| --- | --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-26 at 00 59 28](https://github.com/ku-ring/ios-app/assets/53814741/7d49fa42-cde5-495a-8b11-92d253eda88a) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-25 at 01 05 47](https://github.com/ku-ring/ios-app/assets/53814741/55362a33-1776-409d-a852-299b350bfeae) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-25 at 01 37 00](https://github.com/ku-ring/ios-app/assets/53814741/c82c0b50-ca2b-426e-b953-4e00a3c9dec8) |



| 추가 후 검색 창 | 공지 리스트 화면 | 대표학과 선택 |
| --- | --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-25 at 01 36 57](https://github.com/ku-ring/ios-app/assets/53814741/8a4b9c6d-c7ea-47c1-b826-e46cd62b09a5) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-25 at 01 40 33](https://github.com/ku-ring/ios-app/assets/53814741/54809767-4a3b-4ded-bae8-c7075614b4cb) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-25 at 01 36 53](https://github.com/ku-ring/ios-app/assets/53814741/34f38a84-9a2e-47fb-844a-7f68457aef45) |

### `KuringLinkFetcher`

쿠링링크를 통해 서버에서 공지 카테고리와 구독 정보들을 가져옵니다.

```swift
ContentView()
    .kuringLink(
        onRequest: {
            print("onRequest")
        }, onCompletion: { result in
            print("onCompletion: \(result)")
        }
    )
```