### PR TITLE
[2.0.0] `Color.Kuring.warning` 색상 오류 수정

### DIFF
--- a/KuringApp/KuringApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/KuringApp/KuringApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -11,6 +11,42 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0xBD",
+          "red" : "0x3D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x78",
+          "green" : "0xB1",
+          "red" : "0x38"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/package-kuring/Sources/UIKit/ColorSet/Color.UIKit.swift
+++ b/package-kuring/Sources/UIKit/ColorSet/Color.UIKit.swift
@@ -16,7 +16,7 @@ extension Color.Kuring {
     
     public static let warning: Color = Self.color(
         light: Self.from(hex: "FF4848"),
-        dark: Self.from(hex: "DE4343", alpha: 0.08)
+        dark: Self.from(hex: "DE4343")
     )
     public static let borderLine: Color = Self.color(
         light: Self.from(hex: "000000"),


### PR DESCRIPTION
[수정] `Color.Kuring.warning` 색상 오류 수정
[추가] `Color.accent` 에 다크모드 색상 추가

| 수정 전 | 수정 후 |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-26 at 19 50 52](https://github.com/ku-ring/ios-app/assets/53814741/6d3d6a4b-34d9-442f-9d54-7e99ea871d1f) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-26 at 19 32 04](https://github.com/ku-ring/ios-app/assets/53814741/56f3d835-6e08-40a9-8d6f-abeb399e14b8) |