### PR TITLE
학과 편집하기 UI 개선

### DIFF
--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentEditor.swift
@@ -93,6 +93,7 @@ public struct DepartmentEditor: View {
 
             Spacer()
         }
+        .ignoresSafeArea(.keyboard)
         .padding(.horizontal, 20)
         .background(Color.Kuring.bg)
         .toolbar {

--- a/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/DepartmentUI/DepartmentSelector.swift
@@ -75,21 +75,10 @@ public struct DepartmentSelector: View {
             Spacer()
         }
         .padding(.horizontal, 50)
-        .padding(.vertical, 16)
         .frame(height: 50, alignment: .center)
         .background(backgroundColor)
         .cornerRadius(100)
-        .background {
-            LinearGradient(
-                gradient: Gradient(colors: [
-                    Color.Kuring.bg.opacity(0.1),
-                    Color.Kuring.bg.opacity(0.1),
-                    Color.Kuring.primary.opacity(0.1)
-                ]),
-                startPoint: .top, endPoint: .bottom
-            )
-            .offset(x: 0, y: -32)
-        }
+        .padding(.vertical, 16)
     }
 
     public init(store: StoreOf<DepartmentSelectorFeature>) {


### PR DESCRIPTION
# 작업 내용

학과 편집하기 UI를 개선 합니다
- "내 학과 편집하기" 버튼 패딩값 추가 (아이패드 대응)
- LinearGradient 다크모드에서 이상해 보여서 삭제 
- 아이패드 가로모드에서 키보드 올라오면 컨텐츠 뷰도 같이 올라가서 텍스트 잘리는 현상 수정

# 스크린샷


| iPad AS-IS | iPad AS-IS |
| ----- | ----- |
|   <img width="2388" height="1668" alt="IMG_1012" src="https://github.com/user-attachments/assets/b90d16ac-1f6e-4958-b613-4accd732288a" />    |   <img width="2388" height="1668" alt="IMG_1011" src="https://github.com/user-attachments/assets/2a91cc6e-7424-4ecb-8579-2b9aa5c7f4bc" />    |

| iPad TO-BE | iPad TO-BE |
| ----- | ----- |
|    <img width="2388" height="1668" alt="IMG_1010" src="https://github.com/user-attachments/assets/6a4ec160-21a1-43a6-9547-36bde81e7a50" />  |   <img width="2388" height="1668" alt="IMG_1009" src="https://github.com/user-attachments/assets/888e4e54-840e-49c6-8023-13ac3a8895ab" />    |

| iPhone AS-IS | 
| ----- | 
|   ![IMG_7772](https://github.com/user-attachments/assets/cc666438-4d2d-4e52-abd0-512b3770ed5e)    |  

iPad AS-IS 
--- 
https://github.com/user-attachments/assets/81017322-e9b0-4df3-ae47-df0bfe40c1a1

iPad TO-BE
---
https://github.com/user-attachments/assets/d15fbaee-6b93-4c42-ae42-8eadb36a3a19


