### PR TITLE
아이패드 iOS 18 탭뷰 대응

### DIFF
--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.swift
@@ -35,6 +35,7 @@ struct MyDepartmentSelector: View {
                     .tag(Step.addedDepartment.id)
             }
             .padding(.top, 56)
+            .tabViewStyle(.page(indexDisplayMode: .never))
             
             // 하단 버튼 영역
             if currentStep == .selectDepartment {


### PR DESCRIPTION
# 작업 내용

아이패드 iOS 18에서 온보딩 화면에 탭뷰 paging indicator가 보이는 이슈를 수정합니다

# 스크린샷

AS-IS

| 1 | 2 |
| ----- | ----- |
|   <img width="2388" height="1668" alt="IMG_0997" src="https://github.com/user-attachments/assets/b77602d1-ca10-4ff4-b078-edc979038fb8" />    |   <img width="2388" height="1668" alt="IMG_0998" src="https://github.com/user-attachments/assets/64b8f41c-43a9-4f4c-b947-87eb74186241" />  |

TO-BE

| 1 | 2 |
| ----- | ----- |
|   <img width="2388" height="1668" alt="IMG_1001" src="https://github.com/user-attachments/assets/b2afbdf7-fcf6-4cf6-be42-84cf5764b19e" />    |   <img width="2388" height="1668" alt="IMG_1002" src="https://github.com/user-attachments/assets/aeae58e9-2741-47a0-8de8-e8819fabcfdd" />  |


