### PR TITLE
온보딩 화면 버그 수정 및 UI 개선

### DIFF
--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
@@ -59,13 +59,18 @@ struct DepartmentSelector: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text(StringSet.title_select.rawValue)
-                .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(Color.Kuring.title)
-            
-            Text(StringSet.description_select.rawValue)
-                .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(Color.Kuring.caption1)
+            VStack(alignment: .leading, spacing: 16) {
+                Text(StringSet.title_select.rawValue)
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundStyle(Color.Kuring.title)
+                    .fixedSize(horizontal: false, vertical: true)
+                
+                Text(StringSet.description_select.rawValue)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Color.Kuring.caption1)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .ignoresSafeArea(.keyboard)
             
             HStack(alignment: .center, spacing: 12) {
                 Image(systemName: "magnifyingglass")

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/DepartmentSelector.swift
@@ -59,7 +59,7 @@ struct DepartmentSelector: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 16) {
+            Group {
                 Text(StringSet.title_select.rawValue)
                     .font(.system(size: 24, weight: .bold))
                     .foregroundStyle(Color.Kuring.title)

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.Step.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.Step.swift
@@ -6,11 +6,9 @@
 import Foundation
 
 extension MyDepartmentSelector {
-    enum Step: Identifiable {
+    enum Step: Int {
         case searchDepartment
         case selectDepartment
         case addedDepartment
-        
-        var id: Self { self }
     }
 }

--- a/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.swift
+++ b/package-kuring/Sources/UIKit/OnboardingUI/MyDepartmentSelector/MyDepartmentSelector.swift
@@ -12,7 +12,7 @@ import Dependencies
 
 struct MyDepartmentSelector: View {
     @Environment(\.dismiss) private var dismiss
-    @State private var currentStep: Step.ID = .searchDepartment.id
+    @State private var currentStep: Step = .searchDepartment
     @State private var selectedDepartment: NoticeProvider? = nil
     
     @Dependency(\.kuringLink) var kuringLink
@@ -21,61 +21,75 @@ struct MyDepartmentSelector: View {
 
     var body: some View {
         VStack {
-            // 메인 영역
-            TabView(selection: $currentStep) {
-                DepartmentSelector(selectedDepartment: $selectedDepartment)
-                    .tag(Step.searchDepartment.id)
-                
-                if let selectedDepartment {
-                    ConfirmationView(department: selectedDepartment)
-                        .tag(Step.selectDepartment.id)
-                }
-                
-                CompletionView()
-                    .tag(Step.addedDepartment.id)
-            }
-            .padding(.top, 56)
-            .tabViewStyle(.page(indexDisplayMode: .never))
-            
-            // 하단 버튼 영역
-            if currentStep == .selectDepartment {
-                Button(StringSet.button_complete.rawValue) {
-                    if let selectedDepartment {
-                        // 로컬 저장소에 학과 추가
-                        NoticeProvider.addedDepartments.append(selectedDepartment)
-                        departments.add(selectedDepartment)
-                        
-                        Task(priority: .background) {
-                            // 추가한 학과 구독, 단 api 성공시에만 구독정보 저장
-                            do {
-                                try await kuringLink.subscribeDepartments([selectedDepartment.hostPrefix])
-                                subscriptions.add(selectedDepartment)
-                            }
-                        }
-                    }
-                    currentStep = .addedDepartment.id
-                }
-                .buttonStyle(.kuringStyle())
-                
-                Button(StringSet.button_again.rawValue) {
-                    currentStep = .searchDepartment.id
-                    selectedDepartment = nil
-                }
-                .font(.system(size: 16, weight: .medium))
-                .foregroundStyle(Color.Kuring.caption1)
-                .padding(.vertical, 20)
-            } else {
-                Button(StringSet.button_start.rawValue) {
-                    dismiss()
-                }
-                .buttonStyle(.kuringStyle(enabled: currentStep == .addedDepartment.id))
-            }
+            contentView
+            bottomView
         }
         .padding(.horizontal, 20)
         .background(Color.Kuring.bg)
         .onChange(of: selectedDepartment) { _, _ in
             guard selectedDepartment != nil else { return }
-            currentStep = .selectDepartment.id
+            currentStep = .selectDepartment
+        }
+    }
+    
+    //MARK: - 메인 영역
+    private var contentView: some View {
+        Group {
+            switch currentStep {
+            case .searchDepartment:
+                DepartmentSelector(selectedDepartment: $selectedDepartment)
+            case .selectDepartment:
+                if let selectedDepartment {
+                    ConfirmationView(department: selectedDepartment)
+                }
+            case .addedDepartment:
+                CompletionView()
+            }
+        }
+        .padding(.top, 56)
+    }
+    
+    //MARK: - 하단 버튼 영역
+    @ViewBuilder
+    private var bottomView: some View {
+        
+        if case let .selectDepartment = currentStep {
+            Button(StringSet.button_complete.rawValue) {
+                handleDepartmentSelection()
+                currentStep = .addedDepartment
+            }
+            .buttonStyle(.kuringStyle())
+            
+            Button(StringSet.button_again.rawValue) {
+                currentStep = .searchDepartment
+                selectedDepartment = nil
+            }
+            .font(.system(size: 16, weight: .medium))
+            .foregroundStyle(Color.Kuring.caption1)
+            .padding(.vertical, 20)
+        } else {
+            Button(StringSet.button_start.rawValue) {
+                dismiss()
+            }
+            .buttonStyle(.kuringStyle(enabled: currentStep == .addedDepartment))
+            .padding(.bottom, 16)
+        }
+    }
+    
+    //MARK: - Department selection action
+    private func handleDepartmentSelection() {
+        if let selectedDepartment {
+            // 로컬 저장소에 학과 추가
+            NoticeProvider.addedDepartments.append(selectedDepartment)
+            departments.add(selectedDepartment)
+            
+            Task(priority: .background) {
+                // 추가한 학과 구독, 단 api 성공시에만 구독정보 저장
+                do {
+                    try await kuringLink.subscribeDepartments([selectedDepartment.hostPrefix])
+                    subscriptions.add(selectedDepartment)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# 작업 내용

1. 온보딩 화면이 TabView로 돼있어서 좌우로 스와이프가 가능했던 버그를 수정 합니다
2. 아이패드에서 가로모드로 키보드가 올라왔을때 온보딩 제목이 잘리던 현상을 수정 합니다
3. `MyDepartmentSelector`의 뷰 코드가 모두 한곳에 있던 부분을 분리하여 개선 합니다


# 스크린샷

## TO-BE 화면에서는 안보이지만 열심히 스와이프 중입니다 🤞

아이패드 
---
| AS-IS | TO-BE |
| ----- | ----- |
|   <video src="https://github.com/user-attachments/assets/19e5b69f-ab09-41fe-af3d-d307ee7d231a" controls> </video>    |   <video src="https://github.com/user-attachments/assets/a616916f-da77-4eee-a442-265f7b73e318" controls> </video>   |

아이폰
---
| AS-IS | TO-BE |
| ----- | ----- |
|   <video src="https://github.com/user-attachments/assets/cc2fff0c-f097-416f-932e-e8fffe30ace6" controls> </video>    |   <video src="https://github.com/user-attachments/assets/772083db-673c-4f49-a3c8-3a572b97acdd" controls> </video>   |








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined, step-by-step department selection with automatic progression after choosing a department.
  * Clearer confirmation and completion screens with simplified action buttons.

* **Bug Fixes**
  * Header texts now wrap correctly and no longer get clipped in multi-line cases.
  * Improved keyboard handling so header content isn’t obscured when the keyboard appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->