### PR TITLE
[2.0.0] 다크모드 대응

### DIFF
--- a/package-kuring/Sources/UIKit/BookmarkUI/BookmarkList.swift
+++ b/package-kuring/Sources/UIKit/BookmarkUI/BookmarkList.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import ColorSet
 import NoticeUI
 import NoticeFeatures
 import BookmarkFeatures
@@ -13,9 +14,13 @@ public struct BookmarkList: View {
     @Bindable var store: StoreOf<BookmarkListFeature>
 
     public var body: some View {
-        ZStack(alignment: .bottom) {
+        ZStack(alignment: .center) {
+            ColorSet.bg.ignoresSafeArea()
+            
             if store.bookmarkedNotices.isEmpty {
                 Text("보관된 공지사항이 없습니다.")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(ColorSet.body)
             } else {
                 List {
                     ForEach(self.store.bookmarkedNotices, id: \.id) { notice in
@@ -52,13 +57,13 @@ public struct BookmarkList: View {
                                 } label: {
                                     Image(
                                         systemName: store.selectedIDs.contains(notice.id)
-                                            ? "checkmark.circle.fill"
-                                            : "circle"
+                                        ? "checkmark.circle.fill"
+                                        : "circle"
                                     )
                                     .foregroundStyle(
                                         store.selectedIDs.contains(notice.id)
-                                            ? Color.accentColor
-                                            : Color.caption1.opacity(0.15)
+                                        ? ColorSet.primary
+                                        : ColorSet.body
                                     )
                                 }
                             }

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -94,7 +94,7 @@ public struct DepartmentEditor: View {
                 Button("전체 삭제") {
                     store.send(.deleteAllMyDepartmentButtonTapped)
                 }
-                .tint(ColorSet.primary)
+                .tint(.accentColor)
                 .disabled(store.myDepartments.isEmpty)
             }
         }

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -5,6 +5,7 @@
 
 import Models
 import SwiftUI
+import ColorSet
 import DepartmentFeatures
 import ComposableArchitecture
 
@@ -17,24 +18,25 @@ public struct DepartmentEditor: View {
         VStack(alignment: .leading) {
             Text("학과를 추가하거나\n삭제할 수 있어요")
                 .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(Color(red: 0.1, green: 0.12, blue: 0.15))
+                .foregroundStyle(ColorSet.title)
                 .padding(.top, 28)
                 .padding(.bottom, 24)
 
             HStack(alignment: .center, spacing: 12) {
                 Image(systemName: "magnifyingglass")
                     .frame(width: 16, height: 16)
-                    .foregroundStyle(Color.caption1.opacity(0.6))
+                    .foregroundStyle(ColorSet.gray400)
 
                 TextField("추가할 학과를 검색해 주세요", text: $store.searchText)
                     .focused($focus, equals: .search)
                     .autocorrectionDisabled()
                     .bind($store.focus, to: self.$focus)
+                    .background(ColorSet.gray300)
 
                 if !store.searchText.isEmpty {
                     Image(systemName: "xmark")
                         .frame(width: 16, height: 16)
-                        .foregroundStyle(Color.caption1.opacity(0.6))
+                        .foregroundStyle(ColorSet.gray400)
                         .onTapGesture {
                             store.send(.clearTextFieldButtonTapped)
                             focus = nil
@@ -49,7 +51,7 @@ public struct DepartmentEditor: View {
 
             Text(store.searchText.isEmpty ? "내 학과" : "검색 결과")
                 .font(.system(size: 14))
-                .foregroundStyle(Color.caption1.opacity(0.6))
+                .foregroundStyle(ColorSet.caption1)
                 .padding(.horizontal, 4)
                 .padding(.vertical, 10)
 
@@ -86,12 +88,13 @@ public struct DepartmentEditor: View {
             Spacer()
         }
         .padding(.horizontal, 20)
+        .background(ColorSet.bg)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button("전체 삭제") {
                     store.send(.deleteAllMyDepartmentButtonTapped)
                 }
-                .tint(.accentColor)
+                .tint(ColorSet.primary)
                 .disabled(store.myDepartments.isEmpty)
             }
         }

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentRow.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentRow.swift
@@ -34,13 +34,13 @@ public struct DepartmentRow: View {
                 Button(action: action) {
                     Image(
                         systemName: isSelected
-                            ? "checkmark.circle.fill"
-                            : "plus.circle"
+                        ? "checkmark.circle.fill"
+                        : "plus.circle"
                     )
                     .foregroundStyle(
                         isSelected
-                            ? Color.accentColor
-                            : Color.black.opacity(0.1)
+                        ? ColorSet.primary
+                        : ColorSet.gray400
                     )
                 }
             }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -17,16 +17,13 @@ public struct NoticeApp: View {
 
     public var body: some View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-            ZStack {
-                ColorSet.bg.ignoresSafeArea()
-                
-                NoticeContentView(
-                    store: self.store.scope(
-                        state: \.noticeList,
-                        action: \.noticeList
-                    )
+            NoticeContentView(
+                store: self.store.scope(
+                    state: \.noticeList,
+                    action: \.noticeList
                 )
-            }
+            )
+            .background(ColorSet.bg)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import ColorSet
 import SearchUI
 import DepartmentUI
 import SubscriptionUI
@@ -16,12 +17,16 @@ public struct NoticeApp: View {
 
     public var body: some View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-            NoticeContentView(
-                store: self.store.scope(
-                    state: \.noticeList,
-                    action: \.noticeList
+            ZStack {
+                ColorSet.bg.ignoresSafeArea()
+                
+                NoticeContentView(
+                    store: self.store.scope(
+                        state: \.noticeList,
+                        action: \.noticeList
+                    )
                 )
-            )
+            }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -37,7 +42,7 @@ public struct NoticeApp: View {
                         )
                     ) {
                         Image(systemName: "magnifyingglass")
-                            .foregroundStyle(Color.black)
+                            .foregroundStyle(ColorSet.gray400)
                     }
                 }
 
@@ -48,7 +53,7 @@ public struct NoticeApp: View {
                         store.send(.changeSubscriptionButtonTapped)
                     } label: {
                         Image(systemName: "bell")
-                            .foregroundStyle(.black)
+                            .foregroundStyle(ColorSet.gray400)
                     }
                 }
             }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeContentView.NoDepartment.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeContentView.NoDepartment.swift
@@ -5,6 +5,7 @@
 
 import Models
 import SwiftUI
+import ColorSet
 import NoticeFeatures
 import DepartmentFeatures
 import ComposableArchitecture
@@ -18,7 +19,7 @@ extension NoticeContentView {
             Text("아직 추가된 학과가 없어요.\n관심 학과를 추가하고 공지를 확인해 보세요!")
                 .font(.system(size: 15, weight: .medium))
                 .multilineTextAlignment(.center)
-                .foregroundColor(.black.opacity(0.36))
+                .foregroundStyle(ColorSet.caption2)
 
             NavigationLink(
                 state: NoticeAppFeature.Path.State.departmentEditor(
@@ -46,7 +47,7 @@ extension NoticeContentView {
         .foregroundStyle(Color.white)
         .padding(.horizontal, 36)
         .padding(.vertical, 16)
-        .background(Color.accentColor)
+        .background(ColorSet.primary)
         .cornerRadius(100)
     }
 }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeRow.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeRow.swift
@@ -6,6 +6,7 @@
 import Caches
 import Models
 import SwiftUI
+import ColorSet
 import ComposableArchitecture
 
 public struct NoticeRow: View {
@@ -48,7 +49,7 @@ public struct NoticeRow: View {
         ZStack {
             switch rowType {
             case .important, .importantAndBookmark:
-                Color.accentColor.opacity(0.1)
+                ColorSet.primary.opacity(0.1)
                     .ignoresSafeArea()
             default:
                 Color.clear
@@ -115,13 +116,13 @@ public struct NoticeRow: View {
             .font(.system(size: 12, weight: .semibold))
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .foregroundStyle(Color.accentColor)
-            .background(Color.white)
+            .foregroundStyle(ColorSet.primary)
+            .background(ColorSet.bg)
             .cornerRadius(16)
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
                     .inset(by: 0.25)
-                    .stroke(Color.accentColor, lineWidth: 0.5)
+                    .stroke(ColorSet.primary, lineWidth: 0.5)
             )
     }
 
@@ -129,7 +130,7 @@ public struct NoticeRow: View {
     private var titleView: some View {
         Text(notice.subject)
             .font(.system(size: 15, weight: .medium))
-            .foregroundStyle(Color.caption1)
+            .foregroundStyle(ColorSet.body)
     }
 
     @ViewBuilder
@@ -137,12 +138,11 @@ public struct NoticeRow: View {
         // TODO: - 정보 재구성
         Text(notice.postedDate)
             .font(.system(size: 14))
-            .foregroundStyle(Color.caption1.opacity(0.6))
+            .foregroundStyle(ColorSet.caption1)
     }
 
     @ViewBuilder
     private var bookmarkView: some View {
-        // TODO: 디자인 시스템 분리 - 북마크
         ZStack {
             RoundedRectangle(cornerRadius: 2)
                 .compositingGroup()

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeTypeColumn.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeTypeColumn.swift
@@ -5,6 +5,7 @@
 
 import Models
 import SwiftUI
+import ColorSet
 import ComposableArchitecture
 
 public struct NoticeTypeColumn: View {
@@ -17,7 +18,7 @@ public struct NoticeTypeColumn: View {
         let lineHeight: CGFloat = 3
 
         Text(title)
-            .font(.system(size: 16, weight: provider.id == selectedID ? .semibold : .regular))
+            .font(.system(size: 16, weight: provider.id == selectedID ? .semibold : .medium))
             .padding(.vertical, 8)
             .frame(width: itemSize.width, height: itemSize.height)
             .overlay {
@@ -31,8 +32,8 @@ public struct NoticeTypeColumn: View {
             }
             .foregroundStyle(
                 provider.id == selectedID
-                    ? Color.accentColor
-                    : Color.black.opacity(0.3)
+                ? ColorSet.primary
+                : ColorSet.caption1
             )
             .id(provider.id)
     }

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
@@ -6,6 +6,7 @@
 import Models
 import Combine
 import SwiftUI
+import ColorSet
 import DepartmentUI
 
 @Observable
@@ -69,7 +70,7 @@ struct DepartmentSelector: View {
             HStack(alignment: .center, spacing: 12) {
                 Image(systemName: "magnifyingglass")
                     .frame(width: 16, height: 16)
-                    .foregroundStyle(Color.caption1.opacity(0.6))
+                    .foregroundStyle(ColorSet.gray400)
                 
                 TextField("추가할 학과를 검색해 주세요", text: $finder.text)
                     .focused($focus)

--- a/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
+++ b/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
@@ -32,7 +32,7 @@ public struct SearchView: View {
                     /// 검색 아이콘
                     Image(systemName: "magnifyingglass")
                         .frame(width: 16, height: 16)
-                        .foregroundStyle(Color.caption1.opacity(0.6))
+                        .foregroundStyle(ColorSet.gray400)
 
                     TextField("검색어를 입력해주세요", text: $store.searchInfo.text)
                         .focused($focus, equals: .search)


### PR DESCRIPTION
## 다크모드 대응

 - 공지리스트 화면 다크모드 대응
 - 북마크 다크모드 대응
 - `Toolbar`, `폰트`, `이미지` 등 다크모드 대응
 - 검색 다크모드 대응
 - 학과 다크모드 대응
    - 학과 검색 `TextField` 다크모드 대응하려면 추가작업이 필요할 것으로 보임.
    - 해당 작업 영향 범위가 넓어서 다크모드 색상을 대응하고 후속으로 가져가기로
 - 온보딩 다크모드 대응