### PR TITLE
공지사항 api에 추가된 graduated 필드 대응

### DIFF
--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeList.swift
@@ -181,7 +181,8 @@ public struct NoticeListFeature {
                                     ? "dep" // TODO: korean name 도 쓸 거 고려해서 문자열 말고 좀 더 나은걸로
                                     : provider.hostPrefix,
                                     department,
-                                    retrievalInfo.page
+                                    retrievalInfo.page,
+                                    false
                                 )
                                 return Action.NoticesResult(
                                     provider: provider,

--- a/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
+++ b/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
@@ -18,7 +18,7 @@ extension DependencyValues {
 
 extension KuringLink: DependencyKey {
     public static let liveValue = KuringLink(
-        fetchNotices: { count, type, department, page in
+        fetchNotices: { count, type, department, page, graduted in
             let response: Response<[Notice]> = try await satellite
                 .response(
                     for: Path.getNotices.path,
@@ -28,6 +28,7 @@ extension KuringLink: DependencyKey {
                         .init(name: "department", value: department),
                         .init(name: "page", value: String(page)),
                         .init(name: "size", value: String(count)),
+                        .init(name: "graduated", value: String(graduted)),
                     ]
                 )
             return response.data
@@ -365,7 +366,7 @@ extension KuringLink: DependencyKey {
 
 extension KuringLink {
     public static let testValue: KuringLink = .init(
-        fetchNotices: { _, _, _, _ in
+        fetchNotices: { _, _, _, _, _ in
             [Notice.random]
         },
         sendFeedback: { _ in

--- a/package-kuring/Sources/Networks/KuringLink/KuringLink.swift
+++ b/package-kuring/Sources/Networks/KuringLink/KuringLink.swift
@@ -27,7 +27,7 @@ public struct KuringLink {
             host: (dict["API_HOST"] as? String) ?? "",
             scheme: (dict["USING_HTTPS"] as? Bool) ?? true ? .https : .http
         )
-        satellite._startGPS()
+//        satellite._startGPS()
         return satellite
     }
 

--- a/package-kuring/Sources/Networks/KuringLink/KuringLink.swift
+++ b/package-kuring/Sources/Networks/KuringLink/KuringLink.swift
@@ -27,7 +27,7 @@ public struct KuringLink {
             host: (dict["API_HOST"] as? String) ?? "",
             scheme: (dict["USING_HTTPS"] as? Bool) ?? true ? .https : .http
         )
-        //        satellite._startGPS()
+        satellite._startGPS()
         return satellite
     }
 
@@ -49,7 +49,7 @@ public struct KuringLink {
 
     // MARK: - Notices
     /// 특정 카테고리에 대한 공지를 가져옵니다.
-    public var fetchNotices: (NoticeCount, NoticeType, Department?, Page) async throws -> [Notice]
+    public var fetchNotices: (NoticeCount, NoticeType, Department?, Page, Bool) async throws -> [Notice]
     
     // MARK: - Feedback
     /// 피드백 전송


### PR DESCRIPTION
# 작업 내용 
<!--- 변경 사항에 대해 간단하게 작성 해주세요. -->

- 서버에서 대학원 공지 지원을 위헤 api 요청에 graduated 쿼리파람을 추가했음
- 이에따라 graduated 파라미터 추가

> 지금 서버에서 방어로직 추가해서 배포중입니다~ 확인후 다시 알려드릴게요~!!
> 클라에서도 추후 인자를 추가해주시면 될거 같아요!
> 지금은 graduated없으면 false로 자동인식하고 학사공지로 반환하도록 방어해두었습니다