### PR TITLE
[2.0.0] 캠퍼스맵 `Appearance` 에 `ColorSet` 적용

### DIFF
--- a/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -97,7 +97,7 @@
       "location" : "https://github.com/ku-ring/ios-maps",
       "state" : {
         "branch" : "main",
-        "revision" : "5244d7e94e869ffe269c1bd65f597f74513cedd3"
+        "revision" : "d5a9f56dd4954d4c9edaaf92892911070c2671bb"
       }
     },
     {

--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -109,6 +109,7 @@ let package = Package(
         .target(
             name: "CampusUI",
             dependencies: [
+                "ColorSet",
                 .product(name: "KuringMapsUI", package: "ios-maps")
             ],
             path: "Sources/UIKit/CampusUI",

--- a/package-kuring/Sources/UIKit/CampusUI/CampusApp.swift
+++ b/package-kuring/Sources/UIKit/CampusUI/CampusApp.swift
@@ -4,10 +4,23 @@
 //
 
 import SwiftUI
+import ColorSet
 import KuringMapsUI
 
 public struct CampusApp: View {
-    private let appearance = Appearance()
+    private let appearance = Appearance(
+        tint: Color.Kuring.primary,
+        primary: Color.Kuring.body,
+        secondary: Color.Kuring.caption1,
+        background: Color.Kuring.bg,
+        secondaryBackground: Color.Kuring.gray100,
+        link: Color.Kuring.primary,
+        body: .system(size: 16),
+        title: .system(size: 20),
+        subtitle: .system(size: 16),
+        footnote: .system(size: 14),
+        caption: .system(size: 12)
+    )
     
     private var linkHost: String {
         guard let plistURL = Bundle.module.url(forResource: "KuringMaps-Info", withExtension: "plist") else {


### PR DESCRIPTION
- [x] 캠퍼스맵 Appearance 에 `ColorSet` 의존
- [x] 캠퍼스맵 Bottom sheet 버그 수정
- [x] 캠퍼스맵 도서관잔여좌석 디자인 적용

## UI

| 색상&레이아웃 (변경 전) | 색상&레이아웃 (변경 후) | 잔여좌석 (변경 전) | 잔여좌석 (변경 후) |
| --- | --- | --- | --- |
| ![IMG_4343](https://github.com/ku-ring/ios-app/assets/53814741/7b039cb5-7f38-4e54-bd08-b9abf18f836d) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-29 at 02 39 28](https://github.com/ku-ring/ios-app/assets/53814741/04639ce7-36fe-4848-90f3-6e38db53bf7c) | ![IMG_4344](https://github.com/ku-ring/ios-app/assets/53814741/1134d67a-2259-48fe-bff5-2d4ba7da61e5) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-29 at 02 39 35](https://github.com/ku-ring/ios-app/assets/53814741/e96faee7-380b-4dec-bd84-eb3d92b832db) |