### PR TITLE
[2.0.0] 온보딩 상태에서 구독로직

### DIFF
--- a/KuringApp/KuringApp/Info.plist
+++ b/KuringApp/KuringApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>CFBundleIcons</key>
 	<dict>
 		<key>CFBundleAlternateIcons</key>

--- a/package-kuring/Sources/Caches/Dependency/Departments.swift
+++ b/package-kuring/Sources/Caches/Dependency/Departments.swift
@@ -43,10 +43,6 @@ extension Departments {
                 // 학과 추가시 학과가 0개인 경우에는 current를 처음 학과로 설정
                 current = departments.first
             }
-            
-            @Dependency(\.subscriptions) var subscriptions
-            subscriptions.add(noticeProvider)
-            
             departments.append(noticeProvider)
             Self.selections = departments
             

--- a/package-kuring/Sources/Caches/Dependency/Departments.swift
+++ b/package-kuring/Sources/Caches/Dependency/Departments.swift
@@ -40,7 +40,7 @@ extension Departments {
             var departments = Self.selections
 
             if departments.isEmpty {
-//                학과 추가시 학과가 0개인 경우에는 current를 처음 학과로 설정
+                // 학과 추가시 학과가 0개인 경우에는 current를 처음 학과로 설정
                 current = departments.first
             }
             
@@ -54,11 +54,9 @@ extension Departments {
             var departments = Self.selections
             
             Self.selections.removeAll { $0.id == id }
-            @Dependency(\.subscriptions) var subscriptions
-            subscriptions.remove(id)
-            
+
             if Self.current?.id == id {
-//                삭제한 학과가 현재 선택한 학과일 경우 새로운 학과 정보로 업데이트
+                // 삭제한 학과가 현재 선택한 학과일 경우 새로운 학과 정보로 업데이트
                 Self.current = nil
                 Self.current = Self.selections.first
             }

--- a/package-kuring/Sources/Caches/Dependency/Departments.swift
+++ b/package-kuring/Sources/Caches/Dependency/Departments.swift
@@ -44,6 +44,9 @@ extension Departments {
                 current = departments.first
             }
             
+            @Dependency(\.subscriptions) var subscriptions
+            subscriptions.add(noticeProvider)
+            
             departments.append(noticeProvider)
             Self.selections = departments
             
@@ -51,6 +54,8 @@ extension Departments {
             var departments = Self.selections
             
             Self.selections.removeAll { $0.id == id }
+            @Dependency(\.subscriptions) var subscriptions
+            subscriptions.remove(id)
             
             if Self.current?.id == id {
 //                삭제한 학과가 현재 선택한 학과일 경우 새로운 학과 정보로 업데이트

--- a/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
+++ b/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
@@ -8,6 +8,10 @@ import Foundation
 import Dependencies
 
 public struct KuringSubscriptions {
+    /// 구독한 공지 리스트에 추가
+    public var add: (_ noticeProvider: NoticeProvider) -> Void
+    /// 구독한 공지 리스트에서 삭제
+    public var remove: (_ id: String) -> Void
     /// 구독한 공지 리스트 업데이트
     public var update: (_ noticeProvider: Set<NoticeProvider>) -> Void
     /// 구독한 모든 공지 카테고리
@@ -28,7 +32,12 @@ public struct KuringSubscriptions {
 
 extension KuringSubscriptions {
     public static let `default` = Self(
-        update: { noticeProviders in
+        add: { noticeProvider in
+            var subscriptions = Self.subscriptions
+            subscriptions.insert(noticeProvider)
+            Self.subscriptions = subscriptions
+            
+        }, update: { noticeProviders in
             Self.subscriptions = noticeProviders
             
         }, getAll: {

--- a/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
+++ b/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
@@ -8,10 +8,8 @@ import Foundation
 import Dependencies
 
 public struct KuringSubscriptions {
-    /// 구독한 공지 리스트에 추가
+    /// 구독한 공지 리스트에 단일 객체 추가
     public var add: (_ noticeProvider: NoticeProvider) -> Void
-    /// 구독한 공지 리스트에서 삭제
-    public var remove: (_ id: String) -> Void
     /// 구독한 공지 리스트 업데이트
     public var update: (_ noticeProvider: Set<NoticeProvider>) -> Void
     /// 구독한 모든 공지 카테고리
@@ -37,8 +35,6 @@ extension KuringSubscriptions {
             subscriptions.insert(noticeProvider)
             Self.subscriptions = subscriptions
             
-        }, remove: { _ in
-           // !!!: - 구현 방식에 대한 고민
         }, update: { noticeProviders in
             Self.subscriptions = noticeProviders
             

--- a/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
+++ b/package-kuring/Sources/Caches/Dependency/Subscriptions.swift
@@ -37,6 +37,8 @@ extension KuringSubscriptions {
             subscriptions.insert(noticeProvider)
             Self.subscriptions = subscriptions
             
+        }, remove: { _ in
+           // !!!: - 구현 방식에 대한 고민
         }, update: { noticeProviders in
             Self.subscriptions = noticeProviders
             

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.swift
@@ -7,6 +7,7 @@ import Caches
 import Models
 import SwiftUI
 import ColorSet
+import Networks
 import Dependencies
 
 struct MyDepartmentSelector: View {
@@ -14,6 +15,10 @@ struct MyDepartmentSelector: View {
     @State private var currentStep: Step.ID = .searchDepartment.id
     @State private var selectedDepartment: NoticeProvider? = nil
     
+    @Dependency(\.kuringLink) var kuringLink
+    @Dependency(\.departments) var departments
+    @Dependency(\.subscriptions) var subscriptions
+
     var body: some View {
         VStack {
             // 메인 영역
@@ -35,9 +40,17 @@ struct MyDepartmentSelector: View {
             if currentStep == .selectDepartment {
                 Button(StringSet.button_complete.rawValue) {
                     if let selectedDepartment {
-                        @Dependency(\.departments) var departments
+                        // 로컬 저장소에 학과 추가
                         NoticeProvider.addedDepartments.append(selectedDepartment)
                         departments.add(selectedDepartment)
+                        
+                        Task(priority: .background) {
+                            // 추가한 학과 구독, 단 api 성공시에만 구독정보 저장
+                            do {
+                                try await kuringLink.subscribeDepartments([selectedDepartment.hostPrefix])
+                                subscriptions.add(selectedDepartment)
+                            }
+                        }
                     }
                     currentStep = .addedDepartment.id
                 }


### PR DESCRIPTION
## 내용
 - QA기간에 나온 온보딩 상태에서 구독 로직 개발

## 영상

https://github.com/ku-ring/ios-app/assets/56182112/f5ba2ebb-7a62-447b-bdc1-59ab88d8ffcb

## 내용
 - QA기간에 나온 이야기중에 온보딩 상태에서 학과가 선택될 경우 바로 학과가 구독되도록 하는 로직을 추가
    - 온보딩에서 선택 후 api 응답이 성공적으로 떨어진 경우에만 구독이 활성화 됩니다.
 - 아래 `고려한 점 메모`는 작업 다 하려면 범위가 넓어서 우선 온보딩만 처리하고 나머지는 작은 PR로 분리해서 올리도록 하겠습니다.



### 🌱 고려한 점 메모
 - Package 구조
    - 온보딩에서 구독 로직을 사용하기 위해서는 결국은 kuringkLink를 사용해야 하며 네트워크 모듈에 속해있음.
    - 온보딩은 현재 Feature 모듈없이 UI 모듈만으로 구성되어 있음.
       - 방안1. 온보딩 UI 모듈에 네트워크 모듈 연결
       - 방안2. Feature모듈에 온보딩 Feature 생성 후 개발
 - `Subscription` 디펜던시 개선
    - 온보딩에서 학과를 추가할 경우에 대비해 추가적인 디펜던시 기능이 필요
       - 현재 `Subscription`에는 리스트 전체를 한번에 업데이트 하는 로직만 존재
       - 단일 객체도 추가할 수 있도록 `add` 추가 예정
 - `Department` 디펜던시 개선
    - `remove`시 아이디가 아닌 `NoticeProvider`객체를 들고오도록 수정
       - Swift Collection의 `Set` 자료구조의 경우 `remove(member:  T)`를 해야하는데, id를 가지고 들어오면 `NoticeProvider`객체를 생성해야 함.
       - 이는 `NoticeProvider` 매우 불완전한 구조로 이어질 수도 있다고 보임
          - 방안1. `remove`를 `String`에서 `NoticeProvider`로 개선한다.
          - 방안2. `NoticeProvider`에 `convenienceinit`으로 id값을 가져오도록 생성자를 추가한다.(매뉴얼하게 추적해야 함.)
       - `방안1`이 좋아 보이나 QA기간내에 처리하기엔 공수가 커 보여서 우선 메모
 - `Subscripton`디펜던시 `Department` 디펜던시에 `package` 혹은 `internal` 접근제어자 적용
     - `add`가 추가될 경우 `package` 접근제어자를 활용 할 수 있을것으로 보임.
     - 학과가 추가되거나 삭제될 때 `Department` 디펜던시에서 `Subscription` 디펜던시의 `add`, `remove`를 수행하며, 이는 외부에 보여지지 않도록 숨김.