### PR TITLE
공지 캘린더 연동 기능

### DIFF
--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -48,6 +48,11 @@ let package = Package(
     targets: [
         // MARK: App Library Dependencies
         .target(
+            name: "EKEventUI",
+            dependencies: [],
+            path: "Sources/UIKit/EKEventUI"
+        ),
+        .target(
             name: "BotUI",
             dependencies: [
                 .product(name: "Lottie", package: "lottie-spm"),
@@ -71,6 +76,7 @@ let package = Package(
                 "BotUI",
                 "BotFeatures",
                 "DepartmentFeatures",
+                "EKEventUI",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "ActivityUI", package: "package-activityui"),
             ],

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
@@ -6,6 +6,7 @@
 import Caches
 import Models
 import SwiftUI
+import EventKit
 import ActivityUI
 import ComposableArchitecture
 
@@ -15,6 +16,9 @@ public struct NoticeDetailFeature {
     public struct State: Equatable {
         public var notice: Notice
         public var isBookmarked: Bool = false
+        public var isPresentedEventView: Bool = false
+        public var eventStore: EKEventStore?
+        public var event: EKEvent?
 
         public init(notice: Notice, isBookmarked: Bool? = nil) {
             @Dependency(\.bookmarks) var bookmarks
@@ -33,6 +37,7 @@ public struct NoticeDetailFeature {
 
     public enum Action: BindableAction, Equatable {
         case bookmarkButtonTapped
+        case calenarButtonTapped
         
         case binding(BindingAction<State>)
 
@@ -51,6 +56,24 @@ public struct NoticeDetailFeature {
                 
             case .bookmarkButtonTapped:
                 state.isBookmarked.toggle()
+                return .none
+                
+            case .calenarButtonTapped:
+                let eventStore = EKEventStore()
+                let event = EKEvent(eventStore: eventStore)
+                event.title = state.notice.subject
+                let structuredLocation = EKStructuredLocation(title: "건국대학교 05029 대한민국 서울특별시 광진구 능동로 120")
+                structuredLocation.geoLocation = CLLocation(latitude: 37.54360, longitude: 127.07747)
+                event.url = URL(string: state.notice.url)
+                event.isAllDay = true
+                let alarm = EKAlarm(relativeOffset: -86400)
+                event.notes = "쿠링에서 \(Date.now)에 등록된 일정입니다."
+                event.alarms = [alarm]
+                
+                state.eventStore = eventStore
+                state.event = event
+                state.isPresentedEventView.toggle()
+                
                 return .none
                 
             case .delegate:

--- a/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
@@ -10,6 +10,11 @@ public struct EKEventView: UIViewControllerRepresentable {
     public let eventStore: EKEventStore
     public let event: EKEvent
     
+    public init(eventStore: EKEventStore, event: EKEvent) {
+        self.eventStore = eventStore
+        self.event = event
+    }
+    
     public func makeUIViewController(context: Context) -> some UIViewController {
         let eventEditViewController = EKEventEditViewController()
         eventEditViewController.editViewDelegate = context.coordinator

--- a/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
@@ -3,12 +3,12 @@ import EventKit
 import EventKitUI
 import SwiftUI
 
-struct EKEventView: UIViewControllerRepresentable {
+public struct EKEventView: UIViewControllerRepresentable {
     
     @Environment(\.dismiss) var dismiss
     
-    let eventStore: EKEventStore
-    let event: EKEvent
+    public let eventStore: EKEventStore
+    public let event: EKEvent
     
     func makeUIViewController(context: Context) -> some UIViewController {
         let eventEditViewController = EKEventEditViewController()

--- a/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
@@ -10,7 +10,7 @@ public struct EKEventView: UIViewControllerRepresentable {
     public let eventStore: EKEventStore
     public let event: EKEvent
     
-    func makeUIViewController(context: Context) -> some UIViewController {
+    public func makeUIViewController(context: Context) -> some UIViewController {
         let eventEditViewController = EKEventEditViewController()
         eventEditViewController.editViewDelegate = context.coordinator
         eventEditViewController.eventStore = eventStore
@@ -19,20 +19,20 @@ public struct EKEventView: UIViewControllerRepresentable {
         return eventEditViewController
     }
     
-    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+    public func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
     
-    func makeCoordinator() -> Coordinator {
+    public func makeCoordinator() -> Coordinator {
         return Coordinator(self)
     }
     
-    class Coordinator: NSObject, EKEventEditViewDelegate {
+    public class Coordinator: NSObject, EKEventEditViewDelegate {
         let parent: EKEventView
         
         init(_ parent: EKEventView) {
             self.parent = parent
         }
         
-        func eventEditViewController(_ controller: EKEventEditViewController, didCompleteWith action: EKEventEditViewAction) {
+        public func eventEditViewController(_ controller: EKEventEditViewController, didCompleteWith action: EKEventEditViewAction) {
             parent.dismiss()
         }
     }

--- a/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
@@ -10,7 +10,10 @@ public struct EKEventView: UIViewControllerRepresentable {
     public let eventStore: EKEventStore
     public let event: EKEvent
     
-    public init(eventStore: EKEventStore, event: EKEvent) {
+    public init(
+        eventStore: EKEventStore,
+        event: EKEvent
+    ) {
         self.eventStore = eventStore
         self.event = event
     }

--- a/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/EKEventUI/EKEventView.swift
@@ -1,0 +1,40 @@
+import UIKit
+import EventKit
+import EventKitUI
+import SwiftUI
+
+struct EKEventView: UIViewControllerRepresentable {
+    
+    @Environment(\.dismiss) var dismiss
+    
+    let eventStore: EKEventStore
+    let event: EKEvent
+    
+    func makeUIViewController(context: Context) -> some UIViewController {
+        let eventEditViewController = EKEventEditViewController()
+        eventEditViewController.editViewDelegate = context.coordinator
+        eventEditViewController.eventStore = eventStore
+        eventEditViewController.event = event
+        
+        return eventEditViewController
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+    
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, EKEventEditViewDelegate {
+        let parent: EKEventView
+        
+        init(_ parent: EKEventView) {
+            self.parent = parent
+        }
+        
+        func eventEditViewController(_ controller: EKEventEditViewController, didCompleteWith action: EKEventEditViewAction) {
+            parent.dismiss()
+        }
+    }
+    
+}

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -7,9 +7,11 @@ import Models
 import SwiftUI
 import ColorSet
 import CommonUI
+import EKEventUI
 import ActivityUI
 import NoticeFeatures
 import ComposableArchitecture
+import EventKit
 
 public struct NoticeDetailView: View {
     @Bindable var store: StoreOf<NoticeDetailFeature>
@@ -19,16 +21,30 @@ public struct NoticeDetailView: View {
         ?? NoticeProvider.departments.first { $0.name == store.notice.category }
     }
     
+    @State var showAddEventModal = false
+    let eventStore = EKEventStore()
+    
     public var body: some View {
         WebView(urlString: store.notice.url)
             .background(Color.Kuring.bg)
             .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showAddEventModal) {
+                EKEventView(
+                    eventStore: eventStore,
+                    event: make(eventStore: eventStore)
+                )
+            }
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     Text(noticeProvider?.korName ?? "")
                 }
                 
                 ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
+                        showAddEventModal = true
+                    } label: {
+                        Image(systemName: "calendar")
+                    }
                     Button {
                         self.store.send(.bookmarkButtonTapped)
                     } label: {
@@ -52,6 +68,20 @@ public struct NoticeDetailView: View {
     public init(store: StoreOf<NoticeDetailFeature>) {
         self.store = store
     }
+    
+    func make(eventStore: EKEventStore) -> EKEvent {
+        let event = EKEvent(eventStore: eventStore)
+        event.title = "당근"
+        let structuredLocation = EKStructuredLocation(title: "Starbucks")
+        structuredLocation.geoLocation = CLLocation(latitude: 37.7749, longitude: -122.4194)
+        event.structuredLocation = structuredLocation
+        event.url = URL(string: "www.naver.com")
+        event.isAllDay = true
+        let alarm = EKAlarm(relativeOffset: -86400)
+        event.notes = "자동작성된 이벤트"
+        event.alarms = [alarm]
+        return event
+    }
 }
 
 #Preview {
@@ -64,3 +94,9 @@ public struct NoticeDetailView: View {
         )
     }
 }
+//let eventStore = EKEventStore()
+//let event = make(eventStore: eventStore)
+//EKEventView(
+//    eventStore: eventStore,
+//    event: event
+//)

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -21,17 +21,18 @@ public struct NoticeDetailView: View {
         ?? NoticeProvider.departments.first { $0.name == store.notice.category }
     }
     
-    @State var showAddEventModal = false
-    let eventStore = EKEventStore()
-    
     public var body: some View {
         WebView(urlString: store.notice.url)
             .background(Color.Kuring.bg)
             .navigationBarTitleDisplayMode(.inline)
-            .sheet(isPresented: $showAddEventModal) {
+            .sheet(isPresented: $store.isPresentedEventView) {
+//                guard let eventStore = ,
+//                      let event = store.state.event else {
+//                    EmptyView()
+//                }
                 EKEventView(
-                    eventStore: eventStore,
-                    event: make(eventStore: eventStore)
+                    eventStore: store.state.eventStore!,
+                    event: store.state.event!
                 )
             }
             .toolbar {
@@ -41,9 +42,9 @@ public struct NoticeDetailView: View {
                 
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button {
-                        showAddEventModal = true
+                        self.store.send(.calenarButtonTapped)
                     } label: {
-                        Image(systemName: "calendar")
+                        Image(systemName: "calendar.badge.plus")
                     }
                     Button {
                         self.store.send(.bookmarkButtonTapped)

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -26,14 +26,14 @@ public struct NoticeDetailView: View {
             .background(Color.Kuring.bg)
             .navigationBarTitleDisplayMode(.inline)
             .sheet(isPresented: $store.isPresentedEventView) {
-//                guard let eventStore = ,
-//                      let event = store.state.event else {
-//                    EmptyView()
-//                }
-                EKEventView(
-                    eventStore: store.state.eventStore!,
-                    event: store.state.event!
-                )
+                if let eventStore = store.state.eventStore, let event = store.state.event {
+                    EKEventView(
+                        eventStore: eventStore,
+                        event: event
+                    )
+                } else {
+                    EmptyView()
+                }
             }
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -69,20 +69,6 @@ public struct NoticeDetailView: View {
     public init(store: StoreOf<NoticeDetailFeature>) {
         self.store = store
     }
-    
-    func make(eventStore: EKEventStore) -> EKEvent {
-        let event = EKEvent(eventStore: eventStore)
-        event.title = "당근"
-        let structuredLocation = EKStructuredLocation(title: "Starbucks")
-        structuredLocation.geoLocation = CLLocation(latitude: 37.7749, longitude: -122.4194)
-        event.structuredLocation = structuredLocation
-        event.url = URL(string: "www.naver.com")
-        event.isAllDay = true
-        let alarm = EKAlarm(relativeOffset: -86400)
-        event.notes = "자동작성된 이벤트"
-        event.alarms = [alarm]
-        return event
-    }
 }
 
 #Preview {
@@ -95,9 +81,3 @@ public struct NoticeDetailView: View {
         )
     }
 }
-//let eventStore = EKEventStore()
-//let event = make(eventStore: eventStore)
-//EKEventView(
-//    eventStore: eventStore,
-//    event: event
-//)

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -11,7 +11,6 @@ import EKEventUI
 import ActivityUI
 import NoticeFeatures
 import ComposableArchitecture
-import EventKit
 
 public struct NoticeDetailView: View {
     @Bindable var store: StoreOf<NoticeDetailFeature>


### PR DESCRIPTION
## 이슈
- #237 

## 스크린샷
- 순서대로
   - 1번 화면: 공지 웹뷰에서 `Toolbar` 영역에 버튼 추가
   - 2번화면: `Toolbar` 버튼 추가했을 때 화면 스크롤 최상단
   - 3번화면: `Toolbar` 버튼 추가했을 때 화면 스크롤 최하단
   - 4번화면: 내 캘린더에 등록된 쿠링 공지 이벤트
- 상단에 리마인더 구분되는 UI 무시해주세요!

<p align="center">
 <img src="https://github.com/user-attachments/assets/b85468c7-4698-4384-92b0-89beff979078" width="24%"/>
 <img src="https://github.com/user-attachments/assets/4dcdea07-fa39-4b76-9283-a2b9cb9bbefc" width="24%"/>
 <img src="https://github.com/user-attachments/assets/38d879d3-c8cc-4744-a997-40a6e8d410fa" width="24%"/>
 <img src="https://github.com/user-attachments/assets/0ca9b33a-51ee-4305-bfa7-f244e02db804" width="24%"/>
</p>


## 화면이 닫히지 않는 버그
- 아래 로그가 뜨는데 `HELP` 입니다 🥹
```
received action:
  NoticeAppFeature.Action.path(
    .element(
      id: #2,
      action: .detail(
        .binding(.set(\State.isPresentedEventView, false))
      )
    )
  )
  (No state changes)
```
