### PR TITLE
공지사항 댓글 추가 QA 대응 

### DIFF
--- a/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
+++ b/package-kuring/Sources/Networks/Depdencies/KuringLink.Dependency.swift
@@ -374,8 +374,7 @@ extension KuringLink: DependencyKey {
                     httpMethod: .get,
                     queryItems: queryItems,
                     httpHeaders: [
-                        "Content-Type": "application/json",
-                        "Authorization": "Bearer \(accessToken)"
+                        "Content-Type": "application/json"
                     ]
                 )
             

--- a/package-kuring/Sources/UIKit/NoticeUI/Comments/CommentTextField.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/Comments/CommentTextField.swift
@@ -20,11 +20,12 @@ struct CommentTextField: UIViewRepresentable {
     @Binding var text: String
     @Binding var isReply: Bool
     @Binding var calculatedHeight: CGFloat
+    @AppStorage("com.kuring.sdk.v2.token.accessToken") var accessToken: String = ""
     
     // 최대 줄 수
     let maxLines: Int = 5
     let verticalPadding: CGFloat = 11.0
-
+    
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
         textView.font = .systemFont(ofSize: 15, weight: .medium)
@@ -49,14 +50,14 @@ struct CommentTextField: UIViewRepresentable {
         
         return textView
     }
-
+    
     func updateUIView(_ uiView: UITextView, context: Context) {
         Task { @MainActor in
-            var newPlaceholder = isReply ? "대댓글 추가..." : "댓글 추가..."
-            if uiView.textColor == UIColor(Color.Kuring.caption2) {
-                if uiView.text != newPlaceholder {
-                    uiView.text = newPlaceholder
-                }
+            let parentText = context.coordinator.parent.text
+            
+            // 바인딩 값이 비었을때 placeholder 노출는 로직
+            if parentText.isEmpty {
+                setPlaceholder(for: uiView)
             }
             
             let fittingSize = uiView.sizeThatFits(CGSize(width: uiView.frame.width, height: CGFloat.infinity))
@@ -67,6 +68,26 @@ struct CommentTextField: UIViewRepresentable {
             if !(fittingSize.height >= maxHeight) {
                 self.calculatedHeight = fittingSize.height
             } 
+        }
+    }
+    
+    private func setPlaceholder(for uiView: UITextView) {
+        var newPlaceholder = accessToken == "" ? "로그인 후 댓글을 추가해보세요!" : (isReply ? "대댓글 추가..." : "댓글 추가...")
+        // placeholder모드 여부
+        let isPlaceholderMode = uiView.textColor == UIColor(Color.Kuring.caption2)
+        
+        // 입력이 없는 상태(초기 placeholder 상태)
+        if isPlaceholderMode {
+            if uiView.text != newPlaceholder {
+                uiView.text = newPlaceholder
+            }
+        }
+        // 입력이 있는 상태
+        else if !uiView.text.isEmpty && !isPlaceholderMode {
+            if uiView.text != newPlaceholder {
+                uiView.text = newPlaceholder
+                uiView.textColor = UIColor(Color.Kuring.caption2)
+            }
         }
     }
 
@@ -96,7 +117,7 @@ struct CommentTextField: UIViewRepresentable {
         
         func textViewDidEndEditing(_ textView: UITextView) {
             if textView.text.isEmpty {
-                textView.text = parent.isReply ? "대댓글 추가..." : "댓글 추가..."
+                textView.text = parent.accessToken == "" ? "로그인 후 댓글을 추가해보세요!" : (parent.isReply ? "대댓글 추가..." : "댓글 추가...")
                 textView.textColor = UIColor(Color.Kuring.caption2)
             }
         }

--- a/package-kuring/Sources/UIKit/NoticeUI/Comments/CommentView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/Comments/CommentView.swift
@@ -124,13 +124,13 @@ struct CommentView: View {
      
     private var sendButton: some View {
         Button {
-            guard !commentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                  accessToken != "" else {
+            guard !commentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 return
             }
             onSendComment(commentText, parentId)
             commentText = ""
             parentId = nil
+            isTextFieldFocused = nil
         } label: {
             Circle()
                 .fill(

--- a/package-kuring/Sources/UIKit/NoticeUI/Comments/CommentView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/Comments/CommentView.swift
@@ -80,6 +80,11 @@ struct CommentView: View {
         .padding(.top, 20)
         .padding(.bottom, 14)
         .background(Color.Kuring.bg)
+        .onChange(of: parentId) { _, newValue in
+            if newValue != nil {
+                isTextFieldFocused = true
+            }
+        }
     }
     
     private var headerView: some View {

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeDetailView.swift
@@ -30,6 +30,10 @@ public struct NoticeDetailView: View {
                     CommentView(
                         comments: store.comments?.comments ?? [],
                         onSendComment: { comment, parentId in
+                            if accessToken.isEmpty {
+                                store.send(.showNeedsLoginAlert)
+                                return
+                            }
                             store.send(.addComment(content: comment, parentId: parentId))
                         },
                         onDeleteComment: { comment in
@@ -79,9 +83,6 @@ public struct NoticeDetailView: View {
                     )
                 )
                 .onAppear {
-                    guard !accessToken.isEmpty else {
-                        return
-                    }
                     store.send(.getComments)
                 }
             
@@ -104,11 +105,7 @@ public struct NoticeDetailView: View {
             .padding(.bottom, 20)
             .padding(.trailing, 16)
             .onTapGesture {
-                if accessToken.isEmpty {
-                    store.send(.showNeedsLoginAlert)
-                } else {
-                    store.send(.toggleCommentSection)
-                }
+                store.send(.toggleCommentSection)
             }
         }
     }


### PR DESCRIPTION
# 작업 내용 
<!--- 변경 사항에 대해 간단하게 작성 해주세요. -->

공지사항 댓글 추가 기능 빌드 2.3.3(1) QA 대응
- 댓글은 로그인 안해도 볼수는 있습니다! 작성을 못할뿐!
  - 로그인 유도 팝업 댓글 작성시로 시점 변경
- 댓글 단 후에, 댓글창 초기화 안되는게 어색함
  - 댓글 단 후에 댓글창 초기화 하도록 수정
- 대댓글 눌렀을때 키보드 올라오도록 수정

# 스크린샷 
<!--- 작업된 내용의 스크린샷을 첨부 해주세요. -->
<!--- 번거롭더라도 부탁 드립니다~ 🙏 -->

| AS-IS | TO-BE |
| ----- | ----- |
|    <video src="https://github.com/user-attachments/assets/344ac46c-c5fb-4971-a9f7-a6f19a4ebb7a" controls> </video>    |    <video src="https://github.com/user-attachments/assets/47b4158a-6599-45a3-b953-c77d264076cb" controls> </video>   |

