### PR TITLE
[2.0.0] 이상한 네이밍 수정

### DIFF
--- a/KuringApp/KuringApp/KuringApp.swift
+++ b/KuringApp/KuringApp/KuringApp.swift
@@ -101,7 +101,7 @@ struct KuringApp: App {
                     .kuringLink(
                         onRequest: { },
                         onCompletion: { result in
-                            showsOnboarding = !commons.isCompleteOnboarding()
+                            showsOnboarding = !commons.isOnboardingCompleted()
                             if !showsOnboarding {
                                 completesLink = true
                             }

--- a/package-kuring/Sources/Caches/Dependency/Commons.swift
+++ b/package-kuring/Sources/Caches/Dependency/Commons.swift
@@ -14,7 +14,7 @@ public struct Commons {
     /// 현재 앱 버전
     public var appVersion: () -> String
     /// 온보딩을 완료했는지 여부
-    public var isCompleteOnboarding: () -> Bool
+    public var isOnboardingCompleted: () -> Bool
     /// 온보딩을 완료한 상태로 변경
     public var completeOnboarding: () -> Void
     
@@ -49,7 +49,7 @@ extension Commons {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"]
             return appVersion as? String ?? "0.0.0"
             
-        }, isCompleteOnboarding: {
+        }, isOnboardingCompleted: {
             Self.isOnboardingCompleted
             
         }, completeOnboarding: {


### PR DESCRIPTION
`isCompleteOnboarding` -> `isOnboardingCompleted` 로 수정

Bool 은 `be + 주어 + p.p.`로 명명할 것 (의문형으로)

`"Is onboarding completed?"`



