### PR TITLE
[2.0.1] 앱 최초 설치자의 경우 앱이 스플래시 화면에서 멈추는 이슈 및 피드백 이슈 수정

### DIFF
--- a/KuringApp/KuringApp.xcodeproj/project.pbxproj
+++ b/KuringApp/KuringApp.xcodeproj/project.pbxproj
@@ -407,7 +407,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kuring.service;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -442,7 +442,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kuring.service;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/package-kuring/Sources/PushNotifications/Notifications/Notifications.MessagingDelegate.swift
+++ b/package-kuring/Sources/PushNotifications/Notifications/Notifications.MessagingDelegate.swift
@@ -19,12 +19,6 @@ extension Notifications: MessagingDelegate {
         
         if self.fcmToken != fcmToken {
             self.fcmToken = fcmToken
-            
-            // 토큰 값이 다른 경우에만 해당 API 호출
-            @Dependency(\.kuringLink) var kuringLink
-            Task(priority: .background) {
-                try? await kuringLink.registerAuthorization()
-            }
         }
     }
 }

--- a/package-kuring/Sources/PushNotifications/Notifications/Notifications.swift
+++ b/package-kuring/Sources/PushNotifications/Notifications/Notifications.swift
@@ -20,7 +20,7 @@ public class Notifications: NSObject, UIApplicationDelegate {
     @AppStorage("com.kuring.sdk.notification.custom")
     static var isCustomNotificationEnabled: Bool = true
     
-    @AppStorage("com.kuring.sdk.token.fcm")
+    @AppStorage("com.kuring.sdk.token.fcm.v2")
     var fcmToken: String = ""
     
     func onTapRemoteNotification(with userInfo: [String: Any]) throws {

--- a/package-kuring/Sources/UIKit/CommonUI/View.onFetchAllData.swift
+++ b/package-kuring/Sources/UIKit/CommonUI/View.onFetchAllData.swift
@@ -11,7 +11,7 @@ struct KuringLinkFetcher: ViewModifier {
     @State private var showsNetworkError: Bool = false
     @Dependency(\.kuringLink) private var kuringLink
     
-    @AppStorage("com.kuring.sdk.token.fcm")
+    @AppStorage("com.kuring.sdk.token.fcm.v2")
     var fcmToken: String = ""
     
     let onRequest: () -> Void
@@ -25,9 +25,13 @@ struct KuringLinkFetcher: ViewModifier {
             }
             .onChange(of: fcmToken) { oldValue, newValue in
                 // 앱 설치 초기에 뒤늦게 FCM 토큰을 발급 받는 경우
-                guard oldValue.isEmpty else { return }
                 guard !newValue.isEmpty else { return }
                 Task { await request() }
+                
+                // 토큰 값이 다른 경우에만 해당 API 호출
+                Task(priority: .background) {
+                    try? await kuringLink.registerAuthorization()
+                }
             }
             .alert("앗! 인터넷 연결이 좋지 않아요!", isPresented: $showsNetworkError) {
                 // 무시

--- a/package-kuring/Sources/UIKit/CommonUI/View.onFetchAllData.swift
+++ b/package-kuring/Sources/UIKit/CommonUI/View.onFetchAllData.swift
@@ -29,9 +29,12 @@ struct KuringLinkFetcher: ViewModifier {
                 Task { await request() }
                 
                 // 토큰 값이 다른 경우에만 해당 API 호출
-                Task(priority: .background) {
-                    try? await kuringLink.registerAuthorization()
+                if oldValue != newValue {
+                    Task(priority: .background) {
+                        try? await kuringLink.registerAuthorization()
+                    }
                 }
+                
             }
             .alert("앗! 인터넷 연결이 좋지 않아요!", isPresented: $showsNetworkError) {
                 // 무시


### PR DESCRIPTION
## 내용
 
- 앱을 처음 설치한 유저의 경우 화면이 스플래시 단계에서 멈추는 크리티컬한 버그 수정
   - 원인: fcmToken이 없는 경우 onChange에서 관리하는데 최초 설치자의 경우 로컬 디바이스에 설치된 fcmToke이 "" 상태이고, oldValue.isEmpty면 return 하는 부분에 의해 더이상 로직이 진행되지 않는 문제.
   - oldValue가 empty여도 로직이 진행되도록 수정

 - 피드백 405 에러 이슈 수정
    - http로 post 요청시 리다이렉트 되며, 이때 메소드가 get으로 전환되었음.
    - 해결방법: https로 적용