### PR TITLE
[2.0.0] 대학 및 학과 구독 로직

### DIFF
--- a/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
+++ b/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
@@ -8,10 +8,8 @@ import Foundation
 import Dependencies
 
 public struct KuringSubscriptions {
-    /// 구독한 공지 추가
-    public var add: (_ noticeProvider: NoticeProvider) -> Void
-    /// 구독한 공지 제거
-    public var remove: (_ noticeProvider: NoticeProvider) -> Void
+    /// 구독한 공지 리스트 업데이트
+    public var update: (_ noticeProvider: Set<NoticeProvider>) -> Void
     /// 구독한 모든 공지 카테고리
     public var getAll: () -> Set<NoticeProvider>
     /// 커스텀 공지 구독 여부
@@ -30,15 +28,8 @@ public struct KuringSubscriptions {
 
 extension KuringSubscriptions {
     public static let `default` = Self(
-        add: { noticeProvider in
-            var subscriptions = Self.subscriptions
-            subscriptions.insert(noticeProvider)
-            Self.subscriptions = subscriptions
-            
-        }, remove: { noticeProvider in
-            var subscriptions = Self.subscriptions
-            subscriptions.remove(noticeProvider)
-            Self.subscriptions = subscriptions
+        update: { noticeProviders in
+            Self.subscriptions = noticeProviders
             
         }, getAll: {
             Self.subscriptions

--- a/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
+++ b/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
@@ -13,7 +13,7 @@ public struct KuringSubscriptions {
     /// 구독한 공지 제거
     public var remove: (_ noticeProvider: NoticeProvider) -> Void
     /// 구독한 모든 공지 카테고리
-    public var getAll: () -> [NoticeProvider]
+    public var getAll: () -> Set<NoticeProvider>
     /// 커스텀 공지 구독 여부
     public var isCustomNotification: () -> Bool
     /// 커스텀 공지 구독 여부 변경
@@ -21,7 +21,7 @@ public struct KuringSubscriptions {
     
     /// 구독한 공지 (대학 및 학괴)
     @UserDefault(key: StringSet.subscribedCategories, defaultValue: [])
-    static var subscriptions: [NoticeProvider]
+    static var subscriptions: Set<NoticeProvider>
     
     /// 커스텀 공지 구독 여부 (기본값 true)
     @UserDefault(key: StringSet.customNotification, defaultValue: true)
@@ -32,12 +32,12 @@ extension KuringSubscriptions {
     public static let `default` = Self(
         add: { noticeProvider in
             var subscriptions = Self.subscriptions
-            subscriptions.append(noticeProvider)
+            subscriptions.insert(noticeProvider)
             Self.subscriptions = subscriptions
             
         }, remove: { noticeProvider in
             var subscriptions = Self.subscriptions
-            subscriptions.removeAll { $0.id == noticeProvider.id }
+            subscriptions.remove(noticeProvider)
             Self.subscriptions = subscriptions
             
         }, getAll: {

--- a/package-kuring/Sources/Features/SubscriptionFeatures/Subscription.swift
+++ b/package-kuring/Sources/Features/SubscriptionFeatures/Subscription.swift
@@ -44,16 +44,20 @@ public struct SubscriptionFeature {
             isWaitingResponse: Bool = false
         ) {
             @Dependency(\.subscriptions) var subscriptions
+            @Dependency(\.departments) var departments
+            
             let all = subscriptions.getAll()
             
             self.subscriptionType = subscriptionType
             self.selectedUnivNoticeType = IdentifiedArray(
                 uniqueElements: all.filter { $0.category == .대학 }
             )
-            self.myDepartments =  IdentifiedArray(
+            self.myDepartments = IdentifiedArray(
+                uniqueElements: departments.getAll()
+            )
+            self.selectedDepartment = IdentifiedArray(
                 uniqueElements: all.filter { $0.category == .학과 }
             )
-            self.selectedDepartment = selectedDepartment
             self.isWaitingResponse = isWaitingResponse
         }
     }
@@ -121,13 +125,11 @@ public struct SubscriptionFeature {
                 }
 
             case let .subscriptionResponse(isSucceeded):
-                // TODO: UX 어떻게 할지 디자이너 분들과 논의 해야함 (알림을 띄울지 말지)
-                print(isSucceeded ? "구독 성공~" : "구독 실패")
-//                if isSucceeded {
-                let noticeProviders = state.selectedDepartment + state.selectedUnivNoticeType
-                subscriptions.update(Set(noticeProviders))
-                    
-//                }
+                // !!!: UX 어떻게 할지 디자이너 분들과 논의 해야함 (알림을 띄울지 말지)
+                if isSucceeded {
+                    let noticeProviders = state.selectedDepartment + state.selectedUnivNoticeType
+                    subscriptions.update(Set(noticeProviders))
+                }
                 
                 state.isWaitingResponse = false
                 return .run { _ in

--- a/package-kuring/Sources/Features/SubscriptionFeatures/Subscription.swift
+++ b/package-kuring/Sources/Features/SubscriptionFeatures/Subscription.swift
@@ -124,10 +124,9 @@ public struct SubscriptionFeature {
                 // TODO: UX 어떻게 할지 디자이너 분들과 논의 해야함 (알림을 띄울지 말지)
                 print(isSucceeded ? "구독 성공~" : "구독 실패")
 //                if isSucceeded {
-                    let noticeProviders = state.selectedDepartment + state.selectedUnivNoticeType
-                    noticeProviders.forEach { noticeProvider in
-                        subscriptions.add(noticeProvider)
-                    }
+                let noticeProviders = state.selectedDepartment + state.selectedUnivNoticeType
+                subscriptions.update(Set(noticeProviders))
+                    
 //                }
                 
                 state.isWaitingResponse = false

--- a/package-kuring/Sources/Features/SubscriptionFeatures/Subscription.swift
+++ b/package-kuring/Sources/Features/SubscriptionFeatures/Subscription.swift
@@ -123,12 +123,12 @@ public struct SubscriptionFeature {
             case let .subscriptionResponse(isSucceeded):
                 // TODO: UX 어떻게 할지 디자이너 분들과 논의 해야함 (알림을 띄울지 말지)
                 print(isSucceeded ? "구독 성공~" : "구독 실패")
-                if isSucceeded {
+//                if isSucceeded {
                     let noticeProviders = state.selectedDepartment + state.selectedUnivNoticeType
                     noticeProviders.forEach { noticeProvider in
                         subscriptions.add(noticeProvider)
                     }
-                }
+//                }
                 
                 state.isWaitingResponse = false
                 return .run { _ in

--- a/package-kuring/Sources/Models/NoticeProvider.swift
+++ b/package-kuring/Sources/Models/NoticeProvider.swift
@@ -7,7 +7,7 @@ import Foundation
 import OrderedCollections
 
 /// 공지 제공자 카테고리
-public enum NoticeType: String, Hashable, CaseIterable, Identifiable, Equatable {
+public enum NoticeType: String, Codable, Hashable, CaseIterable, Identifiable, Equatable {
     case 학과, 대학, 세팅하지않음
 
     public var id: Self { self }
@@ -59,6 +59,7 @@ public struct NoticeProvider: Identifiable, Equatable, Hashable, Codable {
         case name
         case hostPrefix
         case korName
+        case category
     }
 
     public init(name: String, hostPrefix: String, korName: String, category: NoticeType) {
@@ -73,7 +74,8 @@ public struct NoticeProvider: Identifiable, Equatable, Hashable, Codable {
         self.name = try container.decode(String.self, forKey: .name)
         self.hostPrefix = try container.decode(String.self, forKey: .hostPrefix)
         self.korName = try container.decode(String.self, forKey: .korName)
-        self.category = .세팅하지않음
+        self.category = try container.decodeIfPresent(NoticeType.self, forKey: .category) ?? .세팅하지않음
+//        self.category = .세팅하지않음
     }
 }
 

--- a/package-kuring/Sources/Models/NoticeProvider.swift
+++ b/package-kuring/Sources/Models/NoticeProvider.swift
@@ -75,7 +75,6 @@ public struct NoticeProvider: Identifiable, Equatable, Hashable, Codable {
         self.hostPrefix = try container.decode(String.self, forKey: .hostPrefix)
         self.korName = try container.decode(String.self, forKey: .korName)
         self.category = try container.decodeIfPresent(NoticeType.self, forKey: .category) ?? .세팅하지않음
-//        self.category = .세팅하지않음
     }
 }
 


### PR DESCRIPTION
## 내용
 - 대학 및 학과 구독 로직 구현
    - API의 응답이 성공으로 떨어졌을 경우에 로컬 데이터에도 반영되도록 설계했습니다.
 - `NoticeProvider` 디코딩 키 잘못 유도되던 부분을 수정
    - `DTO`랑 `NoticeProvider`랑 추후에 분리하면 좋을 것 같아 보입니다.
 - `Subscription` 설계 변경
    -  `add`, `remove`에서 `update`로 수정했습니다.
    
## 버그?
 - `UnivNoticeType`에 `학과`가 끼어들고 있습니다.
 - 해당 데이터를 변경해주는 것은 `API` 뿐인데요. 근데, `path` 정보가 대학구독 카테고리 정보를 내려주는 부분이라 서버에서 api가 `v2`로 바뀌먄서 `학과`를 추가로 내려주는건지, 안드로이드, 서버 등 전반적으로 시퀀스 점검이 필요할 수도 있어 보입니다.
 - 간단히 해결하는 방법으로는 iOS에서 해당 배열에 들어있는 학과 정보를 SubsciriptionFeature 안으로 직접 넣어주어도 될 것 같습니다.