### PR TITLE
공지 캘린더 연동 기능

### DIFF
--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -48,6 +48,13 @@ let package = Package(
     targets: [
         // MARK: App Library Dependencies
         .target(
+            name: "NoticeEKEventUI",
+            dependencies: [
+                "Caches"
+            ],
+            path: "Sources/UIKit/NoticeEKEventUI"
+        ),
+        .target(
             name: "BotUI",
             dependencies: [
                 .product(name: "Lottie", package: "lottie-spm"),
@@ -71,6 +78,7 @@ let package = Package(
                 "BotUI",
                 "BotFeatures",
                 "DepartmentFeatures",
+                "NoticeEKEventUI",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "ActivityUI", package: "package-activityui"),
             ],
@@ -293,7 +301,10 @@ let package = Package(
         .testTarget(
             name: "NoticeFeaturesTests",
             dependencies: [
-                "NoticeFeatures", "SearchFeatures", "Models", "Caches",
+                "NoticeFeatures",
+                "SearchFeatures",
+                "Models",
+                "Caches",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "ActivityUI", package: "package-activityui"),
             ]
@@ -308,7 +319,9 @@ let package = Package(
         .testTarget(
             name: "BookmarkFeaturesTests",
             dependencies: [
-                "BookmarkFeatures", "Caches", "Models",
+                "BookmarkFeatures",
+                "Caches",
+                "Models",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
             ]
         ),

--- a/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
+++ b/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
@@ -12,13 +12,13 @@ import Dependencies
 
 public struct NoticeEKEventStore {
     public typealias NoticeEKEvent = (store: EKEventStore, event: EKEvent)
+    
     /// 전달받은 공지사항으로 EKEvent를 생성
     public var makeEvent: (_ notice: Notice) async -> Void
     /// 생성된 EKEvent 가져오기
     public var getEvent: () -> NoticeEKEvent
     
-    static var event: EKEvent = .init()
-    static var eventStore: EKEventStore = .init()
+    static var noticeEKEvent: NoticeEKEvent = (store: .init(), event: .init())
     
     public init(
         makeEvent: @escaping (_: Notice) async -> Void,
@@ -33,8 +33,8 @@ extension NoticeEKEventStore {
     public static let `default` = NoticeEKEventStore(
         makeEvent: { notice in
             return await withCheckedContinuation { continuation in
-                Self.eventStore = EKEventStore()
-                let event = EKEvent(eventStore: Self.eventStore)
+                let store = EKEventStore()
+                let event = EKEvent(eventStore: store)
                 let defaults = Self.Default()
                 let structuredLocation = EKStructuredLocation(title: defaults.locationTitle)
                 structuredLocation.geoLocation = defaults.geoLocation
@@ -46,11 +46,11 @@ extension NoticeEKEventStore {
                 event.alarms = [defaults.alarm]
                 event.structuredLocation = structuredLocation
                 
-                Self.event = event
+                Self.noticeEKEvent = (store: store, event: event)
                 continuation.resume()
             }
         }, getEvent: {
-            return (store: Self.eventStore, event: Self.event)
+            return Self.noticeEKEvent
         })
 }
 

--- a/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
+++ b/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
@@ -11,14 +11,14 @@ import Dependencies
 
 public struct NoticeEKEventStore {
     /// 전달받은 공지사항으로 EKEvent를 생성
-    public var makeEvent: (_ notice: Notice) -> Void
+    public var makeEvent: (_ notice: Notice) async -> Void
     /// 생성된 EKEvent 가져오기
     public var getEvent: () -> EKEvent?
     
     static var event: EKEvent?
     
     public init(
-        makeEvent: @escaping (_: Notice) -> Void,
+        makeEvent: @escaping (_: Notice) async -> Void,
         getEvent: @escaping () -> EKEvent?
     ) {
         self.makeEvent = makeEvent
@@ -29,20 +29,23 @@ public struct NoticeEKEventStore {
 extension NoticeEKEventStore {
     public static let `default` = NoticeEKEventStore(
         makeEvent: { notice in
-            let eventStore = EKEventStore()
-            let event = EKEvent(eventStore: eventStore)
-            let defaults = Self.Default()
-            let structuredLocation = EKStructuredLocation(title: defaults.locationTitle)
-            structuredLocation.geoLocation = defaults.geoLocation
-            
-            event.title = notice.subject
-            event.url = URL(string: notice.url)
-            event.isAllDay = true
-            event.notes = defaults.notes
-            event.alarms = [defaults.alarm]
-            event.structuredLocation = structuredLocation
-            
-            Self.event = event
+            return await withCheckedContinuation { continuation in
+                let eventStore = EKEventStore()
+                let event = EKEvent(eventStore: eventStore)
+                let defaults = Self.Default()
+                let structuredLocation = EKStructuredLocation(title: defaults.locationTitle)
+                structuredLocation.geoLocation = defaults.geoLocation
+                
+                event.title = notice.subject
+                event.url = URL(string: notice.url)
+                event.isAllDay = true
+                event.notes = defaults.notes
+                event.alarms = [defaults.alarm]
+                event.structuredLocation = structuredLocation
+                
+                Self.event = event
+                continuation.resume()
+            }
         }, getEvent: {
             return Self.event
         })

--- a/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
+++ b/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
@@ -1,0 +1,74 @@
+//
+//  NoticeEKEventStore.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 8/16/25.
+//
+
+import Models
+import EventKit
+import Dependencies
+
+public struct NoticeEKEventStore {
+    /// 전달받은 공지사항으로 EKEvent를 생성
+    public var makeEvent: (_ notice: Notice) -> Void
+    /// 생성된 EKEvent 가져오기
+    public var getEvent: () -> EKEvent?
+    
+    static var event: EKEvent?
+    
+    public init(
+        makeEvent: @escaping (_: Notice) -> Void,
+        getEvent: @escaping () -> EKEvent?
+    ) {
+        self.makeEvent = makeEvent
+        self.getEvent = getEvent
+    }
+}
+
+extension NoticeEKEventStore {
+    public static let `default` = NoticeEKEventStore(
+        makeEvent: { notice in
+            let eventStore = EKEventStore()
+            let event = EKEvent(eventStore: eventStore)
+            let defaults = Self.Default()
+            let structuredLocation = EKStructuredLocation(title: defaults.locationTitle)
+            structuredLocation.geoLocation = defaults.geoLocation
+            
+            event.title = notice.subject
+            event.url = URL(string: notice.url)
+            event.isAllDay = true
+            event.notes = defaults.notes
+            event.alarms = [defaults.alarm]
+            event.structuredLocation = structuredLocation
+            
+            Self.event = event
+        }, getEvent: {
+            return Self.event
+        })
+}
+
+extension NoticeEKEventStore: DependencyKey {
+    public static var liveValue: NoticeEKEventStore = .default
+}
+
+extension DependencyValues {
+    public var noticeEKEventStore: NoticeEKEventStore {
+        get { self[NoticeEKEventStore.self] }
+        set { self[NoticeEKEventStore.self] = newValue }
+    }
+}
+
+extension NoticeEKEventStore {
+    /// 이벤트를 만들때 사용되는 정적 변수
+    struct Default {
+        /// 위치 이름
+        let locationTitle = "건국대학교 05029 대한민국 서울특별시 광진구 능동로 120"
+        /// 위치 좌표
+        let geoLocation = CLLocation(latitude: 37.54360, longitude: 127.07747)
+        /// 24시간 전 알림
+        let alarm = EKAlarm(relativeOffset: -86400)
+        /// 이벤트 상세 내용
+        let notes = "쿠링에서 \(Date.now)에 등록된 일정입니다."
+    }
+}

--- a/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
+++ b/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
@@ -7,19 +7,22 @@
 
 import Models
 import EventKit
+import CoreLocation
 import Dependencies
 
 public struct NoticeEKEventStore {
+    public typealias NoticeEKEvent = (store: EKEventStore, event: EKEvent)
     /// 전달받은 공지사항으로 EKEvent를 생성
     public var makeEvent: (_ notice: Notice) async -> Void
     /// 생성된 EKEvent 가져오기
-    public var getEvent: () -> EKEvent?
+    public var getEvent: () -> NoticeEKEvent
     
-    static var event: EKEvent?
+    static var event: EKEvent = .init()
+    static var eventStore: EKEventStore = .init()
     
     public init(
         makeEvent: @escaping (_: Notice) async -> Void,
-        getEvent: @escaping () -> EKEvent?
+        getEvent: @escaping () -> NoticeEKEvent
     ) {
         self.makeEvent = makeEvent
         self.getEvent = getEvent
@@ -30,8 +33,8 @@ extension NoticeEKEventStore {
     public static let `default` = NoticeEKEventStore(
         makeEvent: { notice in
             return await withCheckedContinuation { continuation in
-                let eventStore = EKEventStore()
-                let event = EKEvent(eventStore: eventStore)
+                Self.eventStore = EKEventStore()
+                let event = EKEvent(eventStore: Self.eventStore)
                 let defaults = Self.Default()
                 let structuredLocation = EKStructuredLocation(title: defaults.locationTitle)
                 structuredLocation.geoLocation = defaults.geoLocation
@@ -47,7 +50,7 @@ extension NoticeEKEventStore {
                 continuation.resume()
             }
         }, getEvent: {
-            return Self.event
+            return (store: Self.eventStore, event: Self.event)
         })
 }
 

--- a/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
+++ b/package-kuring/Sources/Caches/Dependency/NoticeEKEventStore.swift
@@ -11,14 +11,14 @@ import CoreLocation
 import Dependencies
 
 public struct NoticeEKEventStore {
-    public typealias NoticeEKEvent = (store: EKEventStore, event: EKEvent)
+    public typealias NoticeEKEvent = (store: EKEventStore, event: EKEvent?)
     
     /// 전달받은 공지사항으로 EKEvent를 생성
     public var makeEvent: (_ notice: Notice) async -> Void
     /// 생성된 EKEvent 가져오기
     public var getEvent: () -> NoticeEKEvent
     
-    static var noticeEKEvent: NoticeEKEvent = (store: .init(), event: .init())
+    static var noticeEKEvent: NoticeEKEvent = (store: .init(), event: nil)
     
     public init(
         makeEvent: @escaping (_: Notice) async -> Void,

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -111,7 +111,7 @@ public struct NoticeAppFeature {
                 
                 case let .bookmarkUpdated(notice):
                     let isBookmarked = state.noticeList.bookmarkIDs.contains(notice.id)
-                    return.send(.updateBookmarks(notice, isBookmarked))
+                    return .send(.updateBookmarks(notice, isBookmarked))
                 case .showNoticeDetail(let notice):
                     state.path.append(
                         Path.State.detail(

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -112,8 +112,17 @@ public struct NoticeAppFeature {
                 case let .bookmarkUpdated(notice):
                     let isBookmarked = state.noticeList.bookmarkIDs.contains(notice.id)
                     return.send(.updateBookmarks(notice, isBookmarked))
+                case .showNoticeDetail(let notice):
+                    state.path.append(
+                        Path.State.detail(
+                            NoticeDetailFeature.State(
+                                notice: notice,
+                                isBookmarked: state.noticeList.bookmarkIDs.contains(notice.id)
+                            )
+                        )
+                    )
+                    return .none
                 }
-
             case .changeSubscription(.presented(.subscriptionView(.subscriptionResponse))):
                 /// ``SubscriptionAppFeature`` 액션
                 state.changeSubscription = nil

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
@@ -44,7 +44,7 @@ public struct NoticeDetailFeature {
         case delegate(Delegate)
 
         public enum Delegate: Equatable {
-            case bookmarkUpdated(_ notice: Notice, _ isBookmarkd: Bool)
+            case bookmarkUpdated(_ notice: Notice, _ isBookmarked: Bool)
         }
     }
     

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeDetail.swift
@@ -6,6 +6,7 @@
 import Caches
 import Models
 import SwiftUI
+import EventKit
 import ActivityUI
 import ComposableArchitecture
 
@@ -15,10 +16,12 @@ public struct NoticeDetailFeature {
     public struct State: Equatable {
         public var notice: Notice
         public var isBookmarked: Bool = false
+        public var isPresentedEventView: Bool = false
 
         public init(notice: Notice, isBookmarked: Bool? = nil) {
             @Dependency(\.bookmarks) var bookmarks
             self.notice = notice
+            
             if let isBookmarked {
                 self.isBookmarked = isBookmarked
                 return
@@ -33,6 +36,8 @@ public struct NoticeDetailFeature {
 
     public enum Action: BindableAction, Equatable {
         case bookmarkButtonTapped
+        case calendarButtonTapped
+        case presentEventView
         
         case binding(BindingAction<State>)
 
@@ -44,16 +49,25 @@ public struct NoticeDetailFeature {
     }
     
     public var body: some ReducerOf<Self> {
+        BindingReducer()
         Reduce { state, action in
             switch action {
             case .binding:
                 return .none
-                
             case .bookmarkButtonTapped:
                 state.isBookmarked.toggle()
                 return .none
+            case .calendarButtonTapped:
+                @Dependency(\.noticeEKEventStore) var noticeEKEventStore
                 
+                return .run(operation: { [notice = state.notice] send in
+                    await noticeEKEventStore.makeEvent(notice)
+                    await send(.presentEventView)
+                })
             case .delegate:
+                return .none
+            case .presentEventView:
+                state.isPresentedEventView = true
                 return .none
             }
         }

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
@@ -102,6 +102,8 @@ public struct NoticeListFeature {
             case editDepartment
             /// 북마크 업데이트 발생한 경우
             case bookmarkUpdated(Notice)
+            /// 공지를 눌렀을 경우
+            case showNoticeDetail(Notice)
         }
         
         public struct NoticesResult: Equatable {

--- a/package-kuring/Sources/UIKit/NoticeEKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/NoticeEKEventUI/EKEventView.swift
@@ -24,8 +24,10 @@ public struct EKEventView: UIViewControllerRepresentable {
         let eventEditViewController = EKEventEditViewController()
         let getEvent = noticeEKEventStore.getEvent()
         
-        eventEditViewController.eventStore = getEvent.store
-        eventEditViewController.event = getEvent.event
+        if let ekEvent = getEvent.event {
+            eventEditViewController.eventStore = getEvent.store
+            eventEditViewController.event = getEvent.event
+        }
         eventEditViewController.editViewDelegate = context.coordinator
         
         return eventEditViewController

--- a/package-kuring/Sources/UIKit/NoticeEKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/NoticeEKEventUI/EKEventView.swift
@@ -22,14 +22,12 @@ public struct EKEventView: UIViewControllerRepresentable {
 
     public func makeUIViewController(context: Context) -> some UIViewController {
         let eventEditViewController = EKEventEditViewController()
-        guard let ekEvent = noticeEKEventStore.getEvent() else {
-            return eventEditViewController
-        }
+        let getEvent = noticeEKEventStore.getEvent()
         
+        eventEditViewController.eventStore = getEvent.store
+        eventEditViewController.event = getEvent.event
         eventEditViewController.editViewDelegate = context.coordinator
-        eventEditViewController.eventStore = EKEventStore()
-        eventEditViewController.event = ekEvent
-
+        
         return eventEditViewController
     }
 

--- a/package-kuring/Sources/UIKit/NoticeEKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/NoticeEKEventUI/EKEventView.swift
@@ -26,7 +26,7 @@ public struct EKEventView: UIViewControllerRepresentable {
         
         if let ekEvent = getEvent.event {
             eventEditViewController.eventStore = getEvent.store
-            eventEditViewController.event = getEvent.event
+            eventEditViewController.event = ekEvent
         }
         eventEditViewController.editViewDelegate = context.coordinator
         

--- a/package-kuring/Sources/UIKit/NoticeEKEventUI/EKEventView.swift
+++ b/package-kuring/Sources/UIKit/NoticeEKEventUI/EKEventView.swift
@@ -1,0 +1,53 @@
+//
+//  EKEventView.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 8/15/25.
+//
+
+import UIKit
+import Caches
+import SwiftUI
+import EventKit
+import EventKitUI
+import Dependencies
+
+public struct EKEventView: UIViewControllerRepresentable {
+
+    @Environment(\.dismiss) var dismiss
+
+    @Dependency(\.noticeEKEventStore) var noticeEKEventStore
+
+    public init() { }
+
+    public func makeUIViewController(context: Context) -> some UIViewController {
+        let eventEditViewController = EKEventEditViewController()
+        guard let ekEvent = noticeEKEventStore.getEvent() else {
+            return eventEditViewController
+        }
+        
+        eventEditViewController.editViewDelegate = context.coordinator
+        eventEditViewController.eventStore = EKEventStore()
+        eventEditViewController.event = ekEvent
+
+        return eventEditViewController
+    }
+
+    public func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+
+    public func makeCoordinator() -> Coordinator {
+        return Coordinator(self)
+    }
+
+    public class Coordinator: NSObject, EKEventEditViewDelegate {
+        let parent: EKEventView
+
+        init(_ parent: EKEventView) {
+            self.parent = parent
+        }
+
+        public func eventEditViewController(_ controller: EKEventEditViewController, didCompleteWith action: EKEventEditViewAction) {
+            parent.dismiss()
+        }
+    }
+}

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -7,6 +7,7 @@ import Models
 import SwiftUI
 import ColorSet
 import CommonUI
+import NoticeEKEventUI
 import ActivityUI
 import NoticeFeatures
 import ComposableArchitecture
@@ -23,12 +24,20 @@ public struct NoticeDetailView: View {
         WebView(urlString: store.notice.url)
             .background(Color.Kuring.bg)
             .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $store.isPresentedEventView) {
+                EKEventView()
+            }
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     Text(noticeProvider?.korName ?? "")
                 }
                 
                 ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
+                        self.store.send(.calendarButtonTapped)
+                    } label: {
+                        Image(systemName: "calendar.badge.plus")
+                    }
                     Button {
                         self.store.send(.bookmarkButtonTapped)
                     } label: {

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeList.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeList.swift
@@ -16,23 +16,14 @@ struct NoticeList: View {
         Section {
             List(self.store.currentNotices, id: \.id) { notice in
                 ZStack { // Indicator 표시 제거를 위함
-                    NavigationLink(
-                        state: NoticeAppFeature.Path.State.detail(
-                            NoticeDetailFeature.State(
-                                notice: notice,
-                                isBookmarked: self.store.bookmarkIDs.contains(notice.id)
-                            )
-                        )
-                    ) {
-                        EmptyView()
-                    }
-                    .opacity(0)
-                    
                     VStack(spacing: 0) {
                         NoticeRow(
                             notice: notice,
                             bookmarked: self.store.bookmarkIDs.contains(notice.id)
                         )
+                        .onTapGesture {
+                            self.store.send(.delegate(.showNoticeDetail(notice)))
+                        }
                         .onAppear {
                             let type = self.store.provider
                             let noticeInfo = self.store.noticeDictionary[type]

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeRow.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeRow.swift
@@ -53,6 +53,7 @@ public struct NoticeRow: View {
                     .ignoresSafeArea()
             default:
                 Color.clear
+                    .contentShape(Rectangle())
             }
 
             switch rowType {


### PR DESCRIPTION
# 작업 내용

1. 공지사항 캘린더 연동 기능 추가 ([PR](https://github.com/ku-ring/ios-app/pull/238)을 참고하여 작업 했습니다)
2. 공지사항 Reducer State 메모리 낭비 현상 개선 ([이슈](https://github.com/ku-ring/ios-app/issues/246)) 


# 스크린샷

https://github.com/user-attachments/assets/28d6dde4-102c-4089-86b4-4f0c6386f41a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add calendar integration from notice details: tap the new calendar button to open an event editor prefilled with notice info.
  - Tap a notice to open its detail screen.
- Refactor
  - Navigation updated to use explicit actions for smoother, more predictable transitions from list to detail.
- Style
  - Improved tap target on notice rows for more reliable selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->