### PR TITLE
[2.0.0] 다크모드 전부 적용 및 학과 공지 UI 버그 및 다크모드 색상 적용을 위한 UI 수정

### DIFF
--- a/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7f5095b25e2d0a629176f0ebc41ee16d8e7d8c6c0e326ede18f4df4abbe75d63",
+  "originHash" : "a70bf5bcda18b73a91398005590ea6f3e124d517cc68deffb3c56506da7c3f07",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/package-kuring/Sources/Labs/ExperimentList.swift
+++ b/package-kuring/Sources/Labs/ExperimentList.swift
@@ -3,6 +3,7 @@
 // See the 'License.txt' file for licensing information.
 //
 
+import ColorSet
 import ComposableArchitecture
 
 @Reducer
@@ -39,6 +40,7 @@ public struct ExperimentList: View {
             }
             .padding(.vertical, 9)
             .listRowSeparator(.hidden)
+            .listRowBackground(ColorSet.bg)
             
             NavigationLink(
                 state: LabAppFeature.Path.State.appIcon(
@@ -49,8 +51,11 @@ public struct ExperimentList: View {
             }
             .padding(.vertical, 9)
             .listRowSeparator(.hidden)
+            .listRowBackground(ColorSet.bg)
         }
         .listStyle(.plain)
+        .background(ColorSet.bg)
+        
     }
 
     public init(store: StoreOf<ExperimentListFeature>) {

--- a/package-kuring/Sources/Labs/Experiments/AppIconDetail.swift
+++ b/package-kuring/Sources/Labs/Experiments/AppIconDetail.swift
@@ -3,6 +3,7 @@
 // See the 'License.txt' file for licensing information.
 //
 
+import ColorSet
 import ComposableArchitecture
 
 @Reducer
@@ -61,7 +62,7 @@ public struct AppIconDetailView: View {
                 Text(store.description)
 
                 Toggle("기능 활성화", isOn: $store.isEnabled)
-                    .tint(Color.accentColor)
+                    .tint(ColorSet.primary)
             }
         }
         .navigationTitle(store.title)

--- a/package-kuring/Sources/Labs/Experiments/BetaADetail.swift
+++ b/package-kuring/Sources/Labs/Experiments/BetaADetail.swift
@@ -3,6 +3,7 @@
 // See the 'License.txt' file for licensing information.
 //
 
+import ColorSet
 import ComposableArchitecture
 
 @Reducer
@@ -60,7 +61,7 @@ public struct BetaADetailView: View {
                 Text(store.description)
 
                 Toggle("기능 활성화", isOn: $store.isEnabled)
-                    .tint(Color.accentColor)
+                    .tint(ColorSet.primary)
             }
         }
         .navigationTitle(store.title)

--- a/package-kuring/Sources/UIKit/BookmarkUI/BookmarkList.swift
+++ b/package-kuring/Sources/UIKit/BookmarkUI/BookmarkList.swift
@@ -80,11 +80,11 @@ public struct BookmarkList: View {
                         topBlurButton(
                             "삭제하기",
                             fontColor: store.selectedIDs.isEmpty
-                                ? Color.accentColor.opacity(0.4)
-                                : .white,
+                            ? ColorSet.primary.opacity(0.4)
+                            : .white,
                             backgroundColor: store.selectedIDs.isEmpty
-                                ? Color.accentColor.opacity(0.15)
-                                : Color.accentColor
+                            ? ColorSet.primary.opacity(0.15)
+                            : ColorSet.primary
                         )
                     }
                     .padding(.horizontal, 20)
@@ -122,7 +122,7 @@ public struct BookmarkList: View {
                     )
                 }
                 .disabled(store.bookmarkedNotices.isEmpty)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ColorSet.primary)
             }
         }
     }
@@ -143,8 +143,15 @@ public struct BookmarkList: View {
         .background(backgroundColor)
         .cornerRadius(100)
         .background {
-            LinearGradient(gradient: Gradient(colors: [.white.opacity(0.1), .white]), startPoint: .top, endPoint: .bottom)
-                .offset(x: 0, y: -32)
+            LinearGradient(
+                gradient: Gradient(colors: [
+                    ColorSet.bg.opacity(0.1),
+                    ColorSet.bg.opacity(0.1),
+                    ColorSet.primary.opacity(0.1)
+                ]),
+                startPoint: .top, endPoint: .bottom
+            )
+            .offset(x: 0, y: -32)
         }
     }
 }

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -31,7 +31,6 @@ public struct DepartmentEditor: View {
                     .focused($focus, equals: .search)
                     .autocorrectionDisabled()
                     .bind($store.focus, to: self.$focus)
-                    .background(ColorSet.gray300)
 
                 if !store.searchText.isEmpty {
                     Image(systemName: "xmark")
@@ -45,7 +44,7 @@ public struct DepartmentEditor: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 7)
-            .background(Color(red: 0.95, green: 0.95, blue: 0.96))
+            .background(ColorSet.gray100)
             .cornerRadius(20)
             .padding(.bottom, 16)
 
@@ -94,7 +93,7 @@ public struct DepartmentEditor: View {
                 Button("전체 삭제") {
                     store.send(.deleteAllMyDepartmentButtonTapped)
                 }
-                .tint(.accentColor)
+                .tint(ColorSet.primary)
                 .disabled(store.myDepartments.isEmpty)
             }
         }

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentRow.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentRow.swift
@@ -28,7 +28,7 @@ public struct DepartmentRow: View {
             case .delete:
                 Button(action: action) {
                     Text("삭제")
-                        .foregroundStyle(Color.caption1.opacity(0.6))
+                        .foregroundStyle(ColorSet.caption1)
                 }
             case let .radio(isSelected):
                 Button(action: action) {

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
@@ -47,7 +47,6 @@ public struct DepartmentSelector: View {
                     }
                     .padding(.horizontal, 20)
                     .padding(.vertical, 12)
-                    .background(ColorSet.bg)
                     .onTapGesture {
                         store.send(.selectDepartment(id: department.id))
                     }

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
@@ -47,7 +47,7 @@ public struct DepartmentSelector: View {
                     }
                     .padding(.horizontal, 20)
                     .padding(.vertical, 12)
-                    .background(.white)
+                    .background(ColorSet.bg)
                     .onTapGesture {
                         store.send(.selectDepartment(id: department.id))
                     }

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
@@ -29,7 +29,7 @@ public struct DepartmentSelector: View {
                     HStack {
                         Text(department.korName)
                             .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.black)
+                            .foregroundStyle(ColorSet.body)
 
                         Spacer()
 

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
@@ -17,7 +17,7 @@ public struct DepartmentSelector: View {
             HStack(alignment: .center, spacing: 10) {
                 Text("대표 학과 선택")
                     .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(Color.black)
+                    .foregroundStyle(ColorSet.title)
             }
             .padding(.horizontal, 20)
             .padding(.top, 24)
@@ -40,8 +40,8 @@ public struct DepartmentSelector: View {
                         )
                         .foregroundStyle(
                             department == store.currentDepartment
-                                ? Color.accentColor
-                                : Color.black.opacity(0.1)
+                            ? ColorSet.primary
+                            : ColorSet.gray200
                         )
                         .frame(width: 20, height: 20)
                     }
@@ -59,8 +59,8 @@ public struct DepartmentSelector: View {
             } label: {
                 topBlurButton(
                     "내 학과 편집하기",
-                    fontColor: Color.accentColor,
-                    backgroundColor: Color.accentColor.opacity(0.15)
+                    fontColor: ColorSet.body,
+                    backgroundColor: ColorSet.primary
                 )
             }
             .padding(.horizontal, 20)
@@ -83,8 +83,15 @@ public struct DepartmentSelector: View {
         .background(backgroundColor)
         .cornerRadius(100)
         .background {
-            LinearGradient(gradient: Gradient(colors: [.white.opacity(0.1), .white]), startPoint: .top, endPoint: .bottom)
-                .offset(x: 0, y: -32)
+            LinearGradient(
+                gradient: Gradient(colors: [
+                    ColorSet.bg.opacity(0.1),
+                    ColorSet.bg.opacity(0.1),
+                    ColorSet.primary.opacity(0.1)
+                ]),
+                startPoint: .top, endPoint: .bottom
+            )
+            .offset(x: 0, y: -32)
         }
     }
 

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
@@ -5,6 +5,7 @@
 
 import Models
 import SwiftUI
+import ColorSet
 import DepartmentFeatures
 import ComposableArchitecture
 

--- a/package-kuring/Sources/UIKit/NoticeUI/DepartmentSelectorLink.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/DepartmentSelectorLink.swift
@@ -5,6 +5,7 @@
 
 import Models
 import SwiftUI
+import ColorSet
 
 struct DepartmentSelectorLink: View {
     let department: NoticeProvider
@@ -15,7 +16,7 @@ struct DepartmentSelectorLink: View {
         HStack {
             Text(department.korName)
                 .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(Color.black.opacity(0.8))
+                .foregroundStyle(ColorSet.title)
 
             Spacer()
 

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeList.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeList.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import ColorSet
 import DepartmentUI
 import NoticeFeatures
 import ComposableArchitecture
@@ -63,7 +64,7 @@ struct NoticeList: View {
                                             : "bookmark"
                                         )
                                     }
-                                    .tint(Color.accentColor)
+                                    .tint(ColorSet.primary)
                                 }
                                 
                                 Divider()

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeList.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeList.swift
@@ -10,10 +10,19 @@ import ComposableArchitecture
 
 struct NoticeList: View {
     @Bindable var store: StoreOf<NoticeListFeature>
-
+    
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
+            VStack(spacing: 0) {
+                if self.store.provider.category == .학과 {
+                    DepartmentSelectorLink(
+                        department: self.store.provider,
+                        isLoading: $store.isLoading.sending(\.loadingChanged)
+                    ) {
+                        self.store.send(.changeDepartmentButtonTapped)
+                    }
+                }
+                
                 ForEach(self.store.currentNotices, id: \.id) { notice in
                     ZStack {
                         NavigationLink(
@@ -29,7 +38,7 @@ struct NoticeList: View {
                         .opacity(0)
                         
                         Section {
-                            LazyVStack(spacing: 0) {
+                            VStack(spacing: 0) {
                                 NoticeRow(
                                     notice: notice,
                                     bookmarked: self.store.bookmarkIDs.contains(notice.id)
@@ -48,10 +57,11 @@ struct NoticeList: View {
                                     Button {
                                         self.store.send(.bookmarkTapped(notice))
                                     } label: {
-                                         Image(systemName: self.store.bookmarkIDs.contains(notice.id)
-                                               ? "bookmark.slash"
-                                               : "bookmark"
-                                         )
+                                        Image(
+                                            systemName: self.store.bookmarkIDs.contains(notice.id)
+                                            ? "bookmark.slash"
+                                            : "bookmark"
+                                        )
                                     }
                                     .tint(Color.accentColor)
                                 }
@@ -60,17 +70,6 @@ struct NoticeList: View {
                                     .frame(height: 1)
                             }
                             
-                        } header: {
-                            if self.store.provider.category == .학과 {
-                                DepartmentSelectorLink(
-                                    department: self.store.provider,
-                                    isLoading: $store.isLoading.sending(\.loadingChanged)
-                                ) {
-                                    self.store.send(.changeDepartmentButtonTapped)
-                                }
-                            } else {
-                                EmptyView()
-                            }
                         }
                         .navigationTitle("")
                         

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeRow.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeRow.swift
@@ -110,7 +110,6 @@ public struct NoticeRow: View {
         }
     }
 
-    @ViewBuilder
     private var importantTagView: some View {
         Text("중요")
             .font(.system(size: 12, weight: .semibold))
@@ -126,14 +125,12 @@ public struct NoticeRow: View {
             )
     }
 
-    @ViewBuilder
     private var titleView: some View {
         Text(notice.subject)
             .font(.system(size: 15, weight: .medium))
             .foregroundStyle(ColorSet.body)
     }
 
-    @ViewBuilder
     private var dateView: some View {
         // TODO: - 정보 재구성
         Text(notice.postedDate)
@@ -141,12 +138,11 @@ public struct NoticeRow: View {
             .foregroundStyle(ColorSet.caption1)
     }
 
-    @ViewBuilder
     private var bookmarkView: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 2)
                 .compositingGroup()
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ColorSet.primary)
                 .frame(width: 16, height: 21)
 
             RoundedRectangle(cornerRadius: 2)

--- a/package-kuring/Sources/UIKit/OnboardingUI/Common/KuringButtonStyle.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/Common/KuringButtonStyle.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import ColorSet
 
 // TODO: 디자인 시스템으로 이동
 struct KuringButtonStyle: ButtonStyle {
@@ -18,7 +19,7 @@ struct KuringButtonStyle: ButtonStyle {
                 .foregroundStyle(
                     onEnabled
                     ? .white
-                    : Color.accentColor.opacity(0.4)
+                    : ColorSet.primary.opacity(0.4)
                 )
 
             Spacer()
@@ -28,8 +29,8 @@ struct KuringButtonStyle: ButtonStyle {
         .frame(height: 50, alignment: .center)
         .background(
             onEnabled
-            ? Color.accentColor
-            : Color.accentColor.opacity(0.15)
+            ? ColorSet.primary
+            : ColorSet.primary.opacity(0.15)
         )
         .cornerRadius(100)
     }

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/CompletionView.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/CompletionView.swift
@@ -9,28 +9,33 @@ import ColorSet
 
 struct CompletionView: View {
     var body: some View {
-        VStack(spacing: 12) {
-            Text(StringSet.title_complete.rawValue)
-                .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(.primary)
-            
-            Text(StringSet.description_complete.rawValue)
-                .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(Color.caption1.opacity(0.6))
-                .multilineTextAlignment(.center)
-            
+        HStack {
             Spacer()
-            
-            LottieView(animation: .named("success.json", bundle: Bundle.onboarding))
-                .playing()
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 150, height: 150)
-                .clipped()
-            
+            VStack(spacing: 12) {
+                Text(StringSet.title_complete.rawValue)
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundStyle(ColorSet.primary)
+                
+                Text(StringSet.description_complete.rawValue)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(ColorSet.caption1)
+                    .multilineTextAlignment(.center)
+                
+                Spacer()
+                
+                LottieView(animation: .named("success.json", bundle: Bundle.onboarding))
+                    .playing()
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 150, height: 150)
+                    .clipped()
+                
+                Spacer()
+            }
             Spacer()
         }
         .padding(.top, 124)
+        .background(ColorSet.bg)
     }
 }
 

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/ConfirmationView.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/ConfirmationView.swift
@@ -13,9 +13,11 @@ struct ConfirmationView: View {
     var body: some View {
         VStack {
             HStack(spacing: 0) {
+                Spacer()
+                
                 Text(department.korName)
                     .font(.system(size: 24, weight: .bold))
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(ColorSet.primary)
                 
                 Text(
                     department.korName.last == "공"
@@ -23,22 +25,25 @@ struct ConfirmationView: View {
                     : "를"
                 )
                 .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ColorSet.primary)
+                
+                Spacer()
             }
             
             Text(StringSet.title_confirm.rawValue)
                 .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ColorSet.primary)
             
             Text(StringSet.description_confirm.rawValue)
                 .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(Color.caption1.opacity(0.6))
+                .foregroundStyle(ColorSet.caption1)
                 .multilineTextAlignment(.center)
                 .padding(.top, 12)
             
             Spacer()
         }
         .padding(.top, 124)
+        .background(ColorSet.bg)
     }
 }
 

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
@@ -79,7 +79,7 @@ struct DepartmentSelector: View {
                 if !finder.text.isEmpty {
                     Image(systemName: "xmark")
                         .frame(width: 16, height: 16)
-                        .foregroundStyle(Color.caption1.opacity(0.6))
+                        .foregroundStyle(ColorSet.caption1.opacity(0.6))
                         .onTapGesture {
                             finder.text = ""
                             focus = false

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
@@ -46,8 +46,7 @@ class DepartmentFinder {
                 correctResults.append(department)
             }
         }
-//        results = correctResults
-        results = [.emptyDepartment, .emptyDepartment]
+        results = correctResults
     }
 }
 

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
@@ -46,7 +46,8 @@ class DepartmentFinder {
                 correctResults.append(department)
             }
         }
-        results = correctResults
+//        results = correctResults
+        results = [.emptyDepartment, .emptyDepartment]
     }
 }
 
@@ -61,11 +62,11 @@ struct DepartmentSelector: View {
         VStack(alignment: .leading, spacing: 16) {
             Text(StringSet.title_select.rawValue)
                 .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ColorSet.title)
             
             Text(StringSet.description_select.rawValue)
                 .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(Color.caption1.opacity(0.6))
+                .foregroundStyle(ColorSet.caption1)
             
             HStack(alignment: .center, spacing: 12) {
                 Image(systemName: "magnifyingglass")
@@ -88,7 +89,7 @@ struct DepartmentSelector: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 7)
-            .background(Color(red: 0.95, green: 0.95, blue: 0.96))
+            .background(ColorSet.gray100)
             .cornerRadius(20)
             .padding(.bottom, 16)
             
@@ -105,5 +106,6 @@ struct DepartmentSelector: View {
             
             Spacer()
         }
+        .background(ColorSet.bg)
     }
 }

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.swift
@@ -44,7 +44,7 @@ struct MyDepartmentSelector: View {
                     selectedDepartment = nil
                 }
                 .font(.system(size: 16, weight: .medium))
-                .foregroundStyle(Color.caption1.opacity(0.6))
+                .foregroundStyle(ColorSet.caption1)
                 .padding(.vertical, 20)
             } else {
                 Button(StringSet.button_start.rawValue) {
@@ -54,6 +54,7 @@ struct MyDepartmentSelector: View {
             }
         }
         .padding(.horizontal, 20)
+        .background(ColorSet.bg)
         .onChange(of: selectedDepartment) { _, _ in
             guard selectedDepartment != nil else { return }
             currentStep = .selectDepartment.id

--- a/package-kuring/Sources/UIKit/OnboardingUI/OnboardingView/OnboardingView.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/OnboardingView/OnboardingView.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import ColorSet
 
 public struct OnboardingView: View {
     @Environment(\.dismiss) private var dismiss
@@ -13,6 +14,7 @@ public struct OnboardingView: View {
     public var body: some View {
         if showsDepartmentSelector {
             MyDepartmentSelector()
+                .background(ColorSet.bg)
         } else {
             VStack(spacing: 0) {
                 HStack {
@@ -37,7 +39,7 @@ public struct OnboardingView: View {
                             .frame(width: 8, height: 8)
                             .foregroundStyle(
                                 currentGuidance == guidance
-                                ? Color.accentColor
+                                ? ColorSet.primary
                                 : Color(.systemGroupedBackground)
                             )
                     }
@@ -56,14 +58,18 @@ public struct OnboardingView: View {
                     dismiss()
                 }
                 .font(.system(size: 16, weight: .medium))
-                .foregroundStyle(Color.caption1.opacity(0.6))
+                .foregroundStyle(ColorSet.caption1)
                 .padding(.vertical, 20)
             }
             .padding(.horizontal, 20)
+            .background(ColorSet.bg)
         }
     }
     
-    public init() { }
+    public init() {
+        UIPageControl.appearance().currentPageIndicatorTintColor = UIColor(ColorSet.primary)
+        UIPageControl.appearance().pageIndicatorTintColor = UIColor(ColorSet.gray200)
+    }
 }
 
 #Preview {

--- a/package-kuring/Sources/UIKit/SearchUI/SearchDetailView.swift
+++ b/package-kuring/Sources/UIKit/SearchUI/SearchDetailView.swift
@@ -16,6 +16,7 @@ public struct StaffDetailView: View {
             Text(store.staff.name)
                 .font(.system(size: 20, weight: .bold))
                 .listRowSeparator(.hidden)
+                .padding(.top, 22)
 
             Text("\(store.staff.deptName) · \(store.staff.collegeName)")
                 .foregroundStyle(.secondary)

--- a/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
+++ b/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
@@ -144,23 +144,33 @@ public struct SearchView: View {
             case .notice:
                 if let notices = store.resultNotices, !notices.isEmpty {
                     List(notices, id: \.self) { notice in
-                        NavigationLink(
-                            state: NoticeAppFeature.Path.State.detail(
-                                NoticeDetailFeature.State(notice: notice)
-                            )
-                        ) {
+                        ZStack {
+                            NavigationLink(
+                                state: NoticeAppFeature.Path.State.detail(
+                                    NoticeDetailFeature.State(notice: notice)
+                                )
+                            ) {
+                                EmptyView()
+                            }
+                            .opacity(0)
+                            
                             VStack(alignment: .leading) {
                                 Text(notice.subject)
-
+                                
                                 HStack {
                                     Text(notice.postedDate)
-
+                                    
                                     Spacer()
                                 }
                             }
                         }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 22)
+                        .listRowInsets(EdgeInsets())
+                        .background(ColorSet.bg)
                     }
                     .listStyle(.plain)
+                    .listRowBackground(ColorSet.bg)
                 } else {
                     beforePhaseView
                 }
@@ -171,10 +181,15 @@ public struct SearchView: View {
                             store.send(.staffRowSelected(staff))
                         } label: {
                             StaffRow(staff: staff)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 22)
                         }
                         .buttonStyle(.plain)
+                        .listRowInsets(EdgeInsets())
+                        .background(ColorSet.bg)
                     }
                     .listStyle(.plain)
+                    .listRowBackground(ColorSet.bg)
                 } else {
                     beforePhaseView
                 }
@@ -227,6 +242,7 @@ public struct SearchView: View {
 
     public init(store: StoreOf<SearchFeature>) {
         self.store = store
+//        UITableView
     }
 }
 

--- a/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
+++ b/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
@@ -50,14 +50,14 @@ public struct SearchView: View {
                             } label: {
                                 Image(systemName: "xmark")
                                     .frame(width: 16, height: 16)
-                                    .foregroundStyle(Color.caption1.opacity(0.6))
+                                    .foregroundStyle(ColorSet.gray400)
                             }
                         }
                     }
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 7)
-                .background(Color(red: 0.95, green: 0.95, blue: 0.96))
+                .background(ColorSet.gray100)
                 .cornerRadius(20)
             }
 
@@ -66,7 +66,7 @@ public struct SearchView: View {
                     /// 최근 검색어
                     Text("최근검색어")
                         .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(Color.caption1.opacity(0.6))
+                        .foregroundStyle(ColorSet.caption1)
 
                     Spacer()
 
@@ -76,8 +76,7 @@ public struct SearchView: View {
                     } label: {
                         Text("전체삭제")
                             .font(.system(size: 12))
-                            .foregroundStyle(Color.caption1)
-                            .foregroundColor(Color(red: 0.56, green: 0.56, blue: 0.56))
+                            .foregroundStyle(ColorSet.caption1)
                     }
                 }
                 .padding(.top, 20)
@@ -93,10 +92,10 @@ public struct SearchView: View {
                                 } label: {
                                     Text(recent)
                                         .font(.system(size: 14))
-                                        .foregroundStyle(Color.accentColor)
+                                        .foregroundStyle(ColorSet.primary)
                                         .padding(.horizontal, 12)
                                         .padding(.vertical, 4)
-                                        .background(Color.accentColor.opacity(0.1))
+                                        .background(ColorSet.primary.opacity(0.1))
                                         .cornerRadius(20)
                                 }
                             }
@@ -109,7 +108,7 @@ public struct SearchView: View {
             HStack {
                 Text("검색결과")
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(Color.caption1.opacity(0.6))
+                    .foregroundStyle(ColorSet.caption1)
                     .padding(.top, 20)
                     .padding(.bottom, 12)
 
@@ -121,7 +120,7 @@ public struct SearchView: View {
                 .foregroundColor(.clear)
                 .frame(height: 50)
                 .padding(.horizontal, 20)
-                .background(Color(red: 0.95, green: 0.95, blue: 0.96))
+                .background(ColorSet.gray100)
                 .cornerRadius(10)
                 .overlay {
                     HStack {
@@ -182,6 +181,7 @@ public struct SearchView: View {
             }
         }
         .padding(.horizontal, 20)
+        .background(ColorSet.bg)
         .bind($store.focus, to: $focus)
         .sheet(
             item: $store.scope(
@@ -194,10 +194,9 @@ public struct SearchView: View {
         }
     }
 
-    @ViewBuilder
     private func SegmentView(_ title: String, isSelect: Bool) -> some View {
         RoundedRectangle(cornerRadius: 10)
-            .foregroundColor(isSelect ? .white : .clear)
+            .foregroundStyle(isSelect ? ColorSet.bg : .clear)
             .shadow(
                 color: .black.opacity(isSelect ? 0.1 : 0),
                 radius: 6, x: 0, y: 0
@@ -207,13 +206,12 @@ public struct SearchView: View {
                     .font(.system(size: 16, weight: isSelect ? .bold : .medium))
                     .foregroundStyle(
                         isSelect
-                            ? Color.accentColor
-                            : Color.caption1.opacity(0.6)
+                        ? ColorSet.primary
+                        : ColorSet.caption1
                     )
             }
     }
 
-    @ViewBuilder
     private var beforePhaseView: some View {
         VStack {
             Group {

--- a/package-kuring/Sources/UIKit/SettingsUI/AppIconSelector.swift
+++ b/package-kuring/Sources/UIKit/SettingsUI/AppIconSelector.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import ColorSet
 import SettingsFeatures
 import ComposableArchitecture
 
@@ -26,7 +27,7 @@ public struct AppIconSelector: View {
                     store.send(.appIconSelected(icon))
                 } label: {
                     Text(icon.korValue)
-                        .foregroundStyle(.black)
+                        .foregroundStyle(ColorSet.body)
                 }
 
                 if icon == store.state.selectedIcon {
@@ -38,7 +39,9 @@ public struct AppIconSelector: View {
                 }
             }
             .listRowSeparator(.hidden)
+            .listRowBackground(ColorSet.bg)
         }
+        .background(ColorSet.bg)
         .listStyle(.plain)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/package-kuring/Sources/UIKit/SettingsUI/FeedbackView.swift
+++ b/package-kuring/Sources/UIKit/SettingsUI/FeedbackView.swift
@@ -75,10 +75,10 @@ public struct FeedbackView: View {
                     "피드백 보내기",
                     fontColor: store.isSendable
                         ? .white
-                        : Color.accentColor.opacity(0.4),
+                        : ColorSet.primary.opacity(0.4),
                     backgroundColor: store.isSendable
-                        ? Color.accentColor
-                        : Color.accentColor.opacity(0.15)
+                        ? ColorSet.primary
+                        : ColorSet.primary.opacity(0.15)
                 )
             }
             .allowsHitTesting(store.isSendable)

--- a/package-kuring/Sources/UIKit/SettingsUI/OpenSourceList.swift
+++ b/package-kuring/Sources/UIKit/SettingsUI/OpenSourceList.swift
@@ -37,7 +37,7 @@ public struct OpenSourceList: View {
                             .frame(maxWidth: .infinity)
                         }
                         .buttonStyle(.bordered)
-                        .tint(Color.accentColor)
+                        .tint(ColorSet.primary)
                         
                         Text(opensource.license)
                             .font(.footnote)

--- a/package-kuring/Sources/UIKit/SettingsUI/OpenSourceList.swift
+++ b/package-kuring/Sources/UIKit/SettingsUI/OpenSourceList.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import ColorSet
 import SettingsFeatures
 import ComposableArchitecture
 

--- a/package-kuring/Sources/UIKit/SettingsUI/SettingList.swift
+++ b/package-kuring/Sources/UIKit/SettingsUI/SettingList.swift
@@ -27,13 +27,13 @@ public struct SettingList: View {
                     Spacer()
                     Toggle("", isOn: $store.isCustomAlarmOn)
                         .labelsHidden()
-                        .tint(Color.accentColor)
+                        .tint(ColorSet.primary)
                 }
             } header: {
                 headerView("공지 구독")
             }
-            .tint(.black)
             .listRowSeparator(.hidden)
+            .listRowBackground(ColorSet.bg)
             
             Section {
                 HStack(spacing: 0) {
@@ -89,8 +89,8 @@ public struct SettingList: View {
                     .font(.footnote)
                     .foregroundStyle(ColorSet.caption1)
             }
-            .tint(.black)
             .listRowSeparator(.hidden)
+            .listRowBackground(ColorSet.bg)
             
             Section {
                 Button {
@@ -134,6 +134,7 @@ public struct SettingList: View {
                 headerView("쿠링 실험실")
             }
             .listRowSeparator(.hidden)
+            .listRowBackground(ColorSet.bg)
             
             Section {
                 Button {
@@ -141,12 +142,11 @@ public struct SettingList: View {
                 } label: {
                     itemView("icon_instagram", "인스타그램")
                 }
-
             } header: {
                 headerView("SNS")
             }
-            .tint(.black)
             .listRowSeparator(.hidden)
+            .listRowBackground(ColorSet.bg)
             
             Section {
                 Button {
@@ -157,10 +157,11 @@ public struct SettingList: View {
             } header: {
                 headerView("피드백")
             }
-            .tint(.black)
             .listRowSeparator(.hidden)
+            .listRowBackground(ColorSet.bg)
         }
         .listStyle(.plain)
+        .background(ColorSet.bg)
         .navigationTitle("더보기")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionSegment.swift
+++ b/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionSegment.swift
@@ -4,24 +4,25 @@
 //
 
 import SwiftUI
+import ColorSet
 
 struct SubscriptionSegment: View {
     let title: String
     let isSelected: Bool
-
+    
     var body: some View {
         VStack {
             Text(title)
                 .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(
                     isSelected
-                        ? Color.accentColor
-                        : Color.black.opacity(0.3)
+                    ? ColorSet.primary
+                    : ColorSet.caption1.opacity(0.3)
                 )
-
+            
             Rectangle()
                 .foregroundStyle(
-                    Color.accentColor
+                    ColorSet.primary
                         .opacity(isSelected ? 1 : 0)
                 )
                 .frame(height: 1.5)

--- a/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
+++ b/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
@@ -5,6 +5,7 @@
 
 import Models
 import SwiftUI
+import ColorSet
 import DepartmentFeatures
 import SubscriptionFeatures
 import ComposableArchitecture
@@ -17,7 +18,7 @@ struct SubscriptionView: View {
             HStack {
                 Text("알림 받고 싶은 \n카테고리를 선택해주세요")
                     .font(.system(size: 24, weight: .bold))
-                    .foregroundStyle(Color(red: 0.1, green: 0.12, blue: 0.15))
+                    .foregroundStyle(ColorSet.title)
             }
             .padding(.top, 32)
             .padding(.bottom, 60)
@@ -59,13 +60,13 @@ struct SubscriptionView: View {
                                 RoundedRectangle(cornerRadius: 8)
                                     .inset(by: 1)
                                     .stroke(
-                                        isSelected ? Color.accentColor : Color.clear,
+                                        isSelected ? ColorSet.primary : Color.clear,
                                         lineWidth: isSelected ? 2 : 0
                                     )
                                     .fill(
                                         isSelected
-                                            ? Color.accentColor.opacity(0.1)
-                                            : Color.black.opacity(0.03)
+                                        ? ColorSet.primary.opacity(0.1)
+                                        : ColorSet.gray100
                                     )
 
                                 VStack {
@@ -75,8 +76,8 @@ struct SubscriptionView: View {
                                         .font(.system(size: 16, weight: .semibold))
                                         .foregroundStyle(
                                             isSelected
-                                                ? Color.accentColor
-                                                : Color(red: 0.32, green: 0.32, blue: 0.32)
+                                            ? ColorSet.primary
+                                            : ColorSet.body
                                         )
                                 }
                                 .padding()
@@ -101,7 +102,7 @@ struct SubscriptionView: View {
                             Text("아직 추가된 학과가 없어요.\n관심 학과를 추가하고 공지를 확인해 보세요!")
                                 .font(.system(size: 16, weight: .medium))
                                 .multilineTextAlignment(.center)
-                                .foregroundStyle(Color(red: 0.68, green: 0.69, blue: 0.71))
+                                .foregroundStyle(ColorSet.caption2)
 
                             Spacer()
                         }
@@ -172,11 +173,15 @@ struct SubscriptionView: View {
                     .padding(.horizontal, 50)
                     .padding(.vertical, 16)
                     .frame(height: 50, alignment: .center)
-                    .background(Color.accentColor)
+                    .background(ColorSet.primary)
                     .cornerRadius(100)
                     .background {
                         LinearGradient(
-                            gradient: Gradient(colors: [.white.opacity(0.1), .white]),
+                            gradient: Gradient(colors: [
+                                ColorSet.bg.opacity(0.1),
+                                ColorSet.bg.opacity(0.1),
+                                ColorSet.primary.opacity(0.1)
+                            ]),
                             startPoint: .top, endPoint: .bottom
                         )
                         .offset(x: 0, y: -32)

--- a/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
+++ b/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
@@ -120,7 +120,7 @@ struct SubscriptionView: View {
                                     HStack {
                                         Text(department.korName)
                                             .font(.system(size: 16, weight: .semibold))
-                                            .foregroundStyle(.black)
+                                            .foregroundStyle(ColorSet.body)
 
                                         Spacer()
 
@@ -190,6 +190,7 @@ struct SubscriptionView: View {
             }
         }
         .padding(.horizontal, 20)
+        .background(ColorSet.bg)
         // TODO: TCA에 따라 외부에서 구현
         .navigationTitle("푸시 알림 설정")
         .navigationBarTitleDisplayMode(.inline)

--- a/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
+++ b/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionView.swift
@@ -125,7 +125,7 @@ struct SubscriptionView: View {
                                         Spacer()
 
                                         Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                                            .foregroundStyle(isSelected ? Color.accentColor : Color.black.opacity(0.1))
+                                            .foregroundStyle(isSelected ? ColorSet.primary : Color.black.opacity(0.1))
                                             .frame(width: 20, height: 20)
                                     }
                                     .padding(.horizontal, 21.5)


### PR DESCRIPTION
## [2.0.0] 다크모드 전부 적용 및 학과 공지 UI 버그 및 다크모드 색상 적용을 위한 UI 수정

 - 앱 내 다크모드를 전부 적용했습니다.
 - 학과 공지사항 UI가 깨지던 이슈를 수정했습니다.
    - 수정 UI는 카카오톡으로 전달드렸습니다!
 - UI 간격 조정을 위해 `ScrollView` + `LazyVStack`을 사용했었는데, `List`로 변경 가능할 것으로 보입니다.
    - SwiftUI의 `List`의 성능이 좋아졌다고 피드백 주셔서 이 부분은 후속으로 챙기겠습니다.
 - 온보딩 등 다크모드를 제작하면서, UI에 문제가 발생하던 부분을 전부 해결했습니다.
 
 <p align="center">
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/e367b396-cb53-4dc3-996a-e8630aa1436a" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/6d67944f-da2e-493b-83bb-ad2637c6bc00" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/1d4e4c9b-4efc-4f01-a296-3d028c74d18e" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/1f79f649-7652-4b4a-9cac-665d093a6b44" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/61fc6561-db6f-450d-a548-1abd04520a48" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/acbc1c2b-57a9-4dd3-ad30-d6e277d62364" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/0805b010-2454-4a3b-8d92-4617563f4cbc" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/e0c33ce5-14ff-4afd-9fbf-a491e15cd63e" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/abba4212-904d-433f-a3de-93903c8a61da" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/a0b3290f-a29a-44d5-bede-8a55610c8f9d" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/9c11552e-2db5-4148-b3ed-b1a71fb3359d" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/aa0caa86-9ec5-49b8-a742-525f6de06cad" width="24%"/>
</p>
