### PR TITLE
[2.0.0] 버그 수정: [RTIInputSystemClient remoteTextInputSessionWithID:performInputOperation:] perform input operation requires a valid sessionID

### DIFF
--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -28,6 +28,7 @@ public struct DepartmentEditor: View {
 
                 TextField("추가할 학과를 검색해 주세요", text: $store.searchText)
                     .focused($focus, equals: .search)
+                    .autocorrectionDisabled()
                     .bind($store.focus, to: self.$focus)
 
                 if !store.searchText.isEmpty {

--- a/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
+++ b/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
@@ -36,6 +36,7 @@ public struct SearchView: View {
 
                     TextField("검색어를 입력해주세요", text: $store.searchInfo.text)
                         .focused($focus, equals: .search)
+                        .autocorrectionDisabled()
                         .onSubmit { store.send(.search) }
 
                     if store.searchInfo.searchPhase == .searching {


### PR DESCRIPTION
### 버그

> [RTIInputSystemClient remoteTextInputSessionWithID:performInputOperation:] perform input operation requires a valid sessionID

### 해결방안

```swift
TextField(...)
    .autocorrectionDisabled() // ✅ ADDED
```
