### PR TITLE
학사일정 TCA, SwiftData, 캐싱 구현

### DIFF
--- a/KuringApp/KuringApp/BottomTabView.swift
+++ b/KuringApp/KuringApp/BottomTabView.swift
@@ -5,27 +5,52 @@
 //  Created by Jung Hwan Park on 9/15/25.
 //
 
+import Caches
 import SwiftUI
+import Dependencies
 
-enum TabBarItem: Hashable, CaseIterable {
-    case notice
-    case calendar
-    case campusMap
-    case settings
+struct BottomTabView: View {
+    @Bindable var activeTab: ActiveTabStore
     
-    var title: String {
-        switch self {
-        case .notice:
-            return "공지사항"
-        case .calendar:
-            return "학사일정"
-        case .campusMap:
-            return "캠퍼스맵"
-        case .settings:
-            return "더보기"
+    @Environment(\.colorScheme) private var colorScheme
+    private var tabForegroundColor: Color {
+        colorScheme == .dark ? .white : .black
+    }
+    
+    var body: some View {
+        HStack(alignment: .center) {
+            ForEach(TabBarItem.allCases, id: \.title) { tab in
+                tabView(tabItem: tab)
+                    .onTapGesture {
+                        activeTab.value = tab
+                    }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: 49)
+        .ignoresSafeArea(edges: .bottom)
+        .background(
+            Color.Kuring.gray100
+        )
+        .overlay(alignment: .top) {
+            Divider()
         }
     }
     
+    @ViewBuilder
+    private func tabView(tabItem: TabBarItem) -> some View {
+        VStack {
+            Image(activeTab.value == tabItem ? tabItem.selectedImage : tabItem.defaultImage)
+                .frame(height: 28)
+            
+            Text(tabItem.title)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(activeTab.value == tabItem ? tabForegroundColor : .gray)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+extension TabBarItem {
     var selectedImage: ImageResource {
         switch self {
         case .notice:
@@ -50,46 +75,5 @@ enum TabBarItem: Hashable, CaseIterable {
         case .settings:
             return .moreHorizontal
         }
-    }
-}
-
-struct BottomTabView: View {
-    @Binding var activeTab: TabBarItem
-    
-    @Environment(\.colorScheme) private var colorScheme
-    private var tabForegroundColor: Color {
-        colorScheme == .dark ? .white : .black
-    }
-    
-    var body: some View {
-        HStack(alignment: .center) {
-            ForEach(TabBarItem.allCases, id: \.title) { tab in
-                tabView(tabItem: tab)
-                    .onTapGesture {
-                        activeTab = tab
-                    }
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: 49)
-        .ignoresSafeArea(edges: .bottom)
-        .background(
-            Color.Kuring.gray100
-        )
-        .overlay(alignment: .top) {
-            Divider()
-        }
-    }
-    
-    @ViewBuilder
-    private func tabView(tabItem: TabBarItem) -> some View {
-        VStack {
-            Image(activeTab == tabItem ? tabItem.selectedImage : tabItem.defaultImage)
-                .frame(height: 28)
-            
-            Text(tabItem.title)
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(activeTab == tabItem ? tabForegroundColor : .gray)
-        }
-        .frame(maxWidth: .infinity)
     }
 }

--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -3,11 +3,13 @@
 // See the 'License.txt' file for licensing information.
 //
 
+import Caches
 import SwiftUI
 import ColorSet
 import CampusUI
 import NoticeUI
 import SettingsUI
+import Dependencies
 import NoticeFeatures
 import BookmarkFeatures
 import SettingsFeatures
@@ -16,7 +18,9 @@ import ComposableArchitecture
 import AcademicCalendarFeatures
 
 struct ContentView: View {
-    @State var activeTab: TabBarItem = .notice
+    @Dependency(\.activeTab) var activeTab
+    @State private var tabStore: ActiveTabStore
+    
     // 앱 최초 구동 시점에 1회 공지를 가져오기 위함
     @Binding var didAppear: Bool
     
@@ -37,12 +41,13 @@ struct ContentView: View {
 
     init(didAppear: Binding<Bool>) {
         self._didAppear = didAppear
+        self.tabStore = ActiveTabDependency.liveValue.store
     }
     
     var body: some View {
         VStack(spacing: 0) {
             Group {
-                switch activeTab {
+                switch tabStore.value {
                 case .notice:
                     NoticeApp(store: noticeStore)
                 case .calendar:
@@ -57,7 +62,7 @@ struct ContentView: View {
             .background(Color.Kuring.bg)
             .environment(\.horizontalSizeClass, .compact)
             .tabViewStyle(.page(indexDisplayMode: .never))
-            .onChange(of: activeTab) { oldValue, newValue in
+            .onChange(of: tabStore.value) { oldValue, newValue in
                 if oldValue != newValue && newValue == .notice {
                     noticeStore.send(.noticeList(.reloadNotices))
                 }
@@ -69,7 +74,7 @@ struct ContentView: View {
                 }
             }
             
-            BottomTabView(activeTab: $activeTab)
+            BottomTabView(activeTab: tabStore)
         }
     }
 }

--- a/KuringApp/KuringApp/ContentView.swift
+++ b/KuringApp/KuringApp/ContentView.swift
@@ -7,13 +7,13 @@ import SwiftUI
 import ColorSet
 import CampusUI
 import NoticeUI
-import BookmarkUI
 import SettingsUI
 import NoticeFeatures
 import BookmarkFeatures
 import SettingsFeatures
 import AcademicCalendarUI
 import ComposableArchitecture
+import AcademicCalendarFeatures
 
 struct ContentView: View {
     @State var activeTab: TabBarItem = .notice
@@ -25,9 +25,9 @@ struct ContentView: View {
       reducer: { NoticeAppFeature()._printChanges() }
     )
     
-    @State private var bookmarkStore = Store(
-      initialState: BookmarkAppFeature.State(bookmarkList: BookmarkListFeature.State()),
-      reducer: { BookmarkAppFeature() }
+    @State private var calendarStore = Store(
+      initialState: AcademicCalendarFeature.State(),
+      reducer: { AcademicCalendarFeature() }
     )
     
     @State private var settingsStore = Store(
@@ -46,7 +46,7 @@ struct ContentView: View {
                 case .notice:
                     NoticeApp(store: noticeStore)
                 case .calendar:
-                    AcademicCalendar()
+                    AcademicCalendar(store: calendarStore)
                 case .campusMap:
                     CampusApp()
                 case .settings:

--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -286,6 +286,7 @@ let package = Package(
                 "Caches",
                 "SubscriptionFeatures",
                 "LoginFeatures",
+                "AcademicCalendarFeatures",
                 "Labs",
                 "Networks",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")

--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -223,6 +223,7 @@ let package = Package(
                 "SearchFeatures",
                 "LoginFeatures",
                 "SubscriptionFeatures",
+                "AcademicCalendarFeatures",
                 "Networks",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "ActivityUI", package: "package-activityui"),

--- a/package-kuring/Package.swift
+++ b/package-kuring/Package.swift
@@ -202,6 +202,7 @@ let package = Package(
             name: "AcademicCalendarFeatures",
             dependencies: [
                 "Networks",
+                "Caches",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ],
             path: "Sources/Features/AcademicCalendarFeatures"

--- a/package-kuring/Sources/Caches/Dependency/AcademicEvent.swift
+++ b/package-kuring/Sources/Caches/Dependency/AcademicEvent.swift
@@ -10,7 +10,7 @@ import SwiftData
 import Models
 
 public struct AcademicScheduleDB {
-    public var fetchAll: @Sendable (FetchDescriptor<AcademicScheduleEntity>) throws -> [AcademicScheduleEntity]
+    public var fetch: @Sendable (FetchDescriptor<AcademicScheduleEntity>) throws -> AcademicScheduleEntity?
     public var add: @Sendable (AcademicScheduleEntity) throws -> Void
     public var delete: @Sendable (AcademicScheduleEntity) throws -> Void
     public var update: @Sendable (AcademicScheduleEntity, [AcademicEventEntity]) throws -> Void
@@ -25,12 +25,16 @@ public struct AcademicScheduleDB {
 
 extension AcademicScheduleDB: DependencyKey {
     public static let liveValue = Self(
-        fetchAll: { descriptor in
-            @Dependency(\.swiftData.context) var modelContext
-            let context = try modelContext()
-            return try context.fetch(descriptor)
+        fetch: { descriptor in
+            do {
+                @Dependency(\.swiftData.context) var modelContext
+                let context = try modelContext()
+                let descriptor = FetchDescriptor<AcademicScheduleEntity>()
+                return try context.fetch(descriptor).first
+            } catch {
+                throw DBError.fetch
+            }
         },
-        
         add: { schedule in
             do {
                 @Dependency(\.swiftData.context) var modelContext
@@ -41,7 +45,6 @@ extension AcademicScheduleDB: DependencyKey {
                 throw DBError.add
             }
         },
-        
         delete: { schedule in
             do {
                 @Dependency(\.swiftData.context) var modelContext
@@ -70,14 +73,14 @@ extension AcademicScheduleDB: DependencyKey {
 
 extension AcademicScheduleDB: TestDependencyKey {
     public static let testValue = Self(
-        fetchAll: unimplemented("\(Self.self).fetchAll"),
+        fetch: unimplemented("\(Self.self).fetch"),
         add: unimplemented("\(Self.self).add"),
         delete: unimplemented("\(Self.self).delete"),
         update: unimplemented("\(Self.self).update")
     )
     
     public static let noop = Self(
-        fetchAll: { _ in [] },
+        fetch: { _ in nil },
         add: { _ in },
         delete: { _ in },
         update: { _, _ in }

--- a/package-kuring/Sources/Caches/Dependency/AcademicEvent.swift
+++ b/package-kuring/Sources/Caches/Dependency/AcademicEvent.swift
@@ -29,7 +29,6 @@ extension AcademicScheduleDB: DependencyKey {
             do {
                 @Dependency(\.swiftData.context) var modelContext
                 let context = try modelContext()
-                let descriptor = FetchDescriptor<AcademicScheduleEntity>()
                 return try context.fetch(descriptor).first
             } catch {
                 throw DBError.fetch

--- a/package-kuring/Sources/Caches/Dependency/AcademicEvent.swift
+++ b/package-kuring/Sources/Caches/Dependency/AcademicEvent.swift
@@ -1,0 +1,92 @@
+//
+//  AcademicEvent.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/25/25.
+//
+
+import Dependencies
+import SwiftData
+import Models
+
+public struct AcademicScheduleDB {
+    public var fetchAll: @Sendable (FetchDescriptor<AcademicScheduleEntity>) throws -> [AcademicScheduleEntity]
+    public var add: @Sendable (AcademicScheduleEntity) throws -> Void
+    public var delete: @Sendable (AcademicScheduleEntity) throws -> Void
+    public var update: @Sendable (AcademicScheduleEntity, [AcademicEventEntity]) throws -> Void
+    
+    public enum DBError: Error {
+        case fetch
+        case add
+        case delete
+        case update
+    }
+}
+
+extension AcademicScheduleDB: DependencyKey {
+    public static let liveValue = Self(
+        fetchAll: { descriptor in
+            @Dependency(\.swiftData.context) var modelContext
+            let context = try modelContext()
+            return try context.fetch(descriptor)
+        },
+        
+        add: { schedule in
+            do {
+                @Dependency(\.swiftData.context) var modelContext
+                let context = try modelContext()
+                context.insert(schedule)
+                try context.save()
+            } catch {
+                throw DBError.add
+            }
+        },
+        
+        delete: { schedule in
+            do {
+                @Dependency(\.swiftData.context) var modelContext
+                let context = try modelContext()
+                context.delete(schedule)
+                try context.save()
+            } catch {
+                throw DBError.delete
+            }
+        },
+        update: { schedule, newEvents in
+            do {
+                @Dependency(\.swiftData.context) var modelContext
+                let context = try modelContext()
+                
+                schedule.events = newEvents
+                schedule.lastUpdated = .now
+                
+                try context.save()
+            } catch {
+                throw DBError.update
+            }
+        }
+    )
+}
+
+extension AcademicScheduleDB: TestDependencyKey {
+    public static let testValue = Self(
+        fetchAll: unimplemented("\(Self.self).fetchAll"),
+        add: unimplemented("\(Self.self).add"),
+        delete: unimplemented("\(Self.self).delete"),
+        update: unimplemented("\(Self.self).update")
+    )
+    
+    public static let noop = Self(
+        fetchAll: { _ in [] },
+        add: { _ in },
+        delete: { _ in },
+        update: { _, _ in }
+    )
+}
+
+extension DependencyValues {
+    public var academicSchedules: AcademicScheduleDB {
+        get { self[AcademicScheduleDB.self] }
+        set { self[AcademicScheduleDB.self] = newValue }
+    }
+}

--- a/package-kuring/Sources/Caches/Dependency/ActiveTab.swift
+++ b/package-kuring/Sources/Caches/Dependency/ActiveTab.swift
@@ -1,0 +1,55 @@
+//
+//  ActiveTab.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/27/25.
+//
+
+import Models
+import Foundation
+import Dependencies
+import SwiftUI
+
+public struct ActiveTabDependency {
+    public var store: ActiveTabStore
+    
+    public func callAsFunction() -> TabBarItem {
+        store.value
+    }
+}
+
+extension ActiveTabDependency: DependencyKey {
+    public static var liveValue = ActiveTabDependency(store: ActiveTabStore())
+}
+
+extension DependencyValues {
+    public var activeTab: ActiveTabDependency {
+        get { self[ActiveTabDependency.self] }
+        set { self[ActiveTabDependency.self] = newValue }
+    }
+}
+
+@Observable
+final public class ActiveTabStore {
+    public var value: TabBarItem = .notice
+}
+
+public enum TabBarItem: Hashable, CaseIterable {
+    case notice
+    case calendar
+    case campusMap
+    case settings
+    
+    public var title: String {
+        switch self {
+        case .notice:
+            return "공지사항"
+        case .calendar:
+            return "학사일정"
+        case .campusMap:
+            return "캠퍼스맵"
+        case .settings:
+            return "더보기"
+        }
+    }
+}

--- a/package-kuring/Sources/Caches/Dependency/SwiftData.swift
+++ b/package-kuring/Sources/Caches/Dependency/SwiftData.swift
@@ -13,7 +13,12 @@ fileprivate let appContext: ModelContext = {
         let url = URL.applicationSupportDirectory.appending(path: "Model.sqlite")
         let config = ModelConfiguration(url: url)
         
-        let container = try ModelContainer(for: ChatInfo.self, configurations: config)
+        let container = try ModelContainer(
+            for: ChatInfo.self,
+            AcademicEventEntity.self,
+            AcademicScheduleEntity.self,
+            configurations: config
+        )
         return ModelContext(container)
     } catch {
         fatalError("Failed to create container.")

--- a/package-kuring/Sources/Caches/Extensions/Date+.swift
+++ b/package-kuring/Sources/Caches/Extensions/Date+.swift
@@ -41,4 +41,16 @@ public extension Date {
         }
         return self <= threeYearsBefore
     }
+    
+    /// 두개의 날짜가 같은 주에 속하는지
+    func isInDifferentWeek(from otherDate: Date) -> Bool {
+        let calendar = Calendar.current
+        let selfWeek = calendar.component(.weekOfYear, from: self)
+        let otherWeek = calendar.component(.weekOfYear, from: otherDate)
+        
+        let selfYear = calendar.component(.yearForWeekOfYear, from: self)
+        let otherYear = calendar.component(.yearForWeekOfYear, from: otherDate)
+        
+        return selfWeek != otherWeek || selfYear != otherYear
+    }
 }

--- a/package-kuring/Sources/Caches/Extensions/Date+.swift
+++ b/package-kuring/Sources/Caches/Extensions/Date+.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension Date {
+    /// 이 달의 첫째 날
     public var startDateOfMonth: Date {
         guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: self)) else {
             return Date()
@@ -15,6 +16,7 @@ extension Date {
         return date
     }
 
+    /// 이 달의 마지막 날
     public var endDateOfMonth: Date {
         guard let date = Calendar.current.date(byAdding: DateComponents(month: 1, day: -1), to: self.startDateOfMonth) else {
             return Date()

--- a/package-kuring/Sources/Caches/Extensions/Date+.swift
+++ b/package-kuring/Sources/Caches/Extensions/Date+.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-extension Date {
+public extension Date {
     /// 이 달의 첫째 날
-    public var startDateOfMonth: Date {
+    var startDateOfMonth: Date {
         guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: self)) else {
             return Date()
         }
@@ -17,10 +17,28 @@ extension Date {
     }
 
     /// 이 달의 마지막 날
-    public var endDateOfMonth: Date {
+    var endDateOfMonth: Date {
         guard let date = Calendar.current.date(byAdding: DateComponents(month: 1, day: -1), to: self.startDateOfMonth) else {
             return Date()
         }
         return date
+    }
+    
+    /// `self`가 `otherDate`보다 3년 이상 지남
+    /// 예) `self` = 2025-01-01, `otherDate` = 2021-12-31 → `true`
+    func isThreeYearsOrMoreSince(_ otherDate: Date) -> Bool {
+        guard let threeYearsAfter = Calendar.current.date(byAdding: .year, value: 3, to: otherDate) else {
+            return false
+        }
+        return self >= threeYearsAfter
+    }
+    
+    /// `self`가 `otherDate`보다 3년 이상 이전(과거)인지 확인
+    /// 예)  `self` = 2025-01-01, `otherDate` = 2028-01-02 → `true`
+    func isThreeYearsOrMoreBefore(_ otherDate: Date) -> Bool {
+        guard let threeYearsBefore = Calendar.current.date(byAdding: .year, value: -3, to: otherDate) else {
+            return false
+        }
+        return self <= threeYearsBefore
     }
 }

--- a/package-kuring/Sources/Caches/Extensions/Date+.swift
+++ b/package-kuring/Sources/Caches/Extensions/Date+.swift
@@ -1,0 +1,24 @@
+//
+//  Date+.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/26/25.
+//
+
+import Foundation
+
+extension Date {
+    public var startDateOfMonth: Date {
+        guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: self)) else {
+            return Date()
+        }
+        return date
+    }
+
+    public var endDateOfMonth: Date {
+        guard let date = Calendar.current.date(byAdding: DateComponents(month: 1, day: -1), to: self.startDateOfMonth) else {
+            return Date()
+        }
+        return date
+    }
+}

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -47,16 +47,15 @@ public struct AcademicCalendarFeature {
             return events.filter { $0.startTime <= dateString && dateString <= $0.endTime }
         }
         
-        mutating func fetchAcademicSchedule() -> Bool {
+        mutating func fetchAcademicSchedule() -> AcademicScheduleEntity? {
             @Dependency(\.academicSchedules) var academicDB
             
             do {
                 let schedule = try academicDB.fetch(.init())
-                self.events = (schedule?.events ?? []).map(AcademicEvent.init(from:))
-                return schedule?.isComplete ?? false
+                return schedule
             } catch {
                 print("❌ 캐싱된 학사 일정을 가져오는데 실패 했습니다: \(error)")
-                return false
+                return nil
             }
         }
         
@@ -110,11 +109,18 @@ public struct AcademicCalendarFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                if !state.fetchAcademicSchedule() {
-                    return .concatenate([
-                        initializeMonths(state: &state),
-                        .send(.fetchEntireAcademicSchedule)
-                    ])
+                let actions: Effect<Action> = .concatenate([
+                    initializeMonths(state: &state),
+                    .send(.fetchEntireAcademicSchedule)
+                ])
+                // 만약 캐싱된 학사일정이 없다면
+                guard let schedule = state.fetchAcademicSchedule() else {
+                    return actions
+                }
+                state.events = schedule.events.map(AcademicEvent.init(from:))
+                // 만약 캐싱된 학사일정은 있지만 최신이 아니라면
+                if !schedule.isComplete {
+                    return actions
                 }
                 return initializeMonths(state: &state)
             case .previousMonthTapped:

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -16,6 +16,8 @@ import ComposableArchitecture
 public struct AcademicCalendarFeature {
     @ObservableState
     public struct State: Equatable {
+        /// 학사일정 바텀시트
+        public var isAcademicSchedulePresented: Bool = false
         /// 현재 선택된 월
         public var currentDate = Date()
         /// 현재 선택된 날짜
@@ -52,6 +54,7 @@ public struct AcademicCalendarFeature {
             
             do {
                 let schedule = try academicDB.fetch(.init())
+                self.events = (schedule?.events ?? []).map(AcademicEvent.init(from:))
                 return schedule
             } catch {
                 print("❌ 캐싱된 학사 일정을 가져오는데 실패 했습니다: \(error)")
@@ -77,27 +80,73 @@ public struct AcademicCalendarFeature {
         public init() {}
     }
 
-    public enum Action: BindableAction, Sendable {
+    public enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
-        case onAppear
+        /// 공지사항 탭 onAppear
+        case onAppearNotice
+        /// 학사일정 탭 onAppear
+        case onAppearCalendar
         case previousMonthTapped
         case nextMonthTapped
         case monthChanged(Int)
         case selectDate(Date)
         /// 학사 일정 API
+        case toggleAcademicScheduleSheet
+        /// 1달치 학사 일정을 가져옵니다
+        case fetch1MonthAcademicSchedule
+        /// 전체 학사 일정을 가져옵니다
         case fetchEntireAcademicSchedule
-        case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>)
+        /// 최신 학사 일정만 가져옵니다
+        case fetchLatestAcademicSchedule
+        case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>, _ isComplete: Bool)
     }
     
     @Dependency(\.calendar) var calendar
     @Dependency(\.kuringLink) private var kuringLink
+    
+    private var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar.current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }
 
     public var body: some ReducerOf<Self> {
         BindingReducer()
         
         Reduce { state, action in
             switch action {
-            case .onAppear:
+            case .toggleAcademicScheduleSheet:
+                state.isAcademicSchedulePresented.toggle()
+                return .none
+            case .onAppearNotice:
+                // 캐싱된 학사일정이 없을시,
+                // 1달치 일정을 먼저 가져오고 바텀시트를 노출한 후, 모든 일정을 가져온다
+                guard let schedule = state.fetchAcademicSchedule() else {
+                    return .concatenate([
+                        .send(.fetch1MonthAcademicSchedule),
+                        .send(.fetchEntireAcademicSchedule)
+                    ])
+                }
+                
+                // 캐싱된 학사일정이 있다
+                if !schedule.events.isEmpty {
+                    let sevenDaysInSeconds: TimeInterval = 7 * 24 * 60 * 60
+                    let rightNow = Date().timeIntervalSince1970
+                    let scheduleLastUpdated = schedule.lastUpdated.timeIntervalSince1970
+                    
+                    // 일주일이 지났다
+                    if rightNow - scheduleLastUpdated >= sevenDaysInSeconds {
+                        // 일주일치 새로운 학사일정만 가져온다
+                        return .concatenate([
+                            .send(.fetchLatestAcademicSchedule)
+                        ])
+                    }
+                    // 일주일 안지났으면 아무일도 없음
+                    return .none
+                }
+                return .none
+            case .onAppearCalendar:
                 let actions: Effect<Action> = .concatenate([
                     initializeMonths(state: &state),
                     .send(.fetchEntireAcademicSchedule)
@@ -123,20 +172,46 @@ public struct AcademicCalendarFeature {
             case let .selectDate(date):
                 state.selectedDate = date
                 return .none
+            case .fetch1MonthAcademicSchedule:
+                return .run { send in
+                    do {
+                        let result = try await kuringLink.fetchAcademicEvents(
+                            dateFormatter.string(from: Date().startDateOfMonth),
+                            dateFormatter.string(from: Date().endDateOfMonth)
+                        )
+                        await send(.fetchAcademicScheduleResponse(.success(result), false))
+                        await send(.toggleAcademicScheduleSheet)
+                    } catch {
+                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
+                    }
+                }
             case .fetchEntireAcademicSchedule:
                 return .run { send in
                     do {
                         let result = try await kuringLink.fetchAcademicEvents(nil, nil)
-                        await send(.fetchAcademicScheduleResponse(.success(result)))
+                        await send(.fetchAcademicScheduleResponse(.success(result), true))
                     } catch {
-                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription))))
+                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
                     }
                 }
-            case .fetchAcademicScheduleResponse(let result):
+            case .fetchLatestAcademicSchedule:
+                guard let schedule = state.fetchAcademicSchedule() else {
+                    return .none
+                }
+                
+                return .run { send in
+                    do {
+                        let result = try await kuringLink.fetchAcademicEvents(dateFormatter.string(from: schedule.lastUpdated), nil)
+                        await send(.fetchAcademicScheduleResponse(.success(result), true))
+                        await send(.toggleAcademicScheduleSheet)
+                    } catch {
+                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
+                    }
+                }
+            case .fetchAcademicScheduleResponse(let result, let isComplete):
                 switch result {
                 case .success(let events):
-                    state.events = events
-                    state.updateNewSchedule(from: events, isComplete: true)
+                    state.updateNewSchedule(from: events, isComplete: isComplete)
                     return .none
                 case .failure(let error):
                     print("Error: \(error)")

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -5,9 +5,11 @@
 //  Created by Jung Hwan Park on 10/23/25.
 //
 
+import Caches
 import Models
 import Networks
 import Foundation
+import Dependencies
 import ComposableArchitecture
 
 @Reducer
@@ -45,6 +47,34 @@ public struct AcademicCalendarFeature {
             return events.filter { $0.startTime <= dateString && dateString <= $0.endTime }
         }
         
+        mutating func fetchAcademicSchedule() -> Bool {
+            @Dependency(\.academicSchedules) var academicDB
+            
+            do {
+                let schedule = try academicDB.fetch(.init())
+                self.events = (schedule?.events ?? []).map(AcademicEvent.init(from:))
+                return schedule?.isComplete ?? false
+            } catch {
+                print("❌ 캐싱된 학사 일정을 가져오는데 실패 했습니다: \(error)")
+                return false
+            }
+        }
+        
+        mutating func updateNewSchedule(from apiEvents: [AcademicEvent], isComplete: Bool = false) {
+            @Dependency(\.academicSchedules) var academicDB
+
+            let entities = apiEvents.map(AcademicEventEntity.init(from:))
+            let schedule = AcademicScheduleEntity(lastUpdated: .now, events: entities)
+            schedule.isComplete = isComplete
+            
+            do {
+                try academicDB.add(schedule)
+                print("✅ \(entities.count)개의 학사 일정 추가를 성공했습니다")
+            } catch {
+                print("❌ 힉사일정을 SwiftData에 추가하는데 실패했습니다: \(error)")
+            }
+        }
+        
         public init() {}
     }
 
@@ -56,7 +86,7 @@ public struct AcademicCalendarFeature {
         case monthChanged(Int)
         case selectDate(Date)
         /// 학사 일정 API
-        case fetchAcademicSchedule
+        case fetchEntireAcademicSchedule
         case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>)
 
         public enum CalendarKuringError: Error, Equatable {
@@ -80,6 +110,12 @@ public struct AcademicCalendarFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
+                if !state.fetchAcademicSchedule() {
+                    return .concatenate([
+                        initializeMonths(state: &state),
+                        .send(.fetchEntireAcademicSchedule)
+                    ])
+                }
                 return initializeMonths(state: &state)
             case .previousMonthTapped:
                 state.currentMonthIndex -= 1
@@ -92,11 +128,10 @@ public struct AcademicCalendarFeature {
             case let .selectDate(date):
                 state.selectedDate = date
                 return .none
-            case .fetchAcademicSchedule:
+            case .fetchEntireAcademicSchedule:
                 return .run { send in
                     do {
-                        let startAndEnd = returnStartAndEndDate()
-                        let result = try await kuringLink.fetchAcademicEvents(startAndEnd.start, startAndEnd.end)
+                        let result = try await kuringLink.fetchAcademicEvents(nil, nil)
                         await send(.fetchAcademicScheduleResponse(.success(result)))
                     } catch {
                         await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription))))
@@ -106,6 +141,7 @@ public struct AcademicCalendarFeature {
                 switch result {
                 case .success(let events):
                     state.events = events
+                    state.updateNewSchedule(from: events, isComplete: true)
                     return .none
                 case .failure(let error):
                     print("Error: \(error)")
@@ -144,25 +180,5 @@ extension AcademicCalendarFeature {
         
         state.currentDate = state.months[state.currentMonthIndex]
         return .none
-    }
-    
-    // 학사일정 API 태울때 사용. 1년(현재 날짜 - 6개월 ~ 현재 날짜 + 6개월)치의 일정을 가져오기 위함
-    private func returnStartAndEndDate() -> (start: String?, end: String?) {
-        let calendar = Calendar.current
-        let today = Date()
-
-        guard let startDate = calendar.date(byAdding: .month, value: -6, to: today),
-              let endDate = calendar.date(byAdding: .month, value: 6, to: today) else {
-            return (nil, nil)
-        }
-
-        let formatter = DateFormatter()
-        formatter.calendar = calendar
-        formatter.dateFormat = "yyyy-MM-dd"
-
-        return (
-            start: formatter.string(from: startDate),
-            end: formatter.string(from: endDate)
-        )
     }
 }

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -42,7 +42,7 @@ public struct AcademicCalendarFeature {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
             let dateString = formatter.string(from: midnight)
-            return events.filter { $0.startTime == dateString || $0.endTime == dateString }
+            return events.filter { $0.startTime <= dateString && dateString <= $0.endTime }
         }
         
         public init() {}

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -145,13 +145,11 @@ public struct AcademicCalendarFeature {
                 
                 // 캐싱된 학사일정이 있다
                 if !schedule.events.isEmpty {
-                    let sevenDaysInSeconds: TimeInterval = 7 * 24 * 60 * 60
-                    let rightNow = Date().timeIntervalSince1970
-                    let scheduleLastUpdated = schedule.lastUpdated.timeIntervalSince1970
+                    let cachedDate = Calendar.current.date(byAdding: .year, value: -3, to: schedule.lastUpdated) ?? .now
                     
-                    // 일주일이 지났다
-                    if rightNow - scheduleLastUpdated >= sevenDaysInSeconds {
-                        // 일주일치 새로운 학사일정만 가져온다
+                    // 마지막으로 캐싱한 날짜와 현재와 주(week)가 다르다
+                    if cachedDate.isInDifferentWeek(from: .now) {
+                        // 새로운 학사일정만 가져온다
                         return .concatenate([
                             .send(.fetchLatestAcademicSchedule)
                         ])

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -14,24 +14,27 @@ import ComposableArchitecture
 public struct AcademicCalendarFeature {
     @ObservableState
     public struct State: Equatable {
+        /// 현재 선택된 월
         public var currentDate = Date()
+        /// 현재 선택된 날짜
         public var selectedDate: Date?
         public var months: [Date] = []
         public var currentMonthIndex = 1
         
+        /// 학사 일정
         public var events: [AcademicEvent] = []
-        
-        let calendar = Calendar.current
         
         public var monthYearString: String {
             let formatter = DateFormatter()
             formatter.dateFormat = "M월 yyyy"
-            formatter.locale = Locale(identifier: "ko_KR")
             return formatter.string(from: currentDate)
         }
         
         public var eventsForSelectedDate: [AcademicEvent] {
-            guard let selectedDate, calendar.isDate(selectedDate, equalTo: currentDate, toGranularity: .month) else {
+            let calendar = Calendar.current
+            guard let selectedDate,
+                  calendar.isDate(selectedDate, equalTo: currentDate, toGranularity: .month)
+            else {
                 return []
             }
             
@@ -39,8 +42,7 @@ public struct AcademicCalendarFeature {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
             let dateString = formatter.string(from: midnight)
-            
-            return events.filter({ $0.startTime == dateString })
+            return events.filter { $0.startTime == dateString || $0.endTime == dateString }
         }
         
         public init() {}
@@ -53,7 +55,7 @@ public struct AcademicCalendarFeature {
         case nextMonthTapped
         case monthChanged(Int)
         case selectDate(Date)
-        
+        /// 학사 일정 API
         case fetchAcademicSchedule
         case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>)
 
@@ -119,6 +121,7 @@ public struct AcademicCalendarFeature {
 }
 
 extension AcademicCalendarFeature {
+    // 기본적으로 3달만 보유
     private func initializeMonths(state: inout State) -> Effect<Action> {
         let prevMonth = calendar.date(byAdding: .month, value: -1, to: state.currentDate) ?? state.currentDate
         let nextMonth = calendar.date(byAdding: .month, value: 1, to: state.currentDate) ?? state.currentDate
@@ -126,6 +129,7 @@ extension AcademicCalendarFeature {
         return .none
     }
 
+    // 월이 바뀌는 상황에 사용
     private func handleMonthChange(for index: Int, state: inout State) -> Effect<Action> {
         guard !state.months.isEmpty else { return .none }
         
@@ -142,6 +146,7 @@ extension AcademicCalendarFeature {
         return .none
     }
     
+    // 학사일정 API 태울때 사용. 1년(현재 날짜 - 6개월 ~ 현재 날짜 + 6개월)치의 일정을 가져오기 위함
     private func returnStartAndEndDate() -> (start: String?, end: String?) {
         let calendar = Calendar.current
         let today = Date()

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -30,13 +30,13 @@ public struct AcademicCalendarFeature {
         
         /// 이동하려는 월이 오늘 - 3년 전이라면 false
         var canShowPreviousMonth: Bool {
-            let prevMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentDate ?? Date())
+            let prevMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentDate)
             return !Date().isThreeYearsOrMoreSince(prevMonth ?? Date())
         }
         
         /// 이동하려는 월이 오늘 + 3년 후라면 false
         var canShowNextMonth: Bool {
-            let nextMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentDate ?? Date())
+            let nextMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentDate)
             return !Date().isThreeYearsOrMoreBefore(nextMonth ?? Date())
         }
         
@@ -232,6 +232,7 @@ public struct AcademicCalendarFeature {
                 switch result {
                 case .success(let events):
                     state.updateNewSchedule(from: events, isComplete: isComplete)
+                    state.events = events
                     return .none
                 case .failure(let error):
                     print("Error: \(error)")
@@ -261,7 +262,7 @@ extension AcademicCalendarFeature {
         
         if index == 0 {
             let newPrev = calendar.date(byAdding: .month, value: -1, to: state.months.first!)!
-            let prevMonth = Calendar.current.date(byAdding: .month, value: -1, to: state.currentDate ?? Date()) ?? Date()
+            let prevMonth = Calendar.current.date(byAdding: .month, value: -1, to: state.currentDate) ?? Date()
             
             if !Date().isThreeYearsOrMoreSince(prevMonth) {
                 state.months.insert(newPrev, at: 0)

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -1,0 +1,163 @@
+//
+//  AcademicCalendarFeature.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/23/25.
+//
+
+import Models
+import Networks
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+public struct AcademicCalendarFeature {
+    @ObservableState
+    public struct State: Equatable {
+        public var currentDate = Date()
+        public var selectedDate: Date?
+        public var months: [Date] = []
+        public var currentMonthIndex = 1
+        
+        public var events: [AcademicEvent] = []
+        
+        let calendar = Calendar.current
+        
+        public var monthYearString: String {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "M월 yyyy"
+            formatter.locale = Locale(identifier: "ko_KR")
+            return formatter.string(from: currentDate)
+        }
+        
+        public var eventsForSelectedDate: [AcademicEvent] {
+            guard let selectedDate, calendar.isDate(selectedDate, equalTo: currentDate, toGranularity: .month) else {
+                return []
+            }
+            
+            let midnight = calendar.startOfDay(for: selectedDate)
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+            let dateString = formatter.string(from: midnight)
+            
+            return events.filter({ $0.startTime == dateString })
+        }
+        
+        public init() {}
+    }
+
+    public enum Action: BindableAction, Sendable {
+        case binding(BindingAction<State>)
+        case onAppear
+        case previousMonthTapped
+        case nextMonthTapped
+        case monthChanged(Int)
+        case selectDate(Date)
+        
+        case fetchAcademicSchedule
+        case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>)
+
+        public enum CalendarKuringError: Error, Equatable {
+            case error(String)
+            
+            public static func == (lhs: CalendarKuringError, rhs: CalendarKuringError) -> Bool {
+                switch (lhs, rhs) {
+                case let (.error(lmsg), .error(rmsg)):
+                    return lmsg == rmsg
+                }
+            }
+        }
+    }
+    
+    @Dependency(\.calendar) var calendar
+    @Dependency(\.kuringLink) private var kuringLink
+
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                return initializeMonths(state: &state)
+            case .previousMonthTapped:
+                state.currentMonthIndex -= 1
+                return handleMonthChange(for: state.currentMonthIndex, state: &state)
+            case .nextMonthTapped:
+                state.currentMonthIndex += 1
+                return handleMonthChange(for: state.currentMonthIndex, state: &state)
+            case let .monthChanged(index):
+                return handleMonthChange(for: index, state: &state)
+            case let .selectDate(date):
+                state.selectedDate = date
+                return .none
+            case .fetchAcademicSchedule:
+                return .run { send in
+                    do {
+                        let startAndEnd = returnStartAndEndDate()
+                        let result = try await kuringLink.fetchAcademicEvents(startAndEnd.start, startAndEnd.end)
+                        await send(.fetchAcademicScheduleResponse(.success(result)))
+                    } catch {
+                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription))))
+                    }
+                }
+            case .fetchAcademicScheduleResponse(let result):
+                switch result {
+                case .success(let events):
+                    state.events = events
+                    return .none
+                case .failure(let error):
+                    print("Error: \(error)")
+                    return .none
+                }
+            case .binding:
+                return .none
+            }
+        }
+    }
+
+    public init() { }
+}
+
+extension AcademicCalendarFeature {
+    private func initializeMonths(state: inout State) -> Effect<Action> {
+        let prevMonth = calendar.date(byAdding: .month, value: -1, to: state.currentDate) ?? state.currentDate
+        let nextMonth = calendar.date(byAdding: .month, value: 1, to: state.currentDate) ?? state.currentDate
+        state.months = [prevMonth, state.currentDate, nextMonth]
+        return .none
+    }
+
+    private func handleMonthChange(for index: Int, state: inout State) -> Effect<Action> {
+        guard !state.months.isEmpty else { return .none }
+        
+        if index == 0 {
+            let newPrev = calendar.date(byAdding: .month, value: -1, to: state.months.first!)!
+            state.months.insert(newPrev, at: 0)
+            state.currentMonthIndex = 1
+        } else if index == state.months.count - 1 {
+            let newNext = calendar.date(byAdding: .month, value: 1, to: state.months.last!)!
+            state.months.append(newNext)
+        }
+        
+        state.currentDate = state.months[state.currentMonthIndex]
+        return .none
+    }
+    
+    private func returnStartAndEndDate() -> (start: String?, end: String?) {
+        let calendar = Calendar.current
+        let today = Date()
+
+        guard let startDate = calendar.date(byAdding: .month, value: -6, to: today),
+              let endDate = calendar.date(byAdding: .month, value: 6, to: today) else {
+            return (nil, nil)
+        }
+
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        return (
+            start: formatter.string(from: startDate),
+            end: formatter.string(from: endDate)
+        )
+    }
+}

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -28,6 +28,18 @@ public struct AcademicCalendarFeature {
         /// 학사 일정
         public var events: [AcademicEvent] = []
         
+        /// 이동하려는 월이 오늘 - 3년 전이라면 false
+        var canShowPreviousMonth: Bool {
+            let prevMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentDate ?? Date())
+            return !Date().isThreeYearsOrMoreSince(prevMonth ?? Date())
+        }
+        
+        /// 이동하려는 월이 오늘 + 3년 후라면 false
+        var canShowNextMonth: Bool {
+            let nextMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentDate ?? Date())
+            return !Date().isThreeYearsOrMoreBefore(nextMonth ?? Date())
+        }
+        
         public var monthYearString: String {
             let formatter = DateFormatter()
             formatter.dateFormat = "M월 yyyy"
@@ -66,7 +78,9 @@ public struct AcademicCalendarFeature {
             @Dependency(\.academicSchedules) var academicDB
 
             let entities = apiEvents.map(AcademicEventEntity.init(from:))
-            let schedule = AcademicScheduleEntity(lastUpdated: .now, events: entities)
+            let threeYearsAfter = Calendar.current.date(byAdding: .year, value: 3, to: .now)
+
+            let schedule = AcademicScheduleEntity(lastUpdated: threeYearsAfter ?? Date(), events: entities)
             schedule.isComplete = isComplete
             
             do {
@@ -162,10 +176,10 @@ public struct AcademicCalendarFeature {
                 }
                 return initializeMonths(state: &state)
             case .previousMonthTapped:
-                state.currentMonthIndex -= 1
+                state.currentMonthIndex = state.currentMonthIndex > 0 ? state.currentMonthIndex - 1 : 0
                 return handleMonthChange(for: state.currentMonthIndex, state: &state)
             case .nextMonthTapped:
-                state.currentMonthIndex += 1
+                state.currentMonthIndex = state.currentMonthIndex >= state.months.count - 1 ? state.months.count - 1 : state.currentMonthIndex + 1
                 return handleMonthChange(for: state.currentMonthIndex, state: &state)
             case let .monthChanged(index):
                 return handleMonthChange(for: index, state: &state)
@@ -188,7 +202,15 @@ public struct AcademicCalendarFeature {
             case .fetchEntireAcademicSchedule:
                 return .run { send in
                     do {
-                        let result = try await kuringLink.fetchAcademicEvents(nil, nil)
+                        let range: (start: String, end: String) = (
+                            dateFormatter.string(
+                                from: Calendar.current.date(byAdding: .year, value: -3, to: Date()) ?? Date()
+                            ),
+                            dateFormatter.string(
+                                from: Calendar.current.date(byAdding: .year, value: 3, to: Date()) ?? Date()
+                            )
+                        )
+                        let result = try await kuringLink.fetchAcademicEvents(range.start, range.end)
                         await send(.fetchAcademicScheduleResponse(.success(result), true))
                     } catch {
                         await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
@@ -241,11 +263,20 @@ extension AcademicCalendarFeature {
         
         if index == 0 {
             let newPrev = calendar.date(byAdding: .month, value: -1, to: state.months.first!)!
-            state.months.insert(newPrev, at: 0)
-            state.currentMonthIndex = 1
+            let prevMonth = Calendar.current.date(byAdding: .month, value: -1, to: state.currentDate ?? Date()) ?? Date()
+            
+            if !Date().isThreeYearsOrMoreSince(prevMonth) {
+                state.months.insert(newPrev, at: 0)
+                state.currentMonthIndex = 1
+            } else {
+                state.currentMonthIndex = 0
+            }
         } else if index == state.months.count - 1 {
             let newNext = calendar.date(byAdding: .month, value: 1, to: state.months.last!)!
-            state.months.append(newNext)
+            
+            if !Date().isThreeYearsOrMoreBefore(newNext) {
+                state.months.append(newNext)
+            }
         }
         
         state.currentDate = state.months[state.currentMonthIndex]

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/AcademicCalendar.swift
@@ -87,17 +87,6 @@ public struct AcademicCalendarFeature {
         /// 학사 일정 API
         case fetchEntireAcademicSchedule
         case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>)
-
-        public enum CalendarKuringError: Error, Equatable {
-            case error(String)
-            
-            public static func == (lhs: CalendarKuringError, rhs: CalendarKuringError) -> Bool {
-                switch (lhs, rhs) {
-                case let (.error(lmsg), .error(rmsg)):
-                    return lmsg == rmsg
-                }
-            }
-        }
     }
     
     @Dependency(\.calendar) var calendar

--- a/package-kuring/Sources/Features/AcademicCalendarFeatures/CalendarKuringError.swift
+++ b/package-kuring/Sources/Features/AcademicCalendarFeatures/CalendarKuringError.swift
@@ -1,0 +1,19 @@
+//
+//  CalendarKuringError.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/27/25.
+//
+
+import Foundation
+
+public enum CalendarKuringError: Error, Equatable {
+    case error(String)
+    
+    public static func == (lhs: CalendarKuringError, rhs: CalendarKuringError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.error(lmsg), .error(rmsg)):
+            return lmsg == rmsg
+        }
+    }
+}

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -4,6 +4,7 @@
 //
 
 import Models
+import SwiftData
 import LoginFeatures
 import DepartmentFeatures
 import SubscriptionFeatures
@@ -13,8 +14,10 @@ import ComposableArchitecture
 public struct NoticeAppFeature {
     @ObservableState
     public struct State: Equatable {
+        /// 학사일정 바텀시트
+        public var isAcademicSchedulePresented: Bool = false
+        
         // MARK: 네비게이션
-
         /// 루트
         public var noticeList = NoticeListFeature.State()
         /// 스택 네비게이션
@@ -22,6 +25,13 @@ public struct NoticeAppFeature {
         public var signup = EmailVerificationFeature.State()
         /// 트리 네비게이션 - ``SubscriptionAppFeature``
         @Presents public var changeSubscription: SubscriptionAppFeature.State?
+        
+        /// 학사일정 SwiftData 가져올때 사용
+        var fetchDescriptor: FetchDescriptor<AcademicScheduleEntity> {
+            return .init()
+        }
+        /// 학사일정 SwiftData 엔티티
+        public var academicSchedule: AcademicScheduleEntity?
 
         public init(
             noticeList: NoticeListFeature.State = NoticeListFeature.State(),
@@ -39,9 +49,22 @@ public struct NoticeAppFeature {
                 print("북마크 가져오기를 실패했어요: \(error.localizedDescription)")
             }
         }
+        
+        mutating func fetchAcademicEvents() {
+            @Dependency(\.academicSchedules) var academicDB
+            
+            do {
+                let events = try academicDB.fetch(self.fetchDescriptor)
+                self.academicSchedule = events
+            } catch {
+                print("❌ 캐싱된 학사 일정을 가져오는데 실패 했습니다: \(error)")
+            }
+        }
     }
 
-    public enum Action: Equatable {
+    public enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        case onAppear
         /// 루트(``NoticeListFeature``) 액션
         case noticeList(NoticeListFeature.Action)
 
@@ -71,8 +94,16 @@ public struct NoticeAppFeature {
             EmailVerificationFeature()
         }
         
+        BindingReducer()
+        
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                state.fetchAcademicEvents()
+                if let schedule = state.academicSchedule, !schedule.events.isEmpty {
+                    state.isAcademicSchedulePresented = true
+                }
+                return .none
             case .noticeList(.onAppear):
                 // 북마크 상태 동기화
                 @Dependency(\.bookmarks) var bookmarks
@@ -217,7 +248,7 @@ public struct NoticeAppFeature {
                     )
                 )
                 return .none
-            case .path, .noticeList, .changeSubscription, .signup:
+            case .path, .noticeList, .changeSubscription, .signup, .binding:
                 return .none
             }
         }

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -11,20 +11,19 @@ import LoginFeatures
 import DepartmentFeatures
 import SubscriptionFeatures
 import ComposableArchitecture
+import AcademicCalendarFeatures
 
 @Reducer
 public struct NoticeAppFeature {
     @ObservableState
     public struct State: Equatable {
-        /// 학사일정 바텀시트
-        public var isAcademicSchedulePresented: Bool = false
-        
         // MARK: 네비게이션
         /// 루트
         public var noticeList = NoticeListFeature.State()
         /// 스택 네비게이션
         public var path = StackState<Path.State>()
         public var signup = EmailVerificationFeature.State()
+        public var academicCalendar = AcademicCalendarFeature.State()
         /// 트리 네비게이션 - ``SubscriptionAppFeature``
         @Presents public var changeSubscription: SubscriptionAppFeature.State?
         
@@ -44,38 +43,10 @@ public struct NoticeAppFeature {
                 print("북마크 가져오기를 실패했어요: \(error.localizedDescription)")
             }
         }
-        
-        mutating func fetchAcademicSchedule() -> AcademicScheduleEntity? {
-            @Dependency(\.academicSchedules) var academicDB
-            
-            do {
-                let schedule = try academicDB.fetch(.init())
-                return schedule
-            } catch {
-                print("❌ 캐싱된 학사 일정을 가져오는데 실패 했습니다: \(error)")
-                return nil
-            }
-        }
-        
-        mutating func updateNewSchedule(from apiEvents: [AcademicEvent], isComplete: Bool = false) {
-            @Dependency(\.academicSchedules) var academicDB
-
-            let entities = apiEvents.map(AcademicEventEntity.init(from:))
-            let schedule = AcademicScheduleEntity(lastUpdated: .now, events: entities)
-            schedule.isComplete = isComplete
-            
-            do {
-                try academicDB.add(schedule)
-                print("✅ \(entities.count)개의 학사 일정 추가를 성공했습니다")
-            } catch {
-                print("❌ 힉사일정을 SwiftData에 추가하는데 실패했습니다: \(error)")
-            }
-        }
     }
 
     public enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
-        case onAppear
         /// 루트(``NoticeListFeature``) 액션
         case noticeList(NoticeListFeature.Action)
 
@@ -83,6 +54,7 @@ public struct NoticeAppFeature {
         case path(StackAction<Path.State, Path.Action>)
         /// 이메일 인증 네비게이션
         case signup(EmailVerificationFeature.Action)
+        case academicCalendar(AcademicCalendarFeature.Action)
 
         /// 구독 변경 버튼을 탭한 경우
         case changeSubscriptionButtonTapped
@@ -91,39 +63,11 @@ public struct NoticeAppFeature {
         case changeSubscription(PresentationAction<SubscriptionAppFeature.Action>)
         
         case updateBookmarks(_ notice: Notice, _ isBookmarked: Bool)
-        
-        case toggleAcademicScheduleSheet
-        /// 1달치 학사 일정을 가져옵니다
-        case fetch1MonthAcademicSchedule
-        /// 전체 학사 일정을 가져옵니다
-        case fetchEntireAcademicSchedule
-        /// 최신 학사 일정만 가져옵니다
-        case fetchLatestAcademicSchedule
-        case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>, _ isComplete: Bool)
-        
-        public enum CalendarKuringError: Error, Equatable {
-            case error(String)
-            
-            public static func == (lhs: CalendarKuringError, rhs: CalendarKuringError) -> Bool {
-                switch (lhs, rhs) {
-                case let (.error(lmsg), .error(rmsg)):
-                    return lmsg == rmsg
-                }
-            }
-        }
     }
 
     @Dependency(\.bookmarks) var bookmarks
     @Dependency(\.departments) var departments
-    @Dependency(\.kuringLink) private var kuringLink
-    
-    private var dateFormatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar.current
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
-    }
-    
+
     public var body: some ReducerOf<Self> {
         Scope(state: \.noticeList, action: \.noticeList) {
             NoticeListFeature()
@@ -133,40 +77,14 @@ public struct NoticeAppFeature {
             EmailVerificationFeature()
         }
         
+        Scope(state: \.academicCalendar, action: \.academicCalendar) {
+            AcademicCalendarFeature()
+        }
+        
         BindingReducer()
         
         Reduce { state, action in
             switch action {
-            case .onAppear:
-                // 캐싱된 학사일정이 없을시,
-                // 1달치 일정을 먼저 가져오고 바텀시트를 노출한 후, 모든 일정을 가져온다
-                guard let schedule = state.fetchAcademicSchedule() else {
-                    return .concatenate([
-                        .send(.fetch1MonthAcademicSchedule),
-                        .send(.fetchEntireAcademicSchedule)
-                    ])
-                }
-                
-                // 캐싱된 학사일정이 있다
-                if !schedule.events.isEmpty {
-                    let sevenDaysInSeconds: TimeInterval = 7 * 24 * 60 * 60
-                    let rightNow = Date().timeIntervalSince1970
-                    let scheduleLastUpdated = schedule.lastUpdated.timeIntervalSince1970
-                    
-                    // 일주일이 지났다
-                    if rightNow - scheduleLastUpdated >= sevenDaysInSeconds {
-                        // 일주일치 새로운 학사일정만 가져온다
-                        return .concatenate([
-                            .send(.fetchLatestAcademicSchedule)
-                        ])
-                    }
-                    // 일주일 안지났으면 아무일도 없음
-                    return .none
-                }
-                return .none
-            case .toggleAcademicScheduleSheet:
-                state.isAcademicSchedulePresented.toggle()
-                return .none
             case .noticeList(.onAppear):
                 // 북마크 상태 동기화
                 @Dependency(\.bookmarks) var bookmarks
@@ -176,51 +94,6 @@ public struct NoticeAppFeature {
                     print("북마크 가져오기를 실패했어요: \(error.localizedDescription)")
                 }
                 return .none
-            case .fetch1MonthAcademicSchedule:
-                return .run { send in
-                    do {
-                        let result = try await kuringLink.fetchAcademicEvents(
-                            dateFormatter.string(from: Date().startDateOfMonth),
-                            dateFormatter.string(from: Date().endDateOfMonth)
-                        )
-                        await send(.fetchAcademicScheduleResponse(.success(result), false))
-                        await send(.toggleAcademicScheduleSheet)
-                    } catch {
-                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
-                    }
-                }
-            case .fetchEntireAcademicSchedule:
-                return .run { send in
-                    do {
-                        let result = try await kuringLink.fetchAcademicEvents(nil, nil)
-                        await send(.fetchAcademicScheduleResponse(.success(result), true))
-                    } catch {
-                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
-                    }
-                }
-            case .fetchLatestAcademicSchedule:
-                guard let schedule = state.fetchAcademicSchedule() else {
-                    return .none
-                }
-                
-                return .run { send in
-                    do {
-                        let result = try await kuringLink.fetchAcademicEvents(dateFormatter.string(from: schedule.lastUpdated), nil)
-                        await send(.fetchAcademicScheduleResponse(.success(result), true))
-                        await send(.toggleAcademicScheduleSheet)
-                    } catch {
-                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
-                    }
-                }
-            case .fetchAcademicScheduleResponse(let result, let isComplete):
-                switch result {
-                case .success(let events):
-                    state.updateNewSchedule(from: events, isComplete: isComplete)
-                    return .none
-                case .failure(let error):
-                    print("Error: \(error)")
-                    return .none
-                }
             case let .path(.element(id: _, action: .detail(.delegate(action)))):
                 switch action {
                 case let .bookmarkUpdated(notice, isBookmarked):
@@ -355,7 +228,7 @@ public struct NoticeAppFeature {
                     )
                 )
                 return .none
-            case .path, .noticeList, .changeSubscription, .signup, .binding:
+            case .path, .noticeList, .changeSubscription, .signup, .binding, .academicCalendar:
                 return .none
             }
         }

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -3,8 +3,10 @@
 // See the 'License.txt' file for licensing information.
 //
 
+import Caches
 import Models
 import SwiftData
+import Foundation
 import LoginFeatures
 import DepartmentFeatures
 import SubscriptionFeatures
@@ -26,13 +28,6 @@ public struct NoticeAppFeature {
         /// 트리 네비게이션 - ``SubscriptionAppFeature``
         @Presents public var changeSubscription: SubscriptionAppFeature.State?
         
-        /// 학사일정 SwiftData 가져올때 사용
-        var fetchDescriptor: FetchDescriptor<AcademicScheduleEntity> {
-            return .init()
-        }
-        /// 학사일정 SwiftData 엔티티
-        public var academicSchedule: AcademicScheduleEntity?
-
         public init(
             noticeList: NoticeListFeature.State = NoticeListFeature.State(),
             path: StackState<Path.State> = StackState<Path.State>(),
@@ -50,14 +45,30 @@ public struct NoticeAppFeature {
             }
         }
         
-        mutating func fetchAcademicEvents() {
+        mutating func fetchAcademicSchedule() -> AcademicScheduleEntity? {
             @Dependency(\.academicSchedules) var academicDB
             
             do {
-                let events = try academicDB.fetch(self.fetchDescriptor)
-                self.academicSchedule = events
+                let schedule = try academicDB.fetch(.init())
+                return schedule
             } catch {
                 print("❌ 캐싱된 학사 일정을 가져오는데 실패 했습니다: \(error)")
+                return nil
+            }
+        }
+        
+        mutating func updateNewSchedule(from apiEvents: [AcademicEvent], isComplete: Bool = false) {
+            @Dependency(\.academicSchedules) var academicDB
+
+            let entities = apiEvents.map(AcademicEventEntity.init(from:))
+            let schedule = AcademicScheduleEntity(lastUpdated: .now, events: entities)
+            schedule.isComplete = isComplete
+            
+            do {
+                try academicDB.add(schedule)
+                print("✅ \(entities.count)개의 학사 일정 추가를 성공했습니다")
+            } catch {
+                print("❌ 힉사일정을 SwiftData에 추가하는데 실패했습니다: \(error)")
             }
         }
     }
@@ -80,10 +91,36 @@ public struct NoticeAppFeature {
         case changeSubscription(PresentationAction<SubscriptionAppFeature.Action>)
         
         case updateBookmarks(_ notice: Notice, _ isBookmarked: Bool)
+        
+        case toggleAcademicScheduleSheet
+        /// 학사 일정 API
+        case fetch1MonthAcademicSchedule
+        case fetchEntireAcademicSchedule
+        case fetchLatestAcademicSchedule
+        case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>, _ isComplete: Bool)
+        
+        public enum CalendarKuringError: Error, Equatable {
+            case error(String)
+            
+            public static func == (lhs: CalendarKuringError, rhs: CalendarKuringError) -> Bool {
+                switch (lhs, rhs) {
+                case let (.error(lmsg), .error(rmsg)):
+                    return lmsg == rmsg
+                }
+            }
+        }
     }
 
     @Dependency(\.bookmarks) var bookmarks
     @Dependency(\.departments) var departments
+    @Dependency(\.kuringLink) private var kuringLink
+    
+    private var formatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar.current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }
     
     public var body: some ReducerOf<Self> {
         Scope(state: \.noticeList, action: \.noticeList) {
@@ -99,10 +136,34 @@ public struct NoticeAppFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                state.fetchAcademicEvents()
-                if let schedule = state.academicSchedule, !schedule.events.isEmpty {
-                    state.isAcademicSchedulePresented = true
+                // 캐싱된 학사일정이 없을시,
+                // 1달치 일정을 먼저 가져오고 바텀시트를 노출한 후, 모든 일정을 가져온다
+                guard let schedule = state.fetchAcademicSchedule() else {
+                    return .concatenate([
+                        .send(.fetch1MonthAcademicSchedule),
+                        .send(.fetchEntireAcademicSchedule)
+                    ])
                 }
+                
+                // 캐싱된 학사일정이 있다
+                if !schedule.events.isEmpty {
+                    let sevenDaysInSeconds: TimeInterval = 7 * 24 * 60 * 60
+                    let rightNow = Date().timeIntervalSince1970
+                    let scheduleLastUpdated = schedule.lastUpdated.timeIntervalSince1970
+                    
+                    // 일주일이 지났다
+                    if rightNow - scheduleLastUpdated >= sevenDaysInSeconds {
+                        // 일주일치 새로운 학사일정만 가져온다
+                        return .concatenate([
+                            .send(.fetchLatestAcademicSchedule)
+                        ])
+                    }
+                    // 일주일 안지났으면 아무일도 없음
+                    return .none
+                }
+                return .none
+            case .toggleAcademicScheduleSheet:
+                state.isAcademicSchedulePresented.toggle()
                 return .none
             case .noticeList(.onAppear):
                 // 북마크 상태 동기화
@@ -113,7 +174,51 @@ public struct NoticeAppFeature {
                     print("북마크 가져오기를 실패했어요: \(error.localizedDescription)")
                 }
                 return .none
+            case .fetch1MonthAcademicSchedule:
+                return .run { send in
+                    do {
+                        let result = try await kuringLink.fetchAcademicEvents(
+                            formatter.string(from: Date().startDateOfMonth),
+                            formatter.string(from: Date().endDateOfMonth)
+                        )
+                        await send(.fetchAcademicScheduleResponse(.success(result), false))
+                        await send(.toggleAcademicScheduleSheet)
+                    } catch {
+                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
+                    }
+                }
+            case .fetchEntireAcademicSchedule:
+                return .run { send in
+                    do {
+                        let result = try await kuringLink.fetchAcademicEvents(nil, nil)
+                        await send(.fetchAcademicScheduleResponse(.success(result), true))
+                    } catch {
+                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
+                    }
+                }
+            case .fetchLatestAcademicSchedule:
+                guard let schedule = state.fetchAcademicSchedule() else {
+                    return .none
+                }
                 
+                return .run { send in
+                    do {
+                        let result = try await kuringLink.fetchAcademicEvents(formatter.string(from: schedule.lastUpdated), nil)
+                        await send(.fetchAcademicScheduleResponse(.success(result), true))
+                        await send(.toggleAcademicScheduleSheet)
+                    } catch {
+                        await send(.fetchAcademicScheduleResponse(.failure(.error(error.localizedDescription)), false))
+                    }
+                }
+            case .fetchAcademicScheduleResponse(let result, let isComplete):
+                switch result {
+                case .success(let events):
+                    state.updateNewSchedule(from: events, isComplete: isComplete)
+                    return .none
+                case .failure(let error):
+                    print("Error: \(error)")
+                    return .none
+                }
             case let .path(.element(id: _, action: .detail(.delegate(action)))):
                 switch action {
                 case let .bookmarkUpdated(notice, isBookmarked):

--- a/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
+++ b/package-kuring/Sources/Features/NoticeFeatures/NoticeApp.swift
@@ -93,9 +93,11 @@ public struct NoticeAppFeature {
         case updateBookmarks(_ notice: Notice, _ isBookmarked: Bool)
         
         case toggleAcademicScheduleSheet
-        /// 학사 일정 API
+        /// 1달치 학사 일정을 가져옵니다
         case fetch1MonthAcademicSchedule
+        /// 전체 학사 일정을 가져옵니다
         case fetchEntireAcademicSchedule
+        /// 최신 학사 일정만 가져옵니다
         case fetchLatestAcademicSchedule
         case fetchAcademicScheduleResponse(Result<[AcademicEvent], CalendarKuringError>, _ isComplete: Bool)
         
@@ -115,7 +117,7 @@ public struct NoticeAppFeature {
     @Dependency(\.departments) var departments
     @Dependency(\.kuringLink) private var kuringLink
     
-    private var formatter: DateFormatter {
+    private var dateFormatter: DateFormatter {
         let formatter = DateFormatter()
         formatter.calendar = Calendar.current
         formatter.dateFormat = "yyyy-MM-dd"
@@ -178,8 +180,8 @@ public struct NoticeAppFeature {
                 return .run { send in
                     do {
                         let result = try await kuringLink.fetchAcademicEvents(
-                            formatter.string(from: Date().startDateOfMonth),
-                            formatter.string(from: Date().endDateOfMonth)
+                            dateFormatter.string(from: Date().startDateOfMonth),
+                            dateFormatter.string(from: Date().endDateOfMonth)
                         )
                         await send(.fetchAcademicScheduleResponse(.success(result), false))
                         await send(.toggleAcademicScheduleSheet)
@@ -203,7 +205,7 @@ public struct NoticeAppFeature {
                 
                 return .run { send in
                     do {
-                        let result = try await kuringLink.fetchAcademicEvents(formatter.string(from: schedule.lastUpdated), nil)
+                        let result = try await kuringLink.fetchAcademicEvents(dateFormatter.string(from: schedule.lastUpdated), nil)
                         await send(.fetchAcademicScheduleResponse(.success(result), true))
                         await send(.toggleAcademicScheduleSheet)
                     } catch {

--- a/package-kuring/Sources/Features/SettingsFeatures/SettingList.swift
+++ b/package-kuring/Sources/Features/SettingsFeatures/SettingList.swift
@@ -5,10 +5,12 @@
 
 import Caches
 import Models
+import SwiftUI
 import Networks
 import Foundation
 import LoginFeatures
 import ComposableArchitecture
+import AcademicCalendarFeatures
 
 public enum URLLink: String {
     case team = "https://bit.ly/3v2c5eg"
@@ -25,6 +27,7 @@ public struct SettingListFeature {
         // TODO: 나중에 디펜던시로
         public var currentAppIcon: KuringIcon?
         public var isCustomAlarmOn: Bool = false
+        public var isAcademicScheduleAlarmOn: Bool = true
         public var email: String = "kuring@konkuk.ac.kr"
         public var nickname: String = "쿠링님"
         @Presents public var alert: AlertState<Action.Alert>?
@@ -49,6 +52,8 @@ public struct SettingListFeature {
         /// 알림 관련 액션
         case alert(PresentationAction<Alert>)
         case getUserInfoResponse(Result<UserInfo, LoginKuringError>)
+        case toggleAcademicScheduleAlarm(Bool)
+        case toggleAcademicScheduleAlarmResponse(Result<Bool, CalendarKuringError>)
         
         /// 알림
         public enum Alert: Equatable {
@@ -67,12 +72,17 @@ public struct SettingListFeature {
             case showOpensourceList
         }
     }
-
+    
+    @Dependency(\.kuringLink) private var kuringLink
+    @AppStorage("academicEventPush") var academicEventPush: Bool = true
+    
     public var body: some ReducerOf<Self> {
         BindingReducer()
 
         Reduce { state, action in
             switch action {
+            case .binding(\.isAcademicScheduleAlarmOn):
+                return .send(.toggleAcademicScheduleAlarm(state.isAcademicScheduleAlarmOn))
             case .binding, .delegate:
                 return .none
             case .onAppear:
@@ -115,6 +125,25 @@ public struct SettingListFeature {
                     }
                 }
                 return .none
+            case .toggleAcademicScheduleAlarm(let isOn):
+                return .run { send in
+                    do {
+                        let result = try await kuringLink.setAcademicEventPush(isOn)
+                        await send(.toggleAcademicScheduleAlarmResponse(.success(result)))
+                    } catch {
+                        await send(.toggleAcademicScheduleAlarmResponse(.failure(.error(error.localizedDescription))))
+                    }
+                }
+            case .toggleAcademicScheduleAlarmResponse(let result):
+                switch result {
+                case .success(let success):
+                    academicEventPush = !academicEventPush
+                    return .none
+                case .failure(let error):
+                    print("Error: \(error)")
+                    state.isAcademicScheduleAlarmOn.toggle()
+                    return .none
+                }
             case let .alert(.presented(alertAction)):
                 switch alertAction {
                 case .logout:

--- a/package-kuring/Sources/Models/AcademicEvent.swift
+++ b/package-kuring/Sources/Models/AcademicEvent.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import ColorSet
 
 /// 학사 일정 객체
 public struct AcademicEvent: Codable, Equatable, Hashable {

--- a/package-kuring/Sources/Models/AcademicEvent.swift
+++ b/package-kuring/Sources/Models/AcademicEvent.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 /// 학사 일정 객체
-public struct AcademicEvent: Codable {
-    let id: Int
-    let eventUid, summary: String
-    let description: String?
-    let category, startTime, endTime: String
+public struct AcademicEvent: Codable, Equatable, Hashable {
+    public let id: Int
+    public let eventUid, summary: String
+    public let description: String?
+    public let category, startTime, endTime: String
 }
 
 /// 학사 일정 알림 설정 (서버로 보내는)

--- a/package-kuring/Sources/Models/AcademicEvent.swift
+++ b/package-kuring/Sources/Models/AcademicEvent.swift
@@ -14,6 +14,24 @@ public struct AcademicEvent: Codable, Equatable, Hashable {
     public let eventUid, summary: String
     public let description: String?
     public let category, startTime, endTime: String
+    
+    public init(
+        id: Int,
+        eventUid: String,
+        summary: String,
+        description: String?,
+        category: String,
+        startTime: String,
+        endTime: String
+    ) {
+        self.id = id
+        self.eventUid = eventUid
+        self.summary = summary
+        self.description = description
+        self.category = category
+        self.startTime = startTime
+        self.endTime = endTime
+    }
 }
 
 /// 학사 일정 알림 설정 (서버로 보내는)
@@ -22,5 +40,19 @@ public struct AcademicEventPush: Encodable {
     
     public init(enabled: Bool) {
         self.enabled = enabled
+    }
+}
+
+extension AcademicEvent {
+    public init(from event: AcademicEventEntity) {
+        self.init(
+            id: event.id,
+            eventUid: event.eventUid,
+            summary: event.summary,
+            description: event.descriptionText,
+            category: event.category,
+            startTime: event.startTime,
+            endTime: event.endTime
+        )
     }
 }

--- a/package-kuring/Sources/Models/AcademicEventEntity.swift
+++ b/package-kuring/Sources/Models/AcademicEventEntity.swift
@@ -46,6 +46,7 @@ public final class AcademicEventEntity {
 public final class AcademicScheduleEntity {
     @Attribute(.unique) public var id: String
     public var lastUpdated: Date
+    /// 학사일정이 최신 정보인지 나타낸다. 해당 값이 false면 학사일정 API 요청을 한다.
     public var isComplete: Bool = false
     @Relationship(deleteRule: .cascade) public var events: [AcademicEventEntity]
     

--- a/package-kuring/Sources/Models/AcademicEventEntity.swift
+++ b/package-kuring/Sources/Models/AcademicEventEntity.swift
@@ -1,0 +1,67 @@
+//
+//  AcademicEventEntity.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/25/25.
+//
+
+import SwiftData
+import Foundation
+
+/// 하나의 학사 일정 객체
+@Model
+public final class AcademicEventEntity {
+    @Attribute(.unique) public var id: Int
+    public var eventUid: String
+    public var summary: String
+    public var descriptionText: String?
+    public var category: String
+    public var startTime: String
+    public var endTime: String
+    
+    public init(
+        id: Int,
+        eventUid: String,
+        summary: String,
+        descriptionText: String?,
+        category: String,
+        startTime: String,
+        endTime: String
+    ) {
+        self.id = id
+        self.eventUid = eventUid
+        self.summary = summary
+        self.descriptionText = descriptionText
+        self.category = category
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+}
+
+/// 모든 학사일정과 마지막으로 갱신된 시간을 담고있는 객체
+@Model
+public final class AcademicScheduleEntity {
+    @Attribute(.unique) public var id: UUID
+    public var lastUpdated: Date
+    @Relationship(deleteRule: .cascade) public var events: [AcademicEventEntity]
+    
+    public init(id: UUID = UUID(), lastUpdated: Date = .now, events: [AcademicEventEntity] = []) {
+        self.id = id
+        self.lastUpdated = lastUpdated
+        self.events = events
+    }
+}
+
+extension AcademicEventEntity {
+    convenience init(from event: AcademicEvent) {
+        self.init(
+            id: event.id,
+            eventUid: event.eventUid,
+            summary: event.summary,
+            descriptionText: event.description,
+            category: event.category,
+            startTime: event.startTime,
+            endTime: event.endTime
+        )
+    }
+}

--- a/package-kuring/Sources/Models/AcademicEventEntity.swift
+++ b/package-kuring/Sources/Models/AcademicEventEntity.swift
@@ -41,11 +41,15 @@ public final class AcademicEventEntity {
 /// 모든 학사일정과 마지막으로 갱신된 시간을 담고있는 객체
 @Model
 public final class AcademicScheduleEntity {
-    @Attribute(.unique) public var id: UUID
+    @Attribute(.unique) public var id: String
     public var lastUpdated: Date
     @Relationship(deleteRule: .cascade) public var events: [AcademicEventEntity]
     
-    public init(id: UUID = UUID(), lastUpdated: Date = .now, events: [AcademicEventEntity] = []) {
+    public init(
+        id: String = "main",
+        lastUpdated: Date = .now,
+        events: [AcademicEventEntity] = []
+    ) {
         self.id = id
         self.lastUpdated = lastUpdated
         self.events = events
@@ -53,7 +57,7 @@ public final class AcademicScheduleEntity {
 }
 
 extension AcademicEventEntity {
-    convenience init(from event: AcademicEvent) {
+    convenience public init(from event: AcademicEvent) {
         self.init(
             id: event.id,
             eventUid: event.eventUid,

--- a/package-kuring/Sources/Models/AcademicEventEntity.swift
+++ b/package-kuring/Sources/Models/AcademicEventEntity.swift
@@ -19,6 +19,9 @@ public final class AcademicEventEntity {
     public var startTime: String
     public var endTime: String
     
+    @Relationship(inverse: \AcademicScheduleEntity.events)
+    public var schedule: AcademicScheduleEntity?
+    
     public init(
         id: Int,
         eventUid: String,
@@ -43,12 +46,13 @@ public final class AcademicEventEntity {
 public final class AcademicScheduleEntity {
     @Attribute(.unique) public var id: String
     public var lastUpdated: Date
+    public var isComplete: Bool = false
     @Relationship(deleteRule: .cascade) public var events: [AcademicEventEntity]
     
     public init(
         id: String = "main",
         lastUpdated: Date = .now,
-        events: [AcademicEventEntity] = []
+        events: [AcademicEventEntity]
     ) {
         self.id = id
         self.lastUpdated = lastUpdated

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -43,11 +43,10 @@ public struct AcademicCalendar: View {
             }
         }
         .background(Color.Kuring.bg)
-        .navigationTitle("더보기")
+        .navigationTitle("학사 일정")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             store.send(.onAppear)
-            store.send(.fetchAcademicSchedule) // FIXME: use cached schedule
         }
     }
     

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -5,9 +5,12 @@
 //  Created by Jung Hwan Park on 10/20/25.
 //
 
+import Models
 import SwiftUI
 import ColorSet
 import CommonUI
+import ComposableArchitecture
+import AcademicCalendarFeatures
 
 /// 학사 일정 캘린더 뷰
 /// ```swift
@@ -15,24 +18,11 @@ import CommonUI
 /// ```
 ///  - Parameters: none
 public struct AcademicCalendar: View {
-    @State private var currentDate = Date()
-    @State private var selectedDate: Date?
-    @State private var months: [Date] = []
-    @State private var currentMonthIndex = 1
+    @Bindable var store: StoreOf<AcademicCalendarFeature>
     
-    /// MOCK DATA
-    @State private var eventDots: [String: [Color]] = [
-        "2025-10-7": [.yellow, .green, .gray],
-        "2025-10-13": [.yellow],
-        "2025-10-18": [.green],
-        "2025-10-20": [.green],
-        "2025-11-3": [.green, .red, .yellow, .blue, .teal]
-    ]
-    
-    let calendar = Calendar.current
-    let weekdays = ["일", "월", "화", "수", "목", "금", "토"]
-    
-    public init() { }
+    public init(store: StoreOf<AcademicCalendarFeature>) {
+        self.store = store
+    }
     
     public var body: some View {
         VStack(spacing: 0) {
@@ -46,8 +36,8 @@ public struct AcademicCalendar: View {
                 .frame(height: 2)
                 .padding(.top, 22)
             
-            if let selectedDate, !getDotsForDate(selectedDate).isEmpty, isSameMonthAndYear(selectedDate, currentDate) {
-                eventInfo(for: getDotsForDate(selectedDate))
+            if !store.eventsForSelectedDate.isEmpty {
+                eventInfo(for: store.eventsForSelectedDate)
             } else {
                 Spacer()
             }
@@ -55,19 +45,22 @@ public struct AcademicCalendar: View {
         .background(Color.Kuring.bg)
         .navigationTitle("더보기")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            store.send(.onAppear)
+            store.send(.fetchAcademicSchedule)
+        }
     }
     
     private var headerView: some View {
         HStack {
-            Text(monthYearString)
+            Text(store.monthYearString)
                 .font(.system(size: 18, weight: .semibold))
             
             Spacer()
             
             HStack(spacing: 26) {
                 Button {
-                    currentMonthIndex -= 1
-                    handleMonthChange(for: currentMonthIndex)
+                    store.send(.previousMonthTapped)
                 } label: {
                     Image(systemName: "chevron.left")
                         .foregroundColor(Color.Kuring.primary)
@@ -75,8 +68,7 @@ public struct AcademicCalendar: View {
                 }
                 
                 Button {
-                    currentMonthIndex += 1
-                    handleMonthChange(for: currentMonthIndex)
+                    store.send(.nextMonthTapped)
                 } label: {
                     Image(systemName: "chevron.right")
                         .foregroundColor(Color.Kuring.primary)
@@ -89,7 +81,7 @@ public struct AcademicCalendar: View {
     
     private var weekdaysView: some View {
         HStack {
-            ForEach(weekdays, id: \.self) { day in
+            ForEach(["일", "월", "화", "수", "목", "금", "토"], id: \.self) { day in
                 Text(day)
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(Color.Kuring.gray300)
@@ -102,46 +94,43 @@ public struct AcademicCalendar: View {
     
     private var calendarContent: some View {
         ScrollViewReader { proxy in
-            TabView(selection: $currentMonthIndex) {
-                ForEach(Array(months.enumerated()), id: \.offset) { index, month in
+            TabView(selection: $store.currentMonthIndex) {
+                ForEach(Array(store.months.enumerated()), id: \.offset) { index, month in
                     CalendarMonthView(
                         month: month,
-                        selectedDate: $selectedDate,
-                        eventDots: eventDots
+                        selectedDate: $store.selectedDate,
+                        events: store.events
                     )
                     .tag(index)
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             .frame(height: 306)
-            .onChangeDebounced(of: currentMonthIndex, delay: 0.3) { newIndex in
-                handleMonthChange(for: newIndex)
-            }
-            .onAppear {
-                initializeMonths()
+            .onChangeDebounced(of: store.currentMonthIndex, delay: 0.3) { newIndex in
+                store.send(.monthChanged(newIndex))
             }
         }
     }
     
     @ViewBuilder
-    private func eventInfo(for events: [Color]) -> some View {
+    private func eventInfo(for events: [AcademicEvent]) -> some View {
         ScrollView(.vertical) {
             VStack(spacing: 0) {
-                ForEach(events, id: \.self) { color in
+                ForEach(events, id: \.id) { event in
                     VStack(alignment: .leading) {
                         HStack(spacing: 8) {
                             Capsule()
-                                .fill(color)
+                                .fill(.green)
                                 .frame(width: 4)
                                 .frame(maxHeight: .infinity)
                             
                             VStack(spacing: 8) {
-                                Text("수강 바구니 1차")
+                                Text("\(event.summary)")
                                     .foregroundStyle(Color.Kuring.title)
                                     .font(.system(size: 15, weight: .medium))
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                 
-                                Text("8. 04 (월) 오전 9:30 - 8. 05 (화) 오전 9:30 ")
+                                Text("\(event.startTime) - \(event.endTime)")
                                     .foregroundStyle(Color.Kuring.caption1)
                                     .font(.system(size: 12, weight: .medium))
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -160,50 +149,8 @@ public struct AcademicCalendar: View {
     }
 }
 
-extension AcademicCalendar {
-    var monthYearString: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "M월 yyyy"
-        formatter.locale = Locale(identifier: "ko_KR")
-        return formatter.string(from: currentDate)
-    }
-    
-    func initializeMonths() {
-        let prevMonth = calendar.date(byAdding: .month, value: -1, to: currentDate) ?? currentDate
-        let nextMonth = calendar.date(byAdding: .month, value: 1, to: currentDate) ?? currentDate
-        months = [prevMonth, currentDate, nextMonth]
-    }
-
-    func handleMonthChange(for index: Int) {
-        guard !months.isEmpty else {
-            return
-        }
-
-        if index == 0 {
-            let newPrev = calendar.date(byAdding: .month, value: -1, to: months.first!)!
-            months.insert(newPrev, at: 0)
-            currentMonthIndex = 1
-        } else if index == months.count - 1 {
-            let newNext = calendar.date(byAdding: .month, value: 1, to: months.last!)!
-            months.append(newNext)
-        }
-        currentDate = months[currentMonthIndex]
-    }
-    
-    func getDotsForDate(_ date: Date) -> [Color] {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-M-d"
-        let dateString = formatter.string(from: date)
-        return eventDots[dateString] ?? []
-    }
-    
-    func isSameMonthAndYear(_ d1: Date, _ d2: Date) -> Bool {
-        calendar.isDate(d1, equalTo: d2, toGranularity: .month)
-    }
-}
-
-struct CalendarView_Previews: PreviewProvider {
-    static var previews: some View {
-        AcademicCalendar()
-    }
+#Preview {
+    AcademicCalendar(store: .init(initialState: AcademicCalendarFeature.State(), reducer: {
+        AcademicCalendarFeature()
+    }))
 }

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -22,6 +22,7 @@ public struct AcademicCalendar: View {
     
     public init(store: StoreOf<AcademicCalendarFeature>) {
         self.store = store
+        self.store.send(.selectDate(Date()))
     }
     
     public var body: some View {

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -47,7 +47,7 @@ public struct AcademicCalendar: View {
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             store.send(.onAppear)
-            store.send(.fetchAcademicSchedule)
+            store.send(.fetchAcademicSchedule) // FIXME: use cached schedule
         }
     }
     

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -5,6 +5,7 @@
 //  Created by Jung Hwan Park on 10/20/25.
 //
 
+import Caches
 import Models
 import SwiftUI
 import ColorSet

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -120,7 +120,7 @@ public struct AcademicCalendar: View {
                     VStack(alignment: .leading) {
                         HStack(spacing: 8) {
                             Capsule()
-                                .fill(.green)
+                                .fill((AcademicEventCategory(rawValue: event.category) ?? .etc).color)
                                 .frame(width: 4)
                                 .frame(maxHeight: .infinity)
                             
@@ -130,7 +130,7 @@ public struct AcademicCalendar: View {
                                     .font(.system(size: 15, weight: .medium))
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                 
-                                Text("\(event.startTime) - \(event.endTime)")
+                                Text("\(formatKoreanDateString(event.startTime)) - \(formatKoreanDateString(event.endTime))")
                                     .foregroundStyle(Color.Kuring.caption1)
                                     .font(.system(size: 12, weight: .medium))
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -146,6 +146,23 @@ public struct AcademicCalendar: View {
         }
         .scrollBounceBehavior(.basedOnSize)
         .scrollIndicators(.never)
+    }
+}
+
+extension AcademicCalendar {
+    private func formatKoreanDateString(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+
+        guard let date = inputFormatter.date(from: dateString) else {
+            return dateString
+        }
+
+        let outputFormatter = DateFormatter()
+        outputFormatter.locale = Locale(identifier: "ko_KR")
+        outputFormatter.dateFormat = "M.dd (E) a h:mm"
+
+        return outputFormatter.string(from: date)
     }
 }
 

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicCalendar.swift
@@ -47,7 +47,7 @@ public struct AcademicCalendar: View {
         .navigationTitle("학사 일정")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            store.send(.onAppear)
+            store.send(.onAppearCalendar)
         }
     }
     

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicEventCategory.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicEventCategory.swift
@@ -10,12 +10,25 @@ import Foundation
 import SwiftUICore
 
 enum AcademicEventCategory: String {
+    /// 기타
     case etc = "ETC"
+    /// 학사운영/행사
+    case academicOperationEvent = "ACADEMIC_OPERATION_EVENT"
+    /// 등록/수강/성적
+    case registrationCourseGrade = "REGISTRATION_COURSE_GRADE"
+    /// 학적/학위
+    case academicDegree = "ACADEMIC_DEGREE"
     
     var color: Color {
         switch self {
         case .etc:
             return Color.Kuring.etc
+        case .academicOperationEvent:
+            return Color.Kuring.event
+        case .registrationCourseGrade:
+            return Color.Kuring.registration
+        case .academicDegree:
+            return Color.Kuring.degree
         }
     }
 }

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicEventCategory.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicEventCategory.swift
@@ -1,0 +1,21 @@
+//
+//  AcademicEventCategory.swift
+//  package-kuring
+//
+//  Created by Jung Hwan Park on 10/24/25.
+//
+
+import ColorSet
+import Foundation
+import SwiftUICore
+
+enum AcademicEventCategory: String {
+    case etc = "ETC"
+    
+    var color: Color {
+        switch self {
+        case .etc:
+            return Color.Kuring.etc
+        }
+    }
+}

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
@@ -10,8 +10,8 @@ import Caches
 import Models
 import SwiftUI
 import ColorSet
-import Dependencies
 import SwiftData
+import Dependencies
 
 /// 주요 학사 일정을 한번에 보여주는 바텀시트 뷰
 /// 높이는 **280**으로 사용
@@ -30,6 +30,8 @@ import SwiftData
 ///    - schedules: 보여줄 학사 일정들
 ///    - isPresented: 바텀시트 노출 여부
 public struct AcademicScheduleSheet: View {
+    @Dependency(\.activeTab) var activeTab
+    
     let events: [AcademicEvent]
     @State var currentPage: Int = 0
     @Binding var isPresented: Bool
@@ -72,6 +74,10 @@ public struct AcademicScheduleSheet: View {
             
             Button(action: {
                 isPresented = false
+                Task {
+                    try? await Task.sleep(for: .milliseconds(200))
+                    activeTab.store.value = .calendar
+                }
             }) {
                 Text("학사일정 전체 확인하기 >")
                     .font(.system(size: 16, weight: .semibold))

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
@@ -5,6 +5,7 @@
 //  Created by Jung Hwan Park on 10/23/25.
 //
 
+import Models
 import SwiftUI
 import ColorSet
 
@@ -24,12 +25,20 @@ import ColorSet
 ///  - Parameters:
 ///    - schedules: 보여줄 학사 일정들
 ///    - isPresented: 바텀시트 노출 여부
-struct AcademicScheduleSheet: View {
-    let schedules: [ScheduleItem]
+public struct AcademicScheduleSheet: View {
+    let events: [AcademicEvent]
     @State var currentPage: Int = 0
     @Binding var isPresented: Bool
     
-    var body: some View {
+    public init(
+        events: [AcademicEvent],
+        isPresented: Binding<Bool>
+    ) {
+        self.events = events
+        self._isPresented = isPresented
+    }
+    
+    public var body: some View {
         VStack(spacing: 0) {
             Text("이번 주 예정된 학사일정을 확인해보아요")
                 .font(.system(size: 18, weight: .medium))
@@ -37,8 +46,8 @@ struct AcademicScheduleSheet: View {
                 .padding(.top, 24)
 
             TabView(selection: $currentPage) {
-                ForEach(schedules.indices, id: \.self) { index in
-                    ScheduleCard(schedule: schedules[index])
+                ForEach(events.indices, id: \.self) { index in
+                    ScheduleCard(event: events[index])
                         .tag(index)
                 }
             }
@@ -46,7 +55,7 @@ struct AcademicScheduleSheet: View {
             .padding(.top, 16)
             
             HStack(spacing: 8) {
-                ForEach(schedules.indices, id: \.self) { index in
+                ForEach(events.indices, id: \.self) { index in
                     Circle()
                         .fill(currentPage == index ? Color.Kuring.primary : Color.Kuring.primary.opacity(0.3))
                         .frame(width: 8, height: 8)
@@ -73,6 +82,7 @@ struct AcademicScheduleSheet: View {
             .padding(.bottom, 10)
             .padding(.top, 24)
         }
+        .background(Color.Kuring.bg)
     }
 }
 
@@ -83,15 +93,15 @@ struct AcademicScheduleSheet: View {
 ///  - Parameters:
 ///    - schedule: 보여줄 학사 일정
 struct ScheduleCard: View {
-    let schedule: ScheduleItem
+    let event: AcademicEvent
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(schedule.title)
+            Text(event.summary)
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundColor(Color.Kuring.title)
             
-            Text(schedule.date)
+            Text("\(formatKoreanDateString(event.startTime)) - \(formatKoreanDateString(event.endTime))")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundColor(Color.Kuring.caption1)
         }
@@ -106,19 +116,46 @@ struct ScheduleCard: View {
     }
 }
 
-struct ScheduleItem {
-    let title: String
-    let date: String
+extension ScheduleCard {
+    private func formatKoreanDateString(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+
+        guard let date = inputFormatter.date(from: dateString) else {
+            return dateString
+        }
+
+        let outputFormatter = DateFormatter()
+        outputFormatter.locale = Locale(identifier: "ko_KR")
+        outputFormatter.dateFormat = "M.dd (E) a h:mm"
+
+        return outputFormatter.string(from: date)
+    }
 }
 
 #Preview {
     @Previewable @State var currentPage = 0
     @Previewable @State var isPresented = false
     
-    let schedules = [
-        ScheduleItem(title: "학사일정 text", date: "8. 04 (월) 오전 9:30 - 8. 05 (화) 오후 5:00"),
-        ScheduleItem(title: "학사일정 text", date: "8. 06 (수) 오전 10:00 - 8. 07 (목) 오후 3:00"),
-        ScheduleItem(title: "학사일정 text", date: "8. 08 (금) 오전 11:00 - 8. 09 (토) 오후 4:00")
+    let events = [
+        AcademicEvent(
+            id: 0,
+            eventUid: "0000",
+            summary: "테스트 학사일정",
+            description: "일정이에유",
+            category: "ETC",
+            startTime: "2025-10-25T00:00:00",
+            endTime: "2025-10-28T00:00:00"
+        ),
+        AcademicEvent(
+            id: 1,
+            eventUid: "0001",
+            summary: "또다른 테스트 학사일정",
+            description: "이정이에유",
+            category: "ETC",
+            startTime: "2025-10-25T00:00:00",
+            endTime: "2025-10-28T00:00:00"
+        ),
     ]
     
     VStack {
@@ -129,7 +166,7 @@ struct ScheduleItem {
     }
     .sheet(isPresented: $isPresented) {
         AcademicScheduleSheet(
-            schedules: schedules,
+            events: events,
             isPresented: $isPresented
         )
         .presentationDetents([.height(280)])

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
@@ -93,6 +93,7 @@ public struct AcademicScheduleSheet: View {
 }
 
 private extension AcademicEvent {
+    /// 해당 학사일정과 이번주와 일정이 겹치는지
     func overlapsWithCurrentWeek() -> Bool {
         let calendar = Calendar.current
         let today = Date()

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/AcademicScheduleSheet.swift
@@ -5,9 +5,13 @@
 //  Created by Jung Hwan Park on 10/23/25.
 //
 
+
+import Caches
 import Models
 import SwiftUI
 import ColorSet
+import Dependencies
+import SwiftData
 
 /// 주요 학사 일정을 한번에 보여주는 바텀시트 뷰
 /// 높이는 **280**으로 사용
@@ -31,10 +35,12 @@ public struct AcademicScheduleSheet: View {
     @Binding var isPresented: Bool
     
     public init(
-        events: [AcademicEvent],
         isPresented: Binding<Bool>
     ) {
-        self.events = events
+        @Dependency(\.academicSchedules) var academicDB
+        let cachedEvents = ((try? academicDB.fetch(.init())?.events ?? []) ?? []).map(AcademicEvent.init(from:))
+        
+        self.events = cachedEvents.filter { $0.overlapsWithCurrentWeek() }
         self._isPresented = isPresented
     }
     
@@ -83,6 +89,34 @@ public struct AcademicScheduleSheet: View {
             .padding(.top, 24)
         }
         .background(Color.Kuring.bg)
+    }
+}
+
+private extension AcademicEvent {
+    func overlapsWithCurrentWeek() -> Bool {
+        let calendar = Calendar.current
+        let today = Date()
+        
+        guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: today) else {
+            return false
+        }
+        
+        let weekStart = weekInterval.start
+        let weekEnd = weekInterval.end
+        
+        guard let eventStart = toDate(startTime),
+              let eventEnd = toDate(endTime) else {
+            return false
+        }
+        
+        return eventStart < weekEnd && eventEnd >= weekStart
+    }
+    
+    func toDate(_ date: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.date(from: date)
     }
 }
 
@@ -165,12 +199,9 @@ extension ScheduleCard {
         .padding()
     }
     .sheet(isPresented: $isPresented) {
-        AcademicScheduleSheet(
-            events: events,
-            isPresented: $isPresented
-        )
-        .presentationDetents([.height(280)])
-        .presentationCornerRadius(20)
-        .presentationDragIndicator(.visible)
+        AcademicScheduleSheet(isPresented: $isPresented)
+            .presentationDetents([.height(280)])
+            .presentationCornerRadius(20)
+            .presentationDragIndicator(.visible)
     }
 }

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
@@ -60,8 +60,10 @@ struct CalendarMonthView: View {
     }
 }
 
+// MARK: - Helper functions
 extension CalendarMonthView {
-    var numberOfWeeks: Int {
+    // 해당 월은 몇주로 이루어져있나
+    private var numberOfWeeks: Int {
         let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: month))!
         let firstWeekday = calendar.component(.weekday, from: firstDay)
         let daysInMonth = calendar.range(of: .day, in: .month, for: month)!.count
@@ -70,11 +72,13 @@ extension CalendarMonthView {
         return Int(ceil(Double(totalDays) / 7.0))
     }
     
-    var rowHeight: CGFloat {
+    // 캘린더 높이는 고정, 행의 높이는 동적임
+    private var rowHeight: CGFloat {
         return 306.0 / CGFloat(numberOfWeeks)
     }
     
-    func getDateInfo(for weekIndex: Int, dayIndex: Int) -> DateInfo? {
+    // 몇번째 주인지, 그리고 날짜 인덱스(0~6)을 파라미터로 받고, 사용하기 쉬운 DateInfo라는 객체롴 반환.
+    private func getDateInfo(for weekIndex: Int, dayIndex: Int) -> DateInfo? {
         let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: month))!
         let firstWeekday = calendar.component(.weekday, from: firstDay)
         
@@ -90,14 +94,14 @@ extension CalendarMonthView {
         return DateInfo(date: date, day: day, isCurrentMonth: isCurrentMonth)
     }
     
-    func isSelected(_ date: Date) -> Bool {
+    private func isSelected(_ date: Date) -> Bool {
         guard let selectedDate = selectedDate else {
             return false
         }
         return calendar.isDate(date, inSameDayAs: selectedDate)
     }
     
-    func getEventsForDate(_ date: Date) -> [AcademicEvent] {
+    private func getEventsForDate(_ date: Date) -> [AcademicEvent] {
         let midnight = calendar.startOfDay(for: date)
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
@@ -107,6 +111,10 @@ extension CalendarMonthView {
     }
 }
 
+/// 캘린더에 그리기 위해 필요한 정보를 담고있음.
+/// - date: 날짜
+/// - day: 날짜의 '일'에 해달하는 부분 (7일, 31일, 등)
+/// - isCurrentMonth: 해당 월에 속하지 않은 일자인데 표시할때도 있음. 이때는 회색으로 표시해야함. 예를 들어 10월 첫째중 9월 31일이 보이는 경우, 등
 struct DateInfo {
     let date: Date
     let day: Int

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
@@ -5,29 +5,26 @@
 //  Created by Jung Hwan Park on 10/22/25.
 //
 
+import Models
 import SwiftUI
 
 /// 학사 일정 캘린더에 하나의 달을 나타내는 뷰
 /// 하나의 달은 "DateCellView"로 이루어져있음
 /// ```swift
-///  CalendarMonthView(
-///      month: Date(),
-///      selectedDate: .constant(Date()),
-///      dateDots: [
-///          "2025-10-22": [
-///              .green, .blue, .red
-///          ]
-///      ]
-///  )
+///   CalendarMonthView(
+///       month: month,
+///       selectedDate: $store.selectedDate,
+///       events: store.events
+///   )
 /// ```
 ///  - Parameters:
 ///    - month: 해당 달의 Date 객체 (날짜 자체는 상관없음, 월만 중요함)
 ///    - selectedDate: 사용자가 탭하여 선택한 날짜, 바인딩이 필요하기 때문에 주입받아야함
-///    - eventDots: 해당 날짜의 학사일정들
+///    - events: 해당 날짜의 학사일정들
 struct CalendarMonthView: View {
     let month: Date
     @Binding var selectedDate: Date?
-    let eventDots: [String: [Color]]
+    let events: [AcademicEvent]
     
     let calendar = Calendar.current
     
@@ -40,7 +37,7 @@ struct CalendarMonthView: View {
                             DateCellView(
                                 dateInfo: dateInfo,
                                 isSelected: isSelected(dateInfo.date),
-                                dots: getDotsForDate(dateInfo.date),
+                                events: getEventsForDate(dateInfo.date),
                                 onTap: {
                                     if dateInfo.isCurrentMonth {
                                         selectedDate = dateInfo.date
@@ -100,11 +97,13 @@ extension CalendarMonthView {
         return calendar.isDate(date, inSameDayAs: selectedDate)
     }
     
-    func getDotsForDate(_ date: Date) -> [Color] {
+    func getEventsForDate(_ date: Date) -> [AcademicEvent] {
+        let midnight = calendar.startOfDay(for: date)
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-M-d"
-        let dateString = formatter.string(from: date)
-        return eventDots[dateString] ?? []
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        let dateString = formatter.string(from: midnight)
+        
+        return events.filter({ $0.startTime == dateString })
     }
 }
 
@@ -115,13 +114,9 @@ struct DateInfo {
 }
 
 #Preview {
+    @Previewable @State var date: Date? = Date()
     CalendarMonthView(
-        month: Date(),
-        selectedDate: .constant(Date()),
-        eventDots: [
-            "2025-10-22": [
-                .green, .blue, .red
-            ]
-        ]
-    )
+        month: date!,
+        selectedDate: $date,
+        events: [])
 }

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/CalendarMonthView.swift
@@ -107,7 +107,7 @@ extension CalendarMonthView {
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         let dateString = formatter.string(from: midnight)
         
-        return events.filter({ $0.startTime == dateString })
+        return events.filter { $0.startTime <= dateString && dateString <= $0.endTime }
     }
 }
 

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
@@ -47,7 +47,7 @@ struct DateCellView: View {
                 
                 HStack(spacing: 0) {
                     if !events.isEmpty {
-                        ForEach(events, id: \.id) { event in
+                        ForEach(events.prefix(6), id: \.id) { event in
                             Rectangle()
                                 .fill((AcademicEventCategory(rawValue: event.category) ?? .etc).color)
                                 .frame(width: 5, height: 5)

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
@@ -45,17 +45,20 @@ struct DateCellView: View {
                             .frame(width: 26, height: 26)
                     )
                 
-                if !events.isEmpty {
-                    HStack(spacing: 0) {
-                        ForEach(0..<events.count, id: \.self) { index in
+                HStack(spacing: 0) {
+                    if !events.isEmpty {
+                        ForEach(events, id: \.id) { event in
                             Rectangle()
-                                .fill(.green)
+                                .fill((AcademicEventCategory(rawValue: event.category) ?? .etc).color)
                                 .frame(width: 5, height: 5)
                         }
+                    } else {
+                        Spacer()
+                            .frame(width: 5, height: 5)
                     }
-                    .clipShape(Capsule())
-                    .padding(.top, 4)
                 }
+                .clipShape(Capsule())
+                .padding(.top, 4)
             }
         }
         .buttonStyle(PlainButtonStyle())

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
@@ -37,8 +37,8 @@ struct DateCellView: View {
         Button(action: onTap) {
             VStack(spacing: 4) {
                 Text("\(dateInfo.day)")
-                    .font(.system(size: 16))
-                    .foregroundColor(isSelected ? Color.Kuring.primary : (dateInfo.isCurrentMonth ? Color.Kuring.title : Color.Kuring.gray300))
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(dateTextColor())
                     .background(
                         Circle()
                             .fill(isSelected ? Color.Kuring.primarySelected : Color.clear)
@@ -62,6 +62,20 @@ struct DateCellView: View {
             }
         }
         .buttonStyle(PlainButtonStyle())
+    }
+}
+
+extension DateCellView {
+    private func dateTextColor() -> Color {
+        if Calendar.current.isDateInToday(dateInfo.date) {
+            return Color.Kuring.primary
+        }
+        
+        if isSelected {
+            return Color.Kuring.primary
+        }
+        
+        return dateInfo.isCurrentMonth ? Color.Kuring.title : Color.Kuring.gray300
     }
 }
 

--- a/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
+++ b/package-kuring/Sources/UIKit/AcademicCalendarUI/DateCellView.swift
@@ -5,24 +5,22 @@
 //  Created by Jung Hwan Park on 10/22/25.
 //
 
+import Models
 import SwiftUI
 import ColorSet
 
 /// 학사 일정 캘린더에 하나의 날짜를 나타내는 뷰
 /// ```swift
-///   DateCellView(
-///       dateInfo: .init(
-///           date: Date(),
-///           day: 3,
-///           isCurrentMonth: true
-///       ),
-///       isSelected: true,
-///       dots: [
-///           .red, .green, .yellow
-///       ]
-///   ) {
-///       print("Tapped")
-///   }
+///    DateCellView(
+///        dateInfo: dateInfo,
+///        isSelected: isSelected(dateInfo.date),
+///        events: getEventsForDate(dateInfo.date),
+///        onTap: {
+///            if dateInfo.isCurrentMonth {
+///                selectedDate = dateInfo.date
+///            }
+///        }
+///    )
 /// ```
 ///  - Parameters:
 ///    - dateInfo: 하나의 날짜의 정보를 나타내는 DateInfo 객체. 해당 날짜, day(월~일), 그리고 currentMonth 정보를 담고있음.
@@ -32,7 +30,7 @@ import ColorSet
 struct DateCellView: View {
     let dateInfo: DateInfo
     let isSelected: Bool
-    let dots: [Color]
+    let events: [AcademicEvent]
     let onTap: () -> Void
     
     var body: some View {
@@ -47,11 +45,11 @@ struct DateCellView: View {
                             .frame(width: 26, height: 26)
                     )
                 
-                if !dots.isEmpty {
+                if !events.isEmpty {
                     HStack(spacing: 0) {
-                        ForEach(0..<dots.count, id: \.self) { index in
+                        ForEach(0..<events.count, id: \.self) { index in
                             Rectangle()
-                                .fill(dots[index])
+                                .fill(.green)
                                 .frame(width: 5, height: 5)
                         }
                     }
@@ -72,9 +70,7 @@ struct DateCellView: View {
             isCurrentMonth: true
         ),
         isSelected: true,
-        dots: [
-            .red, .green, .yellow
-        ]
+        events: []
     ) {
         print("Tapped")
     }

--- a/package-kuring/Sources/UIKit/ColorSet/Color.UIKit.swift
+++ b/package-kuring/Sources/UIKit/ColorSet/Color.UIKit.swift
@@ -84,6 +84,23 @@ extension Color.Kuring {
         dark: Self.from(hex: "4E4E4E")
     )
     
+    // MARK: - 학사 일정
+    public static let etc: Color = Self.color(
+        light: Self.from(hex: "E5E5E5"),
+        dark: Self.from(hex: "B0B0B0")
+    )
+    public static let degree: Color = Self.color(
+        light: Self.from(hex: "FFF49D"),
+        dark: Self.from(hex: "EADF8D")
+    )
+    public static let registration: Color = Self.color(
+        light: Self.from(hex: "BAEB6B"),
+        dark: Self.from(hex: "A7D260")
+    )
+    public static let event: Color = Self.color(
+        light: Self.from(hex: "FFC8C8"),
+        dark: Self.from(hex: "E9B9B9")
+    )
 }
 
 // MARK: - function

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -67,7 +67,6 @@ public struct NoticeApp: View {
             }
             .sheet(isPresented: $store.isAcademicSchedulePresented) {
                 AcademicScheduleSheet(
-                    events: (store.academicSchedule?.events ?? []).map(AcademicEvent.init(from:)),
                     isPresented: $store.isAcademicSchedulePresented
                 )
                 .presentationDetents([.height(280)])

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -3,6 +3,7 @@
 // See the 'License.txt' file for licensing information.
 //
 
+import Models
 import LoginUI
 import SwiftUI
 import ColorSet
@@ -11,6 +12,7 @@ import DepartmentUI
 import SubscriptionUI
 import NoticeFeatures
 import SearchFeatures
+import AcademicCalendarUI
 import ComposableArchitecture
 
 public struct NoticeApp: View {
@@ -62,6 +64,18 @@ public struct NoticeApp: View {
                 )
             ) { store in
                 SubscriptionApp(store: store)
+            }
+            .sheet(isPresented: $store.isAcademicSchedulePresented) {
+                AcademicScheduleSheet(
+                    events: (store.academicSchedule?.events ?? []).map(AcademicEvent.init(from:)),
+                    isPresented: $store.isAcademicSchedulePresented
+                )
+                .presentationDetents([.height(280)])
+                .presentationCornerRadius(20)
+                .presentationDragIndicator(.visible)
+            }
+            .onAppear {
+                store.send(.onAppear)
             }
         } destination: { store in
             switch store.state {

--- a/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
+++ b/package-kuring/Sources/UIKit/NoticeUI/NoticeApp.swift
@@ -65,16 +65,16 @@ public struct NoticeApp: View {
             ) { store in
                 SubscriptionApp(store: store)
             }
-            .sheet(isPresented: $store.isAcademicSchedulePresented) {
+            .sheet(isPresented: $store.academicCalendar.isAcademicSchedulePresented) {
                 AcademicScheduleSheet(
-                    isPresented: $store.isAcademicSchedulePresented
+                    isPresented: $store.academicCalendar.isAcademicSchedulePresented
                 )
                 .presentationDetents([.height(280)])
                 .presentationCornerRadius(20)
                 .presentationDragIndicator(.visible)
             }
             .onAppear {
-                store.send(.onAppear)
+                store.send(.academicCalendar(.onAppearNotice))
             }
         } destination: { store in
             switch store.state {

--- a/package-kuring/Sources/UIKit/SettingsUI/SettingList.swift
+++ b/package-kuring/Sources/UIKit/SettingsUI/SettingList.swift
@@ -68,7 +68,7 @@ public struct SettingList: View {
                     
                     Spacer()
 
-                    Toggle("", isOn: $store.isCustomAlarmOn)
+                    Toggle("", isOn: $store.isAcademicScheduleAlarmOn)
                         .labelsHidden()
                         .tint(Color.Kuring.primary)
                 }


### PR DESCRIPTION
# 작업 내용 
<!--- 변경 사항에 대해 간단하게 작성 해주세요. -->

- 학사일정 리듀서를 구현합니다
- 학사일정을 캐싱하기 위해 학사일정 SwiftData 디펜던시를 구현합니다
- 외부 패키지에서 선택된 탭을 변경해야되기 때문에, 탭 상태값을 디펜던시로 구현합니다
- 학사일정 푸시 알림 수신/미수신을 구현 합니다
- 학사일정 캐싱 로직을 구현합니다 ([캐싱 로직](https://discord.com/channels/1412795954649632942/1427678369545191557/1431644062691229798))



# 스크린샷 
<!--- 작업된 내용의 스크린샷을 첨부 해주세요. -->
<!--- 번거롭더라도 부탁 드립니다~ 🙏 -->

| iPhone | iPad |
| ----- | ----- |
|   <video src="https://github.com/user-attachments/assets/b6acc8c7-c6fe-45e8-8788-08e6ffd4dc5c" controls> </video>    |   <video src="https://github.com/user-attachments/assets/e54a3bfb-1042-47bc-b963-8fe5b01ec2d4" controls> </video>    |


# 논의사항
<!--- 작업에 대해 논의가 필요한 내용이 있다면 남겨주세요. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 학사 일정 캘린더 기능 추가 - 월별 일정 조회 및 날짜 선택 가능
  * 주간 학사 일정 시트 추가로 진행 중인 일정 확인 가능
  * 학사 일정 알림 토글 추가 (설정에서 관리)
  * 학사 이벤트 카테고리별 색상 코드 적용 (등록, 학위, 행사 등)

* **개선 사항**
  * 탭 상태 관리 최적화 및 화면 전환 시 상태 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->