### PR TITLE
공지사항 댓글 API 구현 

### DIFF
--- a/package-kuring/Sources/Caches/Dependency/Spotlight.swift
+++ b/package-kuring/Sources/Caches/Dependency/Spotlight.swift
@@ -25,7 +25,7 @@ extension Spotlight {
             attributeSet.displayName = notice.subject
             attributeSet.thumbnailData = UIImage(systemName: "AppIcon")?.pngData()
             
-            let searchableItem = CSSearchableItem(uniqueIdentifier: notice.id,
+            let searchableItem = CSSearchableItem(uniqueIdentifier: "\(notice.id)",
                                                   domainIdentifier: "com.kuring.service.bookmarks",
                                                   attributeSet: attributeSet)
             

--- a/package-kuring/Sources/Models/Comments.swift
+++ b/package-kuring/Sources/Models/Comments.swift
@@ -25,12 +25,14 @@ public struct CommentResult: Codable {
 }
 
 public struct Comment: Codable {
-    public let id, parentId, userId: Int
+    public let parentId: Int?
+    public let id, userId: Int
     public let nickName: String
     public let noticeId: Int
     public let content: String
     public let isMine: Bool
-    public let destroyedAt, createdAt, updatedAt: String
+    public let destroyedAt: String?
+    public let createdAt, updatedAt: String
 }
 
 /// 댓글 추가, 수정할때 서버로 보내는 댓글 정보

--- a/package-kuring/Sources/Models/Comments.swift
+++ b/package-kuring/Sources/Models/Comments.swift
@@ -1,0 +1,76 @@
+//
+//  Comments.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 9/26/25.
+//
+
+import Foundation
+
+public struct CommentData: Codable {
+    public let comments: [CommentResult]
+    public let endCursor: String
+    public let hasNext: Bool
+    
+    public init(comments: [CommentResult], endCursor: String, hasNext: Bool) {
+        self.comments = comments
+        self.endCursor = endCursor
+        self.hasNext = hasNext
+    }
+}
+
+public struct CommentResult: Codable {
+    public let comment: Comment
+    public let subComments: [Comment]
+}
+
+public struct Comment: Codable {
+    public let id, parentId, userId: Int
+    public let nickName: String
+    public let noticeId: Int
+    public let content: String
+    public let isMine: Bool
+    public let destroyedAt, createdAt, updatedAt: String
+}
+
+/// 댓글 추가, 수정할때 서버로 보내는 댓글 정보
+public struct CommentRequest: Encodable {
+    public let content: String
+    public let parentId: Int?
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(content, forKey: .content)
+        
+        // nil이 아닐때만 encode
+        if let parentId = parentId {
+            try container.encode(parentId, forKey: .parentId)
+        }
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case content, parentId
+    }
+    
+    public init(content: String, parentId: Int?) {
+        self.content = content
+        self.parentId = parentId
+    }
+}
+
+/// 댓글 신고할때 서버로 보내는 댓글
+public struct ReportCommentRequest: Encodable {
+    public let targetId: Int
+    public let reportType: ReportType
+    public let content: String
+
+    public enum ReportType: String, Encodable {
+        case COMMENT
+    }
+    
+    public init(targetId: Int, reportType: ReportType, content: String) {
+        self.targetId = targetId
+        self.reportType = reportType
+        self.content = content
+    }
+}

--- a/package-kuring/Sources/Models/Comments.swift
+++ b/package-kuring/Sources/Models/Comments.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct CommentData: Codable {
     public let comments: [CommentResult]
-    public let endCursor: String
+    public let endCursor: String?
     public let hasNext: Bool
     
     public init(comments: [CommentResult], endCursor: String, hasNext: Bool) {

--- a/package-kuring/Sources/Models/Comments.swift
+++ b/package-kuring/Sources/Models/Comments.swift
@@ -12,7 +12,7 @@ public struct CommentData: Codable {
     public let endCursor: String?
     public let hasNext: Bool
     
-    public init(comments: [CommentResult], endCursor: String, hasNext: Bool) {
+    public init(comments: [CommentResult], endCursor: String?, hasNext: Bool) {
         self.comments = comments
         self.endCursor = endCursor
         self.hasNext = hasNext

--- a/package-kuring/Sources/Models/Notice.swift
+++ b/package-kuring/Sources/Models/Notice.swift
@@ -6,8 +6,9 @@
 import Foundation
 
 /// 공지
-public struct Notice: Codable, Hashable, Identifiable, Equatable {
-    public var id: String { "\(category)_\(articleId)" }
+public struct Notice: Codable, Identifiable, Hashable, Equatable {
+    /// e.g., `76473`
+    public var id: Int
     /// e.g., `"5b45b56"`
     public let articleId: String
     /// e.g., `"post_date_1"`
@@ -20,18 +21,21 @@ public struct Notice: Codable, Hashable, Identifiable, Equatable {
     public let category: String
     /// e.g., `true`
     public let important: Bool
+    public let commentCount: Int
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
     
-    public init(articleId: String, postedDate: String, subject: String, url: String, category: String, important: Bool) {
+    public init(id: Int, articleId: String, postedDate: String, subject: String, url: String, category: String, important: Bool, commentCount: Int) {
+        self.id = id
         self.articleId = articleId
         self.postedDate = postedDate
         self.subject = subject
         self.url = url
         self.category = category
         self.important = important
+        self.commentCount = commentCount
     }
 }
 
@@ -46,6 +50,9 @@ extension Notice {
     /// try Notice(userInfo: userInfo)
     /// ```
     public init(userInfo: [String: Any]) throws {
+        guard let id = userInfo["id"] as? Int else {
+            throw DecodingError.noID
+        }
         guard let articleID = userInfo["articleId"] as? String else {
             throw DecodingError.noArticleID
         }
@@ -62,20 +69,25 @@ extension Notice {
             throw DecodingError.noCategory
         }
         let important = userInfo["important"] as? Bool
+        let commentCount = userInfo["commentCount"] as? Int
         
         self.init(
+            id: id,
             articleId: articleID,
             postedDate: postedDate,
             subject: subject,
             url: baseUrl,
             category: category,
-            important: important ?? false
+            important: important ?? false,
+            commentCount: commentCount ?? 0
         )
     }
     
     /// 서버값으로 부터 공지 알림을 디코딩 하지 못했을 때 던지는 에러.
     /// - Note: 현재는 푸시 알림 디코딩에만 사용되고 있습니다.
     public enum DecodingError: Error {
+        /// `id` 없음
+        case noID
         /// `articleId` 없음
         case noArticleID
         /// `subject` 없음
@@ -92,6 +104,8 @@ extension Notice {
 extension Notice.DecodingError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .noID:
+            "\"id\" 키에 해당하는 값이 없습니다"
         case .noArticleID:
             "\"articleId\" 키에 해당하는 값이 없습니다"
         case .noSubject:
@@ -110,12 +124,14 @@ extension Notice.DecodingError: LocalizedError {
 extension Notice {
     public static var random: Notice {
         Notice(
+            id: 123,
             articleId: "5389",
             postedDate: "2024-02-21",
             subject: "2024학년도 신입생 입학식 개최 안내",
             url: "https://www.konkuk.ac.kr/bbs/konkuk/234/5389/artclView.do",
             category: "bachelor",
-            important: false
+            important: false,
+            commentCount: 0
         )
     }
 }
@@ -123,7 +139,7 @@ extension Notice {
 /// 검색된 공지
 /// - Note: 서버의 json 데이터의 depth 가 달라 추가된 모델
 public struct SearchedNotice: Codable, Hashable {
-    public var id: String { baseUrl }
+    public var id: Int
     /// e.g., `"5b45b56"`
     public let articleId: String
     /// e.g., `"post_date_1"`
@@ -134,6 +150,8 @@ public struct SearchedNotice: Codable, Hashable {
     public let baseUrl: String
     /// e.g., `"student"`
     public let category: String
+    /// e.g., `13`
+    public let commentCount: Int
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(baseUrl)
@@ -141,12 +159,14 @@ public struct SearchedNotice: Codable, Hashable {
 
     public var asNotice: Notice {
         Notice(
+            id: id,
             articleId: articleId,
             postedDate: postedDate,
             subject: subject,
             url: baseUrl,
             category: category,
-            important: false
+            important: false,
+            commentCount: commentCount
         )
     }
 }

--- a/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
+++ b/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
@@ -379,8 +379,7 @@ extension KuringLink: DependencyKey {
                     ]
                 )
             
-            let isSucceed = (200 ..< 300) ~= response.code
-            return isSucceed ? response.data : .init(comments: [], endCursor: "", hasNext: false)
+            return response.data
         },
         addComment: { noticeId, content, parentId in
             let response: EmptyResponse = try await satellite
@@ -553,7 +552,7 @@ extension KuringLink {
         withdrawAccount: {
             return true
         },
-        getComments: { _, _, size in
+        getComments: { _, _, _ in
             return .init(comments: [], endCursor: "", hasNext: false)
         },
         addComment: { _, _, _ in

--- a/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
+++ b/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
@@ -359,6 +359,79 @@ extension KuringLink: DependencyKey {
                 accessToken = ""
             }
             return isSucceed
+        },
+        getComments: { noticeId, cursor, size in
+            var queryItems: [URLQueryItem] = []
+            if let cursor {
+                queryItems.append(.init(name: "cursor", value: cursor))
+            }
+            if let size {
+                queryItems.append(.init(name: "size", value: String(size)))
+            }
+            let response: Response<CommentData> = try await satellite
+                .response(
+                    for: Path.getComments(id: noticeId).path,
+                    httpMethod: .get,
+                    queryItems: queryItems
+                )
+            
+            let isSucceed = (200 ..< 300) ~= response.code
+            return isSucceed ? response.data : .init(comments: [], endCursor: "", hasNext: false)
+        },
+        addComment: { noticeId, content, parentId in
+            let response: EmptyResponse = try await satellite
+                .response(
+                    for: Path.addComment(id: noticeId).path,
+                    httpMethod: .post,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "Authorization": "Bearer \(accessToken)"
+                    ],
+                    httpBody: CommentRequest(content: content, parentId: parentId)
+                )
+            let isSucceed = (200 ..< 300) ~= response.code
+            return isSucceed
+        },
+        editComment: { noticeId, content, commentId in
+            let response: EmptyResponse = try await satellite
+                .response(
+                    for: Path.editComment(noticeId: noticeId, commentId: commentId).path,
+                    httpMethod: .post,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "Authorization": "Bearer \(accessToken)"
+                    ],
+                    httpBody: CommentRequest(content: content, parentId: nil)
+                )
+            let isSucceed = (200 ..< 300) ~= response.code
+            return isSucceed
+        },
+        deleteComment: { noticeId, commentId in
+            let response: EmptyResponse = try await satellite
+                .response(
+                    for: Path.deleteComment(noticeId: noticeId, commentId: commentId).path,
+                    httpMethod: .delete,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "Authorization": "Bearer \(accessToken)"
+                    ]
+                )
+            let isSucceed = (200 ..< 300) ~= response.code
+            return isSucceed
+        },
+        reportComment: { commentId, content in
+            let response: EmptyResponse = try await satellite
+                .response(
+                    for: Path.reportComment.path,
+                    httpMethod: .post,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "User-Token": fcmToken
+                    ],
+                    httpBody: ReportCommentRequest(targetId: commentId, reportType: .COMMENT, content: content)
+                )
+            let isSucceed = (200 ..< 300) ~= response.code
+            return isSucceed
         }
     )
 }
@@ -474,6 +547,21 @@ extension KuringLink {
             return true
         },
         withdrawAccount: {
+            return true
+        },
+        getComments: { _, _, size in
+            return .init(comments: [], endCursor: "", hasNext: false)
+        },
+        addComment: { _, _, _ in
+            return true
+        },
+        editComment: { _, _, _ in
+            return true
+        },
+        deleteComment: { _, _ in
+            return true
+        },
+        reportComment: { _, _ in
             return true
         }
     )

--- a/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
+++ b/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
@@ -372,7 +372,11 @@ extension KuringLink: DependencyKey {
                 .response(
                     for: Path.getComments(id: noticeId).path,
                     httpMethod: .get,
-                    queryItems: queryItems
+                    queryItems: queryItems,
+                    httpHeaders: [
+                        "Content-Type": "application/json",
+                        "Authorization": "Bearer \(accessToken)"
+                    ]
                 )
             
             let isSucceed = (200 ..< 300) ~= response.code

--- a/package-kuring/Sources/Networks/KuringLink/API.Path.swift
+++ b/package-kuring/Sources/Networks/KuringLink/API.Path.swift
@@ -26,6 +26,11 @@ enum Path {
     case getUserInfo
     case resetPassword
     case withdrawAccount
+    case getComments(id: Int)
+    case addComment(id: Int)
+    case editComment(noticeId: Int, commentId: Int)
+    case deleteComment(noticeId: Int, commentId: Int)
+    case reportComment
 
     var path: String {
         switch self {
@@ -69,6 +74,12 @@ enum Path {
             return "api/v2/users/password"
         case .withdrawAccount:
             return "api/v2/users/withdraw"
+        case .getComments(let id), .addComment(let id):
+            return "api/v2/notices/\(id)/comments"
+        case .editComment(let noticeId, let commentId), .deleteComment(let noticeId, let commentId):
+            return "api/v2/notices/\(noticeId)/comments/\(commentId)"
+        case .reportComment:
+            return "api/v2/reports"
         }
     }
 }

--- a/package-kuring/Sources/Networks/KuringLink/KuringLink.swift
+++ b/package-kuring/Sources/Networks/KuringLink/KuringLink.swift
@@ -95,4 +95,14 @@ public struct KuringLink {
     public var resetPassword: (_ email: String, _ password: String) async throws -> Bool
     /// 회원 탈퇴
     public var withdrawAccount: () async throws -> Bool
+    /// 댓글 조회
+    public var getComments: (_ noticeId: Int, _ cursor: String?, _ size: Int32?) async throws -> CommentData
+    /// 댓글 추가
+    public var addComment: (_ noticeId: Int, _ content: String, _ parentId: Int?) async throws -> Bool
+    /// 댓글 수정
+    public var editComment: (_ noticeId: Int, _ content: String, _ commentId: Int) async throws -> Bool
+    /// 댓글 삭제
+    public var deleteComment: (_ noticeId: Int, _ commentId: Int) async throws -> Bool
+    /// 댓글 신고
+    public var reportComment: (_ commentId: Int, _ content: String) async throws -> Bool
 }


### PR DESCRIPTION
# 작업 내용 
<!--- 변경 사항에 대해 간단하게 작성 해주세요. -->

공지사항 댓글 기능에 필요한 모든 API 구현
- 댓글 조회
- 댓글 추가
- 댓글 수정
- 댓글 삭제
- 댓글 신고

아마 공지사항 댓글 기능을 추가하면서 공지사항 GET API응답에 id 라는 값이 추가된걸로 보임. 
iOS에서는 DTO에 id 값이 추가가 안된 상태였었음.
그래서 id 추가 및 이에 대한 코드 수정

# 스크린샷 
<!--- 작업된 내용의 스크린샷을 첨부 해주세요. -->
<!--- 번거롭더라도 부탁 드립니다~ 🙏 -->

# 논의사항
<!--- 작업에 대해 논의가 필요한 내용이 있다면 남겨주세요. -->

테스트는 모두 완료됐습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 공지 댓글 기능 추가: 댓글 조회(페이지네이션), 작성, 수정, 삭제, 신고 지원
  * 공지 목록/상세에 댓글 수 표시

* 버그 수정
  * 푸시 알림으로 공지 열기 안정성 개선(필수 ID 검증 강화)
  * 기기 검색(Spotlight) 인덱싱 호환성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->