### PR TITLE
탭바 버그 2건을 수정합니다

### DIFF
--- a/KuringApp/KuringApp.xcodeproj/project.pbxproj
+++ b/KuringApp/KuringApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A9539D62E44F9650026A9EE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1A9539D52E44F9640026A9EE /* GoogleService-Info.plist */; };
 		A9DAFA542AB1F04B0064F748 /* KuringApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAFA532AB1F04B0064F748 /* KuringApp.swift */; };
 		A9DAFA562AB1F04B0064F748 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAFA552AB1F04B0064F748 /* ContentView.swift */; };
 		A9DAFA582AB1F04C0064F748 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9DAFA572AB1F04C0064F748 /* Assets.xcassets */; };
@@ -30,6 +31,7 @@
 
 /* Begin PBXFileReference section */
 		1A0C8B412BCA5BB400B314C7 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		1A9539D52E44F9640026A9EE /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A9DAFA502AB1F04B0064F748 /* KuringApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KuringApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9DAFA532AB1F04B0064F748 /* KuringApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KuringApp.swift; sourceTree = "<group>"; };
 		A9DAFA552AB1F04B0064F748 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 			isa = PBXGroup;
 			children = (
 				1A0C8B412BCA5BB400B314C7 /* PrivacyInfo.xcprivacy */,
+				1A9539D52E44F9640026A9EE /* GoogleService-Info.plist */,
 				CACC2F4B2B7E638C003142E2 /* KuringApp.entitlements */,
 				DF062D4A2AC87B6D00FC48C0 /* Info.plist */,
 				DFE7AB132AC332D200230934 /* Setting */,
@@ -219,6 +222,7 @@
 			files = (
 				A9DAFA5B2AB1F04C0064F748 /* Preview Assets.xcassets in Resources */,
 				A9DAFA582AB1F04C0064F748 /* Assets.xcassets in Resources */,
+				1A9539D62E44F9650026A9EE /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -392,7 +396,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 202408281220;
 				DEVELOPMENT_ASSET_PATHS = "\"KuringApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 38PD5AHVVF;
+				DEVELOPMENT_TEAM = 6DXT245L5T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KuringApp/Info.plist;
@@ -427,7 +431,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 202408281220;
 				DEVELOPMENT_ASSET_PATHS = "\"KuringApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 38PD5AHVVF;
+				DEVELOPMENT_TEAM = 6DXT245L5T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KuringApp/Info.plist;

--- a/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KuringApp/KuringApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a70bf5bcda18b73a91398005590ea6f3e124d517cc68deffb3c56506da7c3f07",
+  "originHash" : "bae5b6aa6a6a07e41c2754c1106ad48cf28fc551ffb405e201dbd848591b410e",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-        "version" : "1.0.0"
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
-        "version" : "1.3.0"
+        "revision" : "9810c8d6c2914de251e072312f01d3bf80071852",
+        "version" : "1.7.1"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
-        "version" : "1.0.2"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "ca8b4ab855f4b8075c1fd29eb50db756b1688e61"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "branch" : "main",
-        "revision" : "a0acf426f7e8e794563b6bcbe4fcf5a9fd6cebef"
+        "revision" : "b35827a61c1420e40ff8e7c584b5042144d20195",
+        "version" : "1.12.1"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
-        "version" : "1.1.0"
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "3ce83179e5f0c83ad54c305779c6b438e82aaf1d",
-        "version" : "1.2.1"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "d3a5af3038a09add4d7682f66555d6212058a3c0",
-        "version" : "1.2.2"
+        "revision" : "eefcdaa88d2e2fd82e3405dfb6eb45872011a0b5",
+        "version" : "1.9.3"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
-        "version" : "1.0.0"
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "a5bb578d963fcdbffe4fd56c92b2e222f5b02c8a",
-        "version" : "1.1.2"
+        "revision" : "d924c62a70fca5f43872f286dbd7cef0957f1c01",
+        "version" : "1.6.0"
       }
     },
     {
@@ -238,10 +238,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "d9e72f3083c08375794afa216fb2f89c0114f303",
-        "version" : "1.2.1"
+        "revision" : "e628806aeaa9efe25c1abcd97931a7c498fab281",
+        "version" : "1.5.5"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
-        "version" : "1.1.1"
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
       }
     }
   ],

--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -15,76 +15,77 @@ import SettingsFeatures
 import ComposableArchitecture
 
 struct ContentView: View {
-  @State private var selection: TabBarItem = .notice
-  
-  enum TabBarItem: Hashable {
-    case notice
-    case archive
-    case campusMap
-    case settings
-  }
-  
-  init() {
-    UITabBar.appearance().barTintColor = UIColor.init(Color.Kuring.bg)
-  }
-  
-  var body: some View {
-    ZStack {
-      TabView(selection: $selection) {
-        NoticeApp(
-          store: Store(
-            initialState: NoticeAppFeature.State(
-              noticeList: NoticeListFeature.State()
-            ),
-            reducer: { NoticeAppFeature()._printChanges() }
-          )
-        )
-        .tag(TabBarItem.notice)
-        .tabItem {
-          Image(selection == .notice ? .listFill : .list)
-          
-          Text("공지사항")
-        }
-        
-        BookmarkApp(
-          store: Store(
-            initialState: BookmarkAppFeature.State(
-              bookmarkList: BookmarkListFeature.State()
-            ),
-            reducer: { BookmarkAppFeature() }
-          )
-        )
-        .tag(TabBarItem.archive)
-        .tabItem {
-          Image(selection == .archive ? .archiveFill : .archive)
-          
-          Text("공지보관함")
-        }
-        
-        CampusApp()
-          .tag(TabBarItem.campusMap)
-          .tabItem {
-            Image(selection == .campusMap ? .mapPinFill : .mapPin)
-            
-            Text("캠퍼스맵")
-          }
-        
-        SettingsApp(
-          store: Store(
-            initialState: SettingsAppFeature.State(),
-            reducer: { SettingsAppFeature() }
-          )
-        )
-        .tag(TabBarItem.settings)
-        .tabItem {
-          Image(selection == .settings ? .moreHorizontalFill : .moreHorizontal)
-          
-          Text("더보기")
-        }
-      }
-      .tint(Color.Kuring.gray600)
+    @State private var selection: TabBarItem = .notice
+    
+    @State private var noticeStore = Store(
+      initialState: NoticeAppFeature.State(noticeList: NoticeListFeature.State()),
+      reducer: { NoticeAppFeature()._printChanges() }
+    )
+    
+    @State private var bookmarkStore = Store(
+      initialState: BookmarkAppFeature.State(bookmarkList: BookmarkListFeature.State()),
+      reducer: { BookmarkAppFeature() }
+    )
+    
+    @State private var settingsStore = Store(
+      initialState: SettingsAppFeature.State(),
+      reducer: { SettingsAppFeature() }
+    )
+     
+    enum TabBarItem: Hashable {
+        case notice
+        case archive
+        case campusMap
+        case settings
     }
-  }
+    
+    init() {
+        UITabBar.appearance().barTintColor = UIColor.init(Color.Kuring.bg)
+    }
+    
+    var body: some View {
+        TabView(selection: $selection) {
+            NoticeApp(
+                store: noticeStore
+            )
+            .tag(TabBarItem.notice)
+            .tabItem {
+                Image(selection == .notice ? .listFill : .list)
+                
+                Text("공지사항")
+            }
+            
+            BookmarkApp(
+                store: bookmarkStore
+            )
+            .tag(TabBarItem.archive)
+            .tabItem {
+                Image(selection == .archive ? .archiveFill : .archive)
+                
+                Text("공지보관함")
+            }
+            
+            CampusApp()
+                .tag(TabBarItem.campusMap)
+                .tabItem {
+                    Image(selection == .campusMap ? .mapPinFill : .mapPin)
+                    
+                    Text("캠퍼스맵")
+                }
+            
+            SettingsApp(
+                store: settingsStore
+            )
+            .tag(TabBarItem.settings)
+            .tabItem {
+                Image(selection == .settings ? .moreHorizontalFill : .moreHorizontal)
+                
+                Text("더보기")
+            }
+        }
+        .tint(Color.Kuring.gray600)
+        
+    }
 }
 
 #Preview {

--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -39,10 +39,6 @@ struct ContentView: View {
         case settings
     }
     
-    init() {
-        UITabBar.appearance().barTintColor = UIColor.init(Color.Kuring.bg)
-    }
-    
     var body: some View {
         TabView(selection: $selection) {
             NoticeApp(
@@ -84,7 +80,6 @@ struct ContentView: View {
             }
         }
         .tint(Color.Kuring.gray600)
-        
     }
 }
 

--- a/KuringApp/KuringApp/KuringApp.swift
+++ b/KuringApp/KuringApp/KuringApp.swift
@@ -26,12 +26,13 @@ struct KuringApp: App {
     @Dependency(\.commons) var commons
     
     @Dependency(\.swiftData) var swiftDataService
-        var modelContext: ModelContext {
-            guard let modelContext = try? self.swiftDataService.context() else {
-                fatalError("Could not find modelcontext")
-            }
-            return modelContext
+    
+    var modelContext: ModelContext {
+        guard let modelContext = try? self.swiftDataService.context() else {
+            fatalError("Could not find modelcontext")
         }
+        return modelContext
+    }
     
     var body: some Scene {
         WindowGroup {

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@
 | name | URL | branch | description |
 | ---- | ---- | ------ | ----- |
 | The Satellite | https://github.com/ku-ring/the-satellite | main | iOS API 통신모듈  |
-| Swift Collections | https://github.com/apple/swift-collections | main | OrderedSet |  
-| Composable Architecture | https://github.com/pointfreeco/swift-composable-architecture | main | TCA 구조를 위한 스위프트 패키지 |
+| Swift Collections | https://github.com/apple/swift-collections | 1.1.0 | OrderedSet |  
+| Composable Architecture | https://github.com/pointfreeco/swift-composable-architecture | 1.12.1 | TCA 구조를 위한 스위프트 패키지 |
+| swift-dependencies | https://github.com/pointfreeco/swift-dependencies | 1.9.3 | 디펜던시 관리 라이브러리 |
 | SwiftFormat | https://github.com/nicklockwood/SwiftFormat | 0.50.4 | 코드 스타일 관리 |
 
 ## 기여

--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -35,9 +35,9 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", branch: "main"),
-        .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.1.5"),
-        .package(url: "https://github.com/apple/swift-collections.git", branch: "main"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.12.1"),
+        .package(url: "https://github.com/pointfreeco/swift-dependencies", exact: "1.9.3"),
+        .package(url: "https://github.com/apple/swift-collections.git", exact: "1.1.0"),
         .package(url: "https://github.com/ku-ring/the-satellite", branch: "main"),
         .package(url: "https://github.com/ku-ring/ios-maps", branch: "2.2.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),

--- a/package-kuring/Sources/PushNotifications/Notifications/Notifications.UIApplicationDelegate.swift
+++ b/package-kuring/Sources/PushNotifications/Notifications/Notifications.UIApplicationDelegate.swift
@@ -4,6 +4,8 @@
 //
 
 import UIKit
+import SwiftUI
+import ColorSet
 import Firebase
 
 extension Notifications {
@@ -12,6 +14,7 @@ extension Notifications {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
+        UITabBar.appearance().barTintColor = UIColor(Color.Kuring.bg)
         configureFirebase()
         registerRemoteNotification(for: application)
         return true

--- a/package-kuring/Sources/UIKit/BookmarkUI/BookmarkApp.swift
+++ b/package-kuring/Sources/UIKit/BookmarkUI/BookmarkApp.swift
@@ -21,7 +21,6 @@ public struct BookmarkApp: View {
             )
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("보관함")
-
         } destination: { store in
             switch store.state {
             case .detail:


### PR DESCRIPTION
# 작업 내용

해당 PR은 아래 3가지 수정사항을 포함 합니다. 

***아래 버그는 모두 XCode에서 무선으로 페어링된 기기에 실행 했을때, 빌드속도 오버헤드 때문에 눈에 띄게 심한것으로 추측 됩니다. 상용 앱에서도 발생 하겠지만 체감되지 않을정도 입니다.***

--- 

## 1. TCA Store 생명주기 관리 미흡으로 인해 하단 탭바가 깜빡이던 버그를 수정 합니다

기존에는 ContetView안에서 store를 아래처럼 주입해줬는데, 이러면 ContentView가 렌더링 된때마다 Store가 새로 만들어지게 됩니다. 

```
    TabView(selection: $selection) {
        NoticeApp(
            store: Store(  // ← 매번 새로운 Store 인스턴스 생성
                initialState: NoticeAppFeature.State(
                    noticeList: NoticeListFeature.State()
                ),
                reducer: { NoticeAppFeature()._printChanges() }
            )
        )
    }

```

SwiftUI View는 계산 속성이기 때문입니다. @ State 변수인 `selection`이 바뀔때마다, 즉 탭이 바뀔때마다 렌더링이 되는데 이때 새로운 store 인스턴스가 생성 됩니다.
ContentView 안에서 Store를 @ State 변수로 만들어서 뷰의 생명주기동안 유지하도록 변경 합니다.

**재현영상**

https://github.com/user-attachments/assets/fb7db4f0-f56b-486c-a3db-82ef10ae3c34



## 2. 공지보관함이 깜빡이던 버그를 수정합니다

SwiftUI TabView는 내부적으로 UITabBarController를 사용하기 때문에 ContentView init() 안에 UITabBar.appearance()와 SwiftUI TabView와 충돌한다고 합니다~ 

> 1. ContentView init() → UITabBar.appearance() 설정
> 2. SwiftUI가 TabView 렌더링 → 내부 UITabBar 생성
> 3. 탭 전환 시 → SwiftUI가 tab bar 상태 업데이트
> 4. Appearance 설정이 다시 적용되면서 → 기존 설정과 충돌
> 5. 짧은 순간 깜빡임 발생

UITabBar 코드를 앱델리로 옮겨서 해결 합니다

**재현영상**

https://github.com/user-attachments/assets/179ac73d-e40f-4c6e-844a-afd405d58622

## 3. 디펜던시 버전을 고정합니다

디펜던시 버전을 exact로 고정 하겠습니다. 프로젝트 안정성을 위해서요. 



  
