### PR TITLE
[심사 리젝 대응] 아이패드 iOS 18에서 레거시 탭뷰를 사용하도록 수정 합니다

### DIFF
--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -80,6 +80,7 @@ struct ContentView: View {
             }
         }
         .tint(Color.Kuring.gray600)
+        .environment(\.horizontalSizeClass, .compact)
     }
 }
 


### PR DESCRIPTION
# 작업 내용

iOS 18 부터 아이패드에서 기본 TabView가 바뀌어서, iOS 18 이상도 레거시 탭뷰를 사용하도록 수정 합니다. 

# 스크린샷


| AS-IS | TO-BE |
| ----- | ----- |
|    ![KakaoTalk_Photo_2025-08-11-17-26-11 001](https://github.com/user-attachments/assets/afedc897-2145-403a-9727-252ce41df12b)   |    ![KakaoTalk_Photo_2025-08-11-17-26-11 002](https://github.com/user-attachments/assets/6358fb65-f18f-47e9-9f02-d0196b7bde83)   |
