### PR TITLE
[2.0.0] 공지 디테일 네비게이션 타이틀에서 카테고리 정보 보여주도록 수정

### DIFF
--- a/package-kuring/Sources/Models/Notice.swift
+++ b/package-kuring/Sources/Models/Notice.swift
@@ -110,11 +110,11 @@ extension Notice.DecodingError: LocalizedError {
 extension Notice {
     public static var random: Notice {
         Notice(
-            articleId: "5b4924e",
-            postedDate: "20211109",
-            subject: "교내 출입문 3곳(상허문, 일감문, 건국문) 차량 통제 안내 - 2022학년도 수시모집 논술고사일 - ",
-            url: "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?id=5b4924e",
-            category: "normal",
+            articleId: "5389",
+            postedDate: "2024-02-21",
+            subject: "2024학년도 신입생 입학식 개최 안내",
+            url: "https://www.konkuk.ac.kr/bbs/konkuk/234/5389/artclView.do",
+            category: "bachelor",
             important: false
         )
     }

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -67,7 +67,6 @@ public struct NoticeApp: View {
             case .detail:
                 if let store = store.scope(state: \.detail, action: \.detail) {
                     NoticeDetailView(store: store)
-                        .navigationBarTitleDisplayMode(.inline)
                 }
             case .search:
                 if let store = store.scope(state: \.search, action: \.search) {

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -14,13 +14,18 @@ import ComposableArchitecture
 public struct NoticeDetailView: View {
     @Bindable var store: StoreOf<NoticeDetailFeature>
     
+    var noticeProvider: NoticeProvider? {
+        NoticeProvider.univNoticeTypes.first { $0.name == store.notice.category }
+        ?? NoticeProvider.departments.first { $0.name == store.notice.category }
+    }
+    
     public var body: some View {
         WebView(urlString: store.notice.url)
             .background(Color.Kuring.bg)
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    Text(store.notice.subject)
-                        .font(.system(size: 12))
+                    Text(noticeProvider?.korName ?? "")
                 }
                 
                 ToolbarItemGroup(placement: .topBarTrailing) {
@@ -56,6 +61,5 @@ public struct NoticeDetailView: View {
                 reducer: { NoticeDetailFeature() }
             )
         )
-        .navigationTitle("Notice Detail View")
     }
 }


### PR DESCRIPTION

| 대학 공지 카테고리 | 학과 공지 카테고리 | 푸시 알림 받은 경우 |
| --- | --- | --- |
|  ![Simulator Screenshot - iPhone 15 Pro - 2024-04-05 at 17 41 08](https://github.com/ku-ring/ios-app/assets/53814741/39b14714-be8b-4165-9236-92f71abdc938) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-05 at 17 41 13](https://github.com/ku-ring/ios-app/assets/53814741/fea45351-a912-4798-b185-8d4088cce2b0) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-05 at 17 40 53](https://github.com/ku-ring/ios-app/assets/53814741/b606e197-986a-4b4e-b6de-484f933aaa16) |


### 이슈

학과의 경우 서버에서 내려주는 공지데이터에 "department" 로만 내려오고 구체적인 학과가 내려오지 않기 때문에 푸시알림 받을 경우 어느 학과인지 보여줄 수 없음
따라서, 학과 공지는 "학과" 로 통일 (안드로이드도 동일)