### PR TITLE
학사일정 UI 구현 [캘린더, 바텀시트]

### DIFF
--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
                 "CommonUI",
                 "OnboardingUI",
                 "LoginUI",
+                "AcademicCalendarUI",
                 "PushNotifications",
             ]
         ),
@@ -53,6 +54,7 @@ let package = Package(
             dependencies: [
                 "ColorSet",
                 "Caches",
+                "CommonUI",
                 "AcademicCalendarFeatures",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ],
@@ -202,7 +204,7 @@ let package = Package(
                 "Networks",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ],
-            path: "Sources/UIKit/AcademicCalendarFeatures"
+            path: "Sources/Features/AcademicCalendarFeatures"
         ),
         .target(
             name: "BotFeatures",

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -26,7 +26,7 @@ struct AcademicCalendar: View {
         "2025-10-13": [.yellow],
         "2025-10-18": [.green],
         "2025-10-20": [.green],
-        "2025-11-3": [.green, .red, .green, .blue, .teal]
+        "2025-11-3": [.green, .red, .yellow, .blue, .teal]
     ]
     
     let calendar = Calendar.current

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -1,0 +1,129 @@
+//
+//  AcademicCalendar.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/20/25.
+//
+
+import SwiftUI
+import ColorSet
+import Combine
+import CommonUI
+
+struct AcademicCalendar: View {
+    @State private var currentDate = Date()
+    @State private var selectedDate: Date?
+    @State private var months: [Date] = []
+    @State private var currentMonthIndex = 1
+    
+    @State private var dateDots: [String: [Color]] = [
+        "2025-8-7": [.yellow, .green, .gray],
+        "2025-8-13": [.yellow],
+        "2025-8-18": [.green],
+        "2025-8-20": [.green]
+    ]
+    
+    let calendar = Calendar.current
+    let weekdays = ["일", "월", "화", "수", "목", "금", "토"]
+    
+    @State private var pageIdx = 1
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: 0) {
+                HStack {
+                    Text(monthYearString)
+                        .font(.system(size: 18, weight: .semibold))
+                    
+                    Spacer()
+                    
+                    HStack(spacing: 26) {
+                        Button {
+                            currentMonthIndex -= 1
+                            handleInfiniteScroll(for: currentMonthIndex)
+                        } label: {
+                            Image(systemName: "chevron.left")
+                                .foregroundColor(.green)
+                                .font(.system(size: 20))
+                        }
+                        
+                        Button {
+                            currentMonthIndex += 1
+                            handleInfiniteScroll(for: currentMonthIndex)
+                        } label: {
+                            Image(systemName: "chevron.right")
+                                .foregroundColor(.green)
+                                .font(.system(size: 20))
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                
+                HStack(spacing: 18) {
+                    ForEach(weekdays, id: \.self) { day in
+                        Text(day)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(Color.Kuring.gray300)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .padding(.horizontal, 19.5)
+                .padding(.top, 16)
+            }
+            
+            ScrollViewReader { proxy in
+                TabView(selection: $currentMonthIndex) {
+                    ForEach(Array(months.enumerated()), id: \.offset) { index, month in
+                        CalendarMonthView(
+                            month: month,
+                            selectedDate: $selectedDate,
+                            dateDots: dateDots
+                        )
+                        .tag(index)
+                    }
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never)) // Snap-style scroll
+                .frame(height: 380)
+                .onChangeDebounced(of: currentMonthIndex, delay: 0.3) { newIndex in
+                    handleInfiniteScroll(for: newIndex)
+                }
+                .onAppear {
+                    initializeMonths()
+                }
+            }
+        }
+    }
+    
+    var monthYearString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "M월 yyyy"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: currentDate)
+    }
+    
+    func initializeMonths() {
+        let prevMonth = calendar.date(byAdding: .month, value: -1, to: currentDate) ?? currentDate
+        let nextMonth = calendar.date(byAdding: .month, value: 1, to: currentDate) ?? currentDate
+        months = [prevMonth, currentDate, nextMonth]
+    }
+
+    func handleInfiniteScroll(for index: Int) {
+        guard !months.isEmpty else { return }
+
+        if index == 0 {
+            let newPrev = calendar.date(byAdding: .month, value: -1, to: months.first!)!
+            months.insert(newPrev, at: 0)
+            currentMonthIndex = 1
+        } else if index == months.count - 1 {
+            let newNext = calendar.date(byAdding: .month, value: 1, to: months.last!)!
+            months.append(newNext)
+        }
+        currentDate = months[currentMonthIndex]
+    }
+}
+
+struct CalendarView_Previews: PreviewProvider {
+    static var previews: some View {
+        AcademicCalendar()
+    }
+}

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -17,10 +17,10 @@ struct AcademicCalendar: View {
     @State private var currentMonthIndex = 1
     
     @State private var dateDots: [String: [Color]] = [
-        "2025-8-7": [.yellow, .green, .gray],
-        "2025-8-13": [.yellow],
-        "2025-8-18": [.green],
-        "2025-8-20": [.green]
+        "2025-10-7": [.yellow, .green, .gray],
+        "2025-10-13": [.yellow],
+        "2025-10-18": [.green],
+        "2025-10-20": [.green]
     ]
     
     let calendar = Calendar.current
@@ -31,69 +31,81 @@ struct AcademicCalendar: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(spacing: 0) {
-                HStack {
-                    Text(monthYearString)
-                        .font(.system(size: 18, weight: .semibold))
-                    
-                    Spacer()
-                    
-                    HStack(spacing: 26) {
-                        Button {
-                            currentMonthIndex -= 1
-                            handleInfiniteScroll(for: currentMonthIndex)
-                        } label: {
-                            Image(systemName: "chevron.left")
-                                .foregroundColor(.green)
-                                .font(.system(size: 20))
-                        }
-                        
-                        Button {
-                            currentMonthIndex += 1
-                            handleInfiniteScroll(for: currentMonthIndex)
-                        } label: {
-                            Image(systemName: "chevron.right")
-                                .foregroundColor(.green)
-                                .font(.system(size: 20))
-                        }
-                    }
-                }
-                .padding(.horizontal, 20)
-                
-                HStack(spacing: 18) {
-                    ForEach(weekdays, id: \.self) { day in
-                        Text(day)
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundColor(Color.Kuring.gray300)
-                            .frame(maxWidth: .infinity)
-                    }
-                }
-                .padding(.horizontal, 19.5)
-                .padding(.top, 16)
+                headerView
+                weekdaysView
             }
-            
-            ScrollViewReader { proxy in
-                TabView(selection: $currentMonthIndex) {
-                    ForEach(Array(months.enumerated()), id: \.offset) { index, month in
-                        CalendarMonthView(
-                            month: month,
-                            selectedDate: $selectedDate,
-                            dateDots: dateDots
-                        )
-                        .tag(index)
-                    }
-                }
-                .tabViewStyle(.page(indexDisplayMode: .never)) // Snap-style scroll
-                .frame(height: 380)
-                .onChangeDebounced(of: currentMonthIndex, delay: 0.3) { newIndex in
-                    handleInfiniteScroll(for: newIndex)
-                }
-                .onAppear {
-                    initializeMonths()
-                }
-            }
+            calendarContent
         }
     }
     
+    private var headerView: some View {
+        HStack {
+            Text(monthYearString)
+                .font(.system(size: 18, weight: .semibold))
+            
+            Spacer()
+            
+            HStack(spacing: 26) {
+                Button {
+                    currentMonthIndex -= 1
+                    handleInfiniteScroll(for: currentMonthIndex)
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.green)
+                        .font(.system(size: 20))
+                }
+                
+                Button {
+                    currentMonthIndex += 1
+                    handleInfiniteScroll(for: currentMonthIndex)
+                } label: {
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.green)
+                        .font(.system(size: 20))
+                }
+            }
+        }
+        .padding(.horizontal, 30)
+    }
+    
+    private var weekdaysView: some View {
+        HStack {
+            ForEach(weekdays, id: \.self) { day in
+                Text(day)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Color.Kuring.gray300)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.horizontal, 19.5)
+        .padding(.top, 24)
+    }
+    
+    private var calendarContent: some View {
+        ScrollViewReader { proxy in
+            TabView(selection: $currentMonthIndex) {
+                ForEach(Array(months.enumerated()), id: \.offset) { index, month in
+                    CalendarMonthView(
+                        month: month,
+                        selectedDate: $selectedDate,
+                        dateDots: dateDots
+                    )
+                    .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .frame(height: 306)
+            .onChangeDebounced(of: currentMonthIndex, delay: 0.3) { newIndex in
+                handleInfiniteScroll(for: newIndex)
+            }
+            .onAppear {
+                initializeMonths()
+            }
+        }
+    }
+}
+
+extension AcademicCalendar {
     var monthYearString: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "M월 yyyy"
@@ -108,7 +120,9 @@ struct AcademicCalendar: View {
     }
 
     func handleInfiniteScroll(for index: Int) {
-        guard !months.isEmpty else { return }
+        guard !months.isEmpty else {
+            return
+        }
 
         if index == 0 {
             let newPrev = calendar.date(byAdding: .month, value: -1, to: months.first!)!

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -20,11 +20,13 @@ struct AcademicCalendar: View {
     @State private var months: [Date] = []
     @State private var currentMonthIndex = 1
     
+    /// MOCK DATA
     @State private var eventDots: [String: [Color]] = [
         "2025-10-7": [.yellow, .green, .gray],
         "2025-10-13": [.yellow],
         "2025-10-18": [.green],
-        "2025-10-20": [.green]
+        "2025-10-20": [.green],
+        "2025-11-3": [.green, .red, .green, .blue, .teal]
     ]
     
     let calendar = Calendar.current
@@ -37,6 +39,16 @@ struct AcademicCalendar: View {
                 weekdaysView
             }
             calendarContent
+            
+            Divider()
+                .frame(height: 2)
+                .padding(.top, 22)
+            
+            if let selectedDate, !getDotsForDate(selectedDate).isEmpty, isSameMonthAndYear(selectedDate, currentDate) {
+                eventInfo(for: getDotsForDate(selectedDate))
+            } else {
+                Spacer()
+            }
         }
     }
     
@@ -105,6 +117,42 @@ struct AcademicCalendar: View {
             }
         }
     }
+    
+    @ViewBuilder
+    private func eventInfo(for events: [Color]) -> some View {
+        ScrollView(.vertical) {
+            VStack(spacing: 0) {
+                ForEach(events, id: \.self) { color in
+                    VStack(alignment: .leading) {
+                        HStack(spacing: 8) {
+                            Capsule()
+                                .fill(color)
+                                .frame(width: 4)
+                                .frame(maxHeight: .infinity)
+                            
+                            VStack(spacing: 8) {
+                                Text("수강 바구니 1차")
+                                    .foregroundStyle(Color.Kuring.title)
+                                    .font(.system(size: 15, weight: .medium))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                
+                                Text("8. 04 (월) 오전 9:30 - 8. 05 (화) 오전 9:30 ")
+                                    .foregroundStyle(Color.Kuring.caption1)
+                                    .font(.system(size: 12, weight: .medium))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                        Divider()
+                            .padding(.top, 16)
+                    }
+                    .padding(.top, 16)
+                    .padding(.horizontal, 20)
+                }
+            }
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .scrollIndicators(.never)
+    }
 }
 
 extension AcademicCalendar {
@@ -135,6 +183,17 @@ extension AcademicCalendar {
             months.append(newNext)
         }
         currentDate = months[currentMonthIndex]
+    }
+    
+    func getDotsForDate(_ date: Date) -> [Color] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-M-d"
+        let dateString = formatter.string(from: date)
+        return eventDots[dateString] ?? []
+    }
+    
+    func isSameMonthAndYear(_ d1: Date, _ d2: Date) -> Bool {
+        calendar.isDate(d1, equalTo: d2, toGranularity: .month)
     }
 }
 

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -7,16 +7,20 @@
 
 import SwiftUI
 import ColorSet
-import Combine
 import CommonUI
 
+/// 학사 일정 캘린더 뷰
+/// ```swift
+///   AcademicCalendar()
+/// ```
+///  - Parameters: none
 struct AcademicCalendar: View {
     @State private var currentDate = Date()
     @State private var selectedDate: Date?
     @State private var months: [Date] = []
     @State private var currentMonthIndex = 1
     
-    @State private var dateDots: [String: [Color]] = [
+    @State private var eventDots: [String: [Color]] = [
         "2025-10-7": [.yellow, .green, .gray],
         "2025-10-13": [.yellow],
         "2025-10-18": [.green],
@@ -25,8 +29,6 @@ struct AcademicCalendar: View {
     
     let calendar = Calendar.current
     let weekdays = ["일", "월", "화", "수", "목", "금", "토"]
-    
-    @State private var pageIdx = 1
     
     var body: some View {
         VStack(spacing: 0) {
@@ -48,20 +50,20 @@ struct AcademicCalendar: View {
             HStack(spacing: 26) {
                 Button {
                     currentMonthIndex -= 1
-                    handleInfiniteScroll(for: currentMonthIndex)
+                    handleMonthChange(for: currentMonthIndex)
                 } label: {
                     Image(systemName: "chevron.left")
-                        .foregroundColor(.green)
-                        .font(.system(size: 20))
+                        .foregroundColor(Color.Kuring.primary)
+                        .font(.system(size: 20, weight: .medium))
                 }
                 
                 Button {
                     currentMonthIndex += 1
-                    handleInfiniteScroll(for: currentMonthIndex)
+                    handleMonthChange(for: currentMonthIndex)
                 } label: {
                     Image(systemName: "chevron.right")
-                        .foregroundColor(.green)
-                        .font(.system(size: 20))
+                        .foregroundColor(Color.Kuring.primary)
+                        .font(.system(size: 20, weight: .medium))
                 }
             }
         }
@@ -88,7 +90,7 @@ struct AcademicCalendar: View {
                     CalendarMonthView(
                         month: month,
                         selectedDate: $selectedDate,
-                        dateDots: dateDots
+                        eventDots: eventDots
                     )
                     .tag(index)
                 }
@@ -96,7 +98,7 @@ struct AcademicCalendar: View {
             .tabViewStyle(.page(indexDisplayMode: .never))
             .frame(height: 306)
             .onChangeDebounced(of: currentMonthIndex, delay: 0.3) { newIndex in
-                handleInfiniteScroll(for: newIndex)
+                handleMonthChange(for: newIndex)
             }
             .onAppear {
                 initializeMonths()
@@ -119,7 +121,7 @@ extension AcademicCalendar {
         months = [prevMonth, currentDate, nextMonth]
     }
 
-    func handleInfiniteScroll(for index: Int) {
+    func handleMonthChange(for index: Int) {
         guard !months.isEmpty else {
             return
         }

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
@@ -8,7 +8,23 @@
 import SwiftUI
 import ColorSet
 
-struct BottomSheetContent: View {
+/// 주요 학사 일정을 한번에 보여주는 바텀시트 뷰
+/// 높이는 **280**으로 사용
+/// ```swift
+///    .sheet(isPresented: $isPresented) {
+///        AcademicScheduleSheet(
+///            schedules: schedules,
+///            isPresented: $isPresented
+///        )
+///        .presentationDetents([.height(280)])
+///        .presentationCornerRadius(20)
+///        .presentationDragIndicator(.visible)
+///    }
+/// ```
+///  - Parameters:
+///    - schedules: 보여줄 학사 일정들
+///    - isPresented: 바텀시트 노출 여부
+struct AcademicScheduleSheet: View {
     let schedules: [ScheduleItem]
     @State var currentPage: Int = 0
     @Binding var isPresented: Bool
@@ -60,6 +76,12 @@ struct BottomSheetContent: View {
     }
 }
 
+/// 학사 일정 바텀시트에 사용되는 하나의 학사 일정 카드
+/// ```swift
+///    ScheduleCard(schedule: schedules[index])
+/// ```
+///  - Parameters:
+///    - schedule: 보여줄 학사 일정
 struct ScheduleCard: View {
     let schedule: ScheduleItem
     
@@ -106,7 +128,7 @@ struct ScheduleItem {
         .padding()
     }
     .sheet(isPresented: $isPresented) {
-        BottomSheetContent(
+        AcademicScheduleSheet(
             schedules: schedules,
             isPresented: $isPresented
         )

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
@@ -1,0 +1,117 @@
+//
+//  AcademicScheduleSheet.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/23/25.
+//
+
+import SwiftUI
+import ColorSet
+
+struct BottomSheetContent: View {
+    let schedules: [ScheduleItem]
+    @State var currentPage: Int = 0
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("이번 주 예정된 학사일정을 확인해보아요")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(Color.Kuring.title)
+                .padding(.top, 24)
+
+            TabView(selection: $currentPage) {
+                ForEach(schedules.indices, id: \.self) { index in
+                    ScheduleCard(schedule: schedules[index])
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .padding(.top, 16)
+            
+            HStack(spacing: 8) {
+                ForEach(schedules.indices, id: \.self) { index in
+                    Circle()
+                        .fill(currentPage == index ? Color.Kuring.primary : Color.Kuring.primary.opacity(0.3))
+                        .frame(width: 8, height: 8)
+                        .animation(.easeInOut(duration: 0.3), value: currentPage)
+                }
+            }
+            .padding(.top, 24)
+            
+            Button(action: {
+                isPresented = false
+            }) {
+                Text("학사일정 전체 확인하기 >")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(Color.Kuring.bg)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 56)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .background(
+                        Capsule()
+                            .fill(Color.Kuring.primary)
+                    )
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 10)
+            .padding(.top, 24)
+        }
+    }
+}
+
+struct ScheduleCard: View {
+    let schedule: ScheduleItem
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(schedule.title)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(Color.Kuring.title)
+            
+            Text(schedule.date)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(Color.Kuring.caption1)
+        }
+        .frame(maxHeight: 60)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 15)
+                .fill(Color.Kuring.primarySelected)
+        )
+        .padding(.horizontal, 20)
+    }
+}
+
+struct ScheduleItem {
+    let title: String
+    let date: String
+}
+
+#Preview {
+    @Previewable @State var currentPage = 0
+    @Previewable @State var isPresented = false
+    
+    let schedules = [
+        ScheduleItem(title: "학사일정 text", date: "8. 04 (월) 오전 9:30 - 8. 05 (화) 오후 5:00"),
+        ScheduleItem(title: "학사일정 text", date: "8. 06 (수) 오전 10:00 - 8. 07 (목) 오후 3:00"),
+        ScheduleItem(title: "학사일정 text", date: "8. 08 (금) 오전 11:00 - 8. 09 (토) 오후 4:00")
+    ]
+    
+    VStack {
+        Button("Show Schedule") {
+            isPresented = true
+        }
+        .padding()
+    }
+    .sheet(isPresented: $isPresented) {
+        BottomSheetContent(
+            schedules: schedules,
+            isPresented: $isPresented
+        )
+        .presentationDetents([.height(280)])
+        .presentationCornerRadius(20)
+        .presentationDragIndicator(.visible)
+    }
+}

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
@@ -7,16 +7,27 @@
 
 import SwiftUI
 
-struct DateInfo {
-    let date: Date
-    let day: Int
-    let isCurrentMonth: Bool
-}
-
+/// 학사 일정 캘린더에 하나의 달을 나타내는 뷰
+/// 하나의 달은 "DateCellView"로 이루어져있음
+/// ```swift
+///  CalendarMonthView(
+///      month: Date(),
+///      selectedDate: .constant(Date()),
+///      dateDots: [
+///          "2025-10-22": [
+///              .green, .blue, .red
+///          ]
+///      ]
+///  )
+/// ```
+///  - Parameters:
+///    - month: 해당 달의 Date 객체 (날짜 자체는 상관없음, 월만 중요함)
+///    - selectedDate: 사용자가 탭하여 선택한 날짜, 바인딩이 필요하기 때문에 주입받아야함
+///    - eventDots: 해당 날짜의 학사일정들
 struct CalendarMonthView: View {
     let month: Date
     @Binding var selectedDate: Date?
-    let dateDots: [String: [Color]]
+    let eventDots: [String: [Color]]
     
     let calendar = Calendar.current
     
@@ -93,15 +104,21 @@ extension CalendarMonthView {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-M-d"
         let dateString = formatter.string(from: date)
-        return dateDots[dateString] ?? []
+        return eventDots[dateString] ?? []
     }
+}
+
+struct DateInfo {
+    let date: Date
+    let day: Int
+    let isCurrentMonth: Bool
 }
 
 #Preview {
     CalendarMonthView(
         month: Date(),
         selectedDate: .constant(Date()),
-        dateDots: [
+        eventDots: [
             "2025-10-22": [
                 .green, .blue, .red
             ]

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
@@ -1,0 +1,104 @@
+//
+//  CalendarMonthView.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/22/25.
+//
+
+import SwiftUI
+
+struct DateInfo {
+    let date: Date
+    let day: Int
+    let isCurrentMonth: Bool
+}
+
+struct CalendarMonthView: View {
+    let month: Date
+    @Binding var selectedDate: Date?
+    let dateDots: [String: [Color]]
+    
+    let calendar = Calendar.current
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(0..<numberOfWeeks, id: \.self) { weekIndex in
+                HStack(spacing: 8) {
+                    ForEach(0..<7) { dayIndex in
+                        if let dateInfo = getDateInfo(for: weekIndex, dayIndex: dayIndex) {
+                            DateCellView(
+                                dateInfo: dateInfo,
+                                isSelected: isSelected(dateInfo.date),
+                                dots: getDotsForDate(dateInfo.date),
+                                onTap: {
+                                    if dateInfo.isCurrentMonth {
+                                        selectedDate = dateInfo.date
+                                    }
+                                }
+                            )
+                            .frame(maxWidth: .infinity)
+                            .frame(height: rowHeight)
+                        } else {
+                            Color.clear
+                                .frame(maxWidth: .infinity)
+                                .frame(height: rowHeight)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+        .frame(width: UIScreen.main.bounds.width)
+    }
+    
+    var numberOfWeeks: Int {
+        let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: month))!
+        let firstWeekday = calendar.component(.weekday, from: firstDay)
+        let daysInMonth = calendar.range(of: .day, in: .month, for: month)!.count
+        
+        let totalDays = firstWeekday + daysInMonth - 1
+        return Int(ceil(Double(totalDays) / 7.0))
+    }
+    
+    var rowHeight: CGFloat {
+        return 380.0 / CGFloat(numberOfWeeks)
+    }
+    
+    func getDateInfo(for weekIndex: Int, dayIndex: Int) -> DateInfo? {
+        let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: month))!
+        let firstWeekday = calendar.component(.weekday, from: firstDay)
+        
+        let dayOffset = weekIndex * 7 + dayIndex - firstWeekday + 1
+        
+        guard let date = calendar.date(byAdding: .day, value: dayOffset, to: firstDay) else {
+            return nil
+        }
+        
+        let isCurrentMonth = calendar.isDate(date, equalTo: month, toGranularity: .month)
+        let day = calendar.component(.day, from: date)
+        
+        return DateInfo(date: date, day: day, isCurrentMonth: isCurrentMonth)
+    }
+    
+    func isSelected(_ date: Date) -> Bool {
+        guard let selectedDate = selectedDate else { return false }
+        return calendar.isDate(date, inSameDayAs: selectedDate)
+    }
+    
+    func getDotsForDate(_ date: Date) -> [Color] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-M-d"
+        let dateString = formatter.string(from: date)
+        return dateDots[dateString] ?? []
+    }
+}
+
+#Preview {
+    CalendarMonthView(
+        month: Date(),
+        selectedDate: .constant(Date()),
+        dateDots: [
+            "2025-10-22": [.green, .blue, .red]
+        ]
+    )
+}

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
@@ -23,7 +23,7 @@ struct CalendarMonthView: View {
     var body: some View {
         VStack(spacing: 0) {
             ForEach(0..<numberOfWeeks, id: \.self) { weekIndex in
-                HStack(spacing: 8) {
+                HStack {
                     ForEach(0..<7) { dayIndex in
                         if let dateInfo = getDateInfo(for: weekIndex, dayIndex: dayIndex) {
                             DateCellView(
@@ -36,7 +36,7 @@ struct CalendarMonthView: View {
                                     }
                                 }
                             )
-                            .frame(maxWidth: .infinity)
+                            .frame(maxWidth: .infinity, alignment: .center)
                             .frame(height: rowHeight)
                         } else {
                             Color.clear
@@ -47,10 +47,12 @@ struct CalendarMonthView: View {
                 }
             }
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, 19.5)
         .frame(width: UIScreen.main.bounds.width)
     }
-    
+}
+
+extension CalendarMonthView {
     var numberOfWeeks: Int {
         let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: month))!
         let firstWeekday = calendar.component(.weekday, from: firstDay)
@@ -61,7 +63,7 @@ struct CalendarMonthView: View {
     }
     
     var rowHeight: CGFloat {
-        return 380.0 / CGFloat(numberOfWeeks)
+        return 306.0 / CGFloat(numberOfWeeks)
     }
     
     func getDateInfo(for weekIndex: Int, dayIndex: Int) -> DateInfo? {
@@ -81,7 +83,9 @@ struct CalendarMonthView: View {
     }
     
     func isSelected(_ date: Date) -> Bool {
-        guard let selectedDate = selectedDate else { return false }
+        guard let selectedDate = selectedDate else {
+            return false
+        }
         return calendar.isDate(date, inSameDayAs: selectedDate)
     }
     
@@ -98,7 +102,9 @@ struct CalendarMonthView: View {
         month: Date(),
         selectedDate: .constant(Date()),
         dateDots: [
-            "2025-10-22": [.green, .blue, .red]
+            "2025-10-22": [
+                .green, .blue, .red
+            ]
         ]
     )
 }

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import ColorSet
 
 struct DateCellView: View {
     let dateInfo: DateInfo
@@ -18,10 +19,11 @@ struct DateCellView: View {
             VStack(spacing: 4) {
                 Text("\(dateInfo.day)")
                     .font(.system(size: 16))
-                    .foregroundColor(isSelected ? .white : (dateInfo.isCurrentMonth ? .black : .gray))
+                    .foregroundColor(isSelected ? Color.Kuring.primary : (dateInfo.isCurrentMonth ? Color.Kuring.title : Color.Kuring.gray300))
                     .background(
                         Circle()
-                            .fill(isSelected ? Color.green : Color.clear)
+                            .fill(isSelected ? Color.Kuring.primarySelected : Color.clear)
+                            .frame(width: 26, height: 26)
                     )
                 
                 if !dots.isEmpty {
@@ -29,13 +31,30 @@ struct DateCellView: View {
                         ForEach(0..<dots.count, id: \.self) { index in
                             Rectangle()
                                 .fill(dots[index])
-                                .frame(width: 8, height: 4)
+                                .frame(width: 5, height: 5)
                         }
                     }
                     .clipShape(Capsule())
+                    .padding(.top, 4)
                 }
             }
         }
         .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    DateCellView(
+        dateInfo: .init(
+            date: Date(),
+            day: 3,
+            isCurrentMonth: true
+        ),
+        isSelected: true,
+        dots: [
+            .red, .green, .yellow
+        ]
+    ) {
+        print("Tapped")
     }
 }

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
@@ -8,6 +8,27 @@
 import SwiftUI
 import ColorSet
 
+/// 학사 일정 캘린더에 하나의 날짜를 나타내는 뷰
+/// ```swift
+///   DateCellView(
+///       dateInfo: .init(
+///           date: Date(),
+///           day: 3,
+///           isCurrentMonth: true
+///       ),
+///       isSelected: true,
+///       dots: [
+///           .red, .green, .yellow
+///       ]
+///   ) {
+///       print("Tapped")
+///   }
+/// ```
+///  - Parameters:
+///    - dateInfo: 하나의 날짜의 정보를 나타내는 DateInfo 객체. 해당 날짜, day(월~일), 그리고 currentMonth 정보를 담고있음.
+///    - isSelected: 사용자가 탭하여 선택한 날짜인지 나타내는 값
+///    - dots: 해당 날짜의 학사일정들, 있다면
+///    - onTap: 날짜를 탭했을때 액션을 수행함
 struct DateCellView: View {
     let dateInfo: DateInfo
     let isSelected: Bool

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
@@ -1,0 +1,41 @@
+//
+//  DateCellView.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/22/25.
+//
+
+import SwiftUI
+
+struct DateCellView: View {
+    let dateInfo: DateInfo
+    let isSelected: Bool
+    let dots: [Color]
+    let onTap: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 4) {
+                Text("\(dateInfo.day)")
+                    .font(.system(size: 16))
+                    .foregroundColor(isSelected ? .white : (dateInfo.isCurrentMonth ? .black : .gray))
+                    .background(
+                        Circle()
+                            .fill(isSelected ? Color.green : Color.clear)
+                    )
+                
+                if !dots.isEmpty {
+                    HStack(spacing: 0) {
+                        ForEach(0..<dots.count, id: \.self) { index in
+                            Rectangle()
+                                .fill(dots[index])
+                                .frame(width: 8, height: 4)
+                        }
+                    }
+                    .clipShape(Capsule())
+                }
+            }
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}

--- a/package-kuring/Sources/UIKit/CommonUI/View.onChangedDebounce.swift
+++ b/package-kuring/Sources/UIKit/CommonUI/View.onChangedDebounce.swift
@@ -1,0 +1,41 @@
+//
+//  View.onChangedDebounce.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/22/25.
+//
+
+import SwiftUI
+
+struct DebouncedAsyncChangeModifier<Value: Equatable>: ViewModifier {
+    let target: Value
+    let delay: TimeInterval
+    let action: (Value) async -> Void
+
+    @State private var task: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: target) { newValue in
+                task?.cancel()
+                task = Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(delay))
+                    if Task.isCancelled { return }
+                    await action(newValue)
+                }
+            }
+            .onDisappear {
+                task?.cancel()
+            }
+    }
+}
+
+extension View {
+    public func onChangeDebounced<Value: Equatable>(
+        of value: Value,
+        delay: TimeInterval = 0.5,
+        perform action: @escaping (Value) async -> Void
+    ) -> some View {
+        modifier(DebouncedAsyncChangeModifier(target: value, delay: delay, action: action))
+    }
+}

--- a/package-kuring/Sources/UIKit/NoticeUI/Resources/Symbols.xcassets/comment/report_icon.imageset/Contents.json
+++ b/package-kuring/Sources/UIKit/NoticeUI/Resources/Symbols.xcassets/comment/report_icon.imageset/Contents.json
@@ -1,17 +1,17 @@
 {
   "images" : [
     {
-      "filename" : "신고.png",
+      "filename" : "신고.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "filename" : "신고 (1).png",
+      "filename" : "신고 (1).png",
       "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "filename" : "신고 (2).png",
+      "filename" : "신고 (2).png",
       "idiom" : "universal",
       "scale" : "3x"
     }


### PR DESCRIPTION
# 작업 내용 
<!--- 변경 사항에 대해 간단하게 작성 해주세요. -->

학사일정 기능에 대한 UI를 구현 합니다.
현재는 목데이터를 기반으로 동작하며, 추후 TCA 구조에서 비즈니스 로직을 분리할 예정 입니다.

- 학사 일정 캘린더 
- 학시 일정 바텀시트
- 목데이터로 임시 구현
- 비즈니스 로직 리듀서로 분리할것 (tca 브랜치에서)

# 스크린샷 
<!--- 작업된 내용의 스크린샷을 첨부 해주세요. -->
<!--- 번거롭더라도 부탁 드립니다~ 🙏 -->

학사일정 캘린더 
---

| iPhone | iPad |
| ----- | ----- |
|   <video src="https://github.com/user-attachments/assets/e344ae16-50ab-40df-96b2-561f2d6f2e34" controls> </video>   |   <video src="https://github.com/user-attachments/assets/ab7ddbb9-87ef-4264-a566-2495d8d7b18c" controls> </video>   |

학사일정 바텀시트
---

| iPhone | iPad |
| ----- | ----- |
|   <video src="https://github.com/user-attachments/assets/a3ff392d-f973-4f06-8bcf-38e71faaddb2" controls> </video>   |   <video src="https://github.com/user-attachments/assets/5264a80a-89e9-4828-b9f8-23634270217d" controls> </video>   |


# 논의사항
<!--- 작업에 대해 논의가 필요한 내용이 있다면 남겨주세요. -->

캘린더를 TabView로 구현 했는데, iOS 17 이상이라 ScrollView -> scrollTargetBehavior, ScrollPosition으로도 구현 가능하나 스와이프 감속/스냅이 마음에 들지 않아서 + 스크롤뷰 빠르게 스와이프시 깜빡이는 등의 문제로 더 간단한 TabView를 사용했다. 

TabView도 빠르게 여러번 스크롤을 하면 간헐적으로 인덱스 중간에서 멈추는 현상이 있어서 해결하기 위해 이것저것 해봤으나,
스크롤, 즉 페이지값의 onChange에 디바운스를 걸어놓는것이 가장 좋은 해결책으로 파악했다.
`onChangeDebounced`라는 모디파이어를 추가했다~ ([여기](https://github.com/ku-ring/ios-app/blob/8b5cd4ed674c1846b0ba3a8fb59f73a5a201304c/package-kuring/Sources/UIKit/CommonUI/View.onChangedDebounce.swift))



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 학사 달력 UI 추가: 다중월 보기, 월 네비게이션, 날짜 선택 기능
  * 달력에 이벤트 표시 기능 (색상 표시)
  * 학사 일정 조회를 위한 바텀 시트 컴포넌트 추가
  * 디바운스 기능이 적용된 비동기 변경 감지 유틸리티 추가

* **개선 사항**
  * 파일 구조 정규화 및 패키지 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->