### PR TITLE
[2.0.0] 공지 웹뷰 영역 다크모드 대응

### DIFF
--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -5,6 +5,7 @@
 
 import Models
 import SwiftUI
+import ColorSet
 import CommonUI
 import ActivityUI
 import NoticeFeatures
@@ -16,6 +17,7 @@ public struct NoticeDetailView: View {
     public var body: some View {
         WebView(urlString: store.notice.url)
             .activitySheet($store.shareItem)
+            .background(Color.Kuring.bg)
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     Text(store.notice.subject)


### PR DESCRIPTION
## 내용
 - 공지 웹뷰 영역 다크모드 대응
     - AS-IS: 시스템 블랙 (좌측)
     - TO-BE: 쿠링 배경색 (우측)

 <p align="center">
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/d27a0966-f0fe-438b-b95d-3f0f496e9954" width="24%"/>
 <img src="https://github.com/ku-ring/ios-app/assets/56182112/2168bf06-03f7-4324-82cb-ad6ac114240b" width="24%"/>
</p>