### PR TITLE
[2.0.0] 학과 검색 로직 추가 및 공유하기 버그 수정

### DIFF
--- a/package-kuring/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
+++ b/package-kuring/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
@@ -98,7 +98,6 @@ public struct DepartmentEditorFeature {
     }
 
     @Dependency(\.departments) var departments
-    private enum CancelID { case location }
     
     private var engine: DepartmentSearchEngine = DepartmentSearchEngineImpl()
     

--- a/package-kuring/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
+++ b/package-kuring/Sources/Features/DepartmentFeatures/DepartmentEditor.swift
@@ -51,7 +51,7 @@ public struct DepartmentEditorFeature {
             @Dependency(\.departments) var departments
             
             self.myDepartments = IdentifiedArrayOf(uniqueElements: departments.getAll())
-            self.searchResults = results
+            self.searchResults = []
             self.allDepartments = results
             self.searchText = searchText
             self.focus = focus

--- a/package-kuring/Sources/Features/DepartmentFeatures/DepartmentSearchEngine.swift
+++ b/package-kuring/Sources/Features/DepartmentFeatures/DepartmentSearchEngine.swift
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2024 쿠링
+// See the 'License.txt' file for licensing information.
+//
+
+import Models
+import ComposableArchitecture
+
+protocol DepartmentSearchEngine {
+    func search(keyword: String, allDepartments: IdentifiedArrayOf<NoticeProvider>) -> IdentifiedArrayOf<NoticeProvider>
+}
+
+struct DepartmentSearchEngineImpl: DepartmentSearchEngine {
+    /// 한글
+    private var hangeul = ["ㄱ","ㄲ","ㄴ","ㄷ","ㄸ","ㄹ","ㅁ","ㅂ","ㅃ","ㅅ","ㅆ","ㅇ","ㅈ","ㅉ","ㅊ","ㅋ","ㅌ","ㅍ","ㅎ"]
+    
+    
+    /// 전체학과 정보와 주어진 검색 키워드를 기반으로 검색된 학과 리스트를 반환
+    ///
+    ///
+    /// - Parameters:
+    ///     - keyword: 검색 키워드
+    ///     - allDepartments: 모든 학과 리스트
+    func search(keyword: String, allDepartments: IdentifiedArrayOf<NoticeProvider>) -> IdentifiedArrayOf<NoticeProvider> {
+        var filteredDepartments: IdentifiedArrayOf<NoticeProvider>
+        
+        if isChosung(keyword) {
+            let results = allDepartments.filter { department in
+                department.korName.contains(keyword) || searchChosung(department.korName).contains(keyword)
+            }
+            
+            filteredDepartments = results
+        } else {
+            var correctResults = allDepartments
+                .filter { $0.korName.contains(keyword) }
+                .compactMap { $0 }
+                .sorted { $0.korName < $1.korName }
+               
+            allDepartments.forEach { department in
+                var count = 0
+                var textChecker = Array(repeating: 0, count: keyword.count)
+                for alpha in department.korName {
+                    for (idx, value) in keyword.enumerated() {
+                        if value == alpha && textChecker[idx] == 0 {
+                            textChecker[idx] = 1
+                            count += 1
+                            break
+                        }
+                    }
+                    
+                }
+                if count == keyword.count && !correctResults.contains(department) {
+                    correctResults.append(department)
+                }
+            }
+            filteredDepartments = IdentifiedArray(correctResults)
+        }
+        
+        return filteredDepartments
+    }
+    
+    /// 해당 keyword가 초성문자인지 검사
+    private func isChosung(_ keyword: String) -> Bool {
+        var result = false
+        
+        for char in keyword {
+            if 0 < hangeul.filter({ $0.contains(char) }).count {
+                result = true
+            } else {
+                result = false
+                break
+            }
+        }
+        
+        return result
+    }
+    
+    /// 초성 검색
+    private func searchChosung(_ keyword: String) -> String {
+        var result = ""
+        
+        for char in keyword {
+            // unicodeScalars: 유니코드 스칼라 값의 모음으로 표현되는 문자열 값
+            let octal = char.unicodeScalars[char.unicodeScalars.startIndex].value
+            
+            // ~=: 왼쪽에서 정의한 범위 값 안에 오른쪽의 값이 속하면 true, 아니면 false 반환
+            if 44032...55203 ~= octal {
+                let index = (octal - 0xac00) / 28 / 21
+                result = result + hangeul[Int(index)]
+            }
+        }
+        return result
+    }
+}

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
@@ -15,7 +15,6 @@ public struct NoticeDetailFeature {
     public struct State: Equatable {
         public var notice: Notice
         public var isBookmarked: Bool = false
-        public var shareItem: ActivityItem? = nil
 
         public init(notice: Notice, isBookmarked: Bool? = nil) {
             @Dependency(\.bookmarks) var bookmarks
@@ -34,7 +33,6 @@ public struct NoticeDetailFeature {
 
     public enum Action: BindableAction, Equatable {
         case bookmarkButtonTapped
-        case shareButtonTapped
         
         case binding(BindingAction<State>)
 
@@ -53,12 +51,6 @@ public struct NoticeDetailFeature {
                 
             case .bookmarkButtonTapped:
                 state.isBookmarked.toggle()
-                return .none
-                
-            case .shareButtonTapped:
-                state.shareItem = ActivityItem(
-                    items: state.notice.url
-                )
                 return .none
                 
             case .delegate:

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -129,6 +129,5 @@ public struct DepartmentEditor: View {
                 reducer: { DepartmentEditorFeature() }
             )
         )
-        .navigationTitle("Department Editor")
     }
 }

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -27,10 +27,13 @@ public struct DepartmentEditor: View {
                     .frame(width: 16, height: 16)
                     .foregroundStyle(Color.Kuring.gray400)
 
-                TextField("추가할 학과를 검색해 주세요", text: $store.searchText)
-                    .focused($focus, equals: .search)
-                    .autocorrectionDisabled()
-                    .bind($store.focus, to: self.$focus)
+                TextField(
+                    "추가할 학과를 검색해 주세요",
+                    text: $store.searchText.sending(\.searchQueryChanged)
+                )
+                .focused($focus, equals: .search)
+                .autocorrectionDisabled()
+                .bind($store.focus, to: self.$focus)
 
                 if !store.searchText.isEmpty {
                     Image(systemName: "xmark")
@@ -69,7 +72,7 @@ public struct DepartmentEditor: View {
             } else {
                 // 검색결과
                 ScrollView {
-                    ForEach(store.results) { result in
+                    ForEach(store.searchResults) { result in
                         DepartmentRow(
                             department: result,
                             style: .radio(store.myDepartments.contains(result))

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -78,7 +78,6 @@ public struct NoticeApp: View {
             case .departmentEditor:
                 if let store = store.scope(state: \.departmentEditor, action: \.departmentEditor) {
                     DepartmentEditor(store: store)
-                        .navigationTitle("Department Editor")
                 }
             }
         }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -16,7 +16,6 @@ public struct NoticeDetailView: View {
     
     public var body: some View {
         WebView(urlString: store.notice.url)
-            .activitySheet($store.shareItem)
             .background(Color.Kuring.bg)
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -35,9 +34,9 @@ public struct NoticeDetailView: View {
                         )
                     }
                     
-                    Button {
-                        self.store.send(.shareButtonTapped)
-                    } label: {
+                    ShareLink(
+                        item: store.notice.url
+                    ) {
                         Image(systemName: "square.and.arrow.up")
                     }
                 }

--- a/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
+++ b/package-kuring/Sources/UIKit/SearchUI/SearchView.swift
@@ -33,7 +33,7 @@ public struct SearchView: View {
                     .frame(width: 16, height: 16)
                     .foregroundStyle(Color.Kuring.gray300)
                 
-                TextField("검색어를 입력해주세요", text: $store.searchInfo.text)
+                TextField("공지 제목 또는 교수명을 입력해주세요.", text: $store.searchInfo.text)
                     .focused($focus, equals: .search)
                     .autocorrectionDisabled()
                     .onSubmit { store.send(.search) }

--- a/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionApp.swift
+++ b/package-kuring/Sources/UIKit/SubscriptionUI/SubscriptionApp.swift
@@ -29,7 +29,6 @@ public struct SubscriptionApp: View {
                     action: \.departmentEditor
                 ) {
                     DepartmentEditor(store: store)
-                        .navigationTitle("Department Editor")
                 }
             }
         }


### PR DESCRIPTION
## [2.0.0] 학과 검색 로직 추가 및 공유하기 버그 수정
 - 학과 검색 로직 추가
    - 해당 로직은 v1의 로직과 동일하게 작성
 - 공유하기 버그 수정
    - `ShareLink`도입
    - 추후에 `ActivityUI` 디펜던시는 제거할 예정
 - 디자인 변경 대응
    - 검색하기 PlaceHolderText 변경

## 참고
 - 제보해주신 온보딩 버그는 재현이 안되어서 우선 냅두었습니다.

#### 그냥 적용해보고 싶은 내용
 - 접근제어자 중에 `package` 새로 나와서 써보고 싶은데, 음,, 뭔가 사용할만한 곳이 딱히 보이지가 않아서, 찾아서 적용해보면 좋을 것 같습니다~!
