### PR TITLE
버그 3건 수정

### DIFF
--- a/App/Sources/AppDelegate/AppDelegate+UNUserNotificationCenterDelegate.swift
+++ b/App/Sources/AppDelegate/AppDelegate+UNUserNotificationCenterDelegate.swift
@@ -48,6 +48,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     
     /// 푸시 알림을 탭 했을 때
     /// - Important: ``newMessagePublisher`` 를 구독하여 ``Message`` 객체를 이벤트로 전달받을 수 있습니다.
+    @MainActor
     public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse

--- a/App/Sources/AppDelegate/AppDelegate.swift
+++ b/App/Sources/AppDelegate/AppDelegate.swift
@@ -25,11 +25,13 @@ class AppDelegate: NSObject {
     var fcmToken: String = ""
     
     func onTapRemoteNotification(with userInfo: [String: Any]) throws {
-        let message = try Message(userInfo: userInfo)
         Task { @MainActor in
-            // 종료된 앱을 시작시키는 경우를 고려하여 2초 딜레이.
-            try await Task.sleep(for: .seconds(1.5))
-            newMessagePublisher.send(message)
+            do {
+                let message = try Message(userInfo: userInfo)
+                PushRouter.shared.handle(message)
+            } catch {
+                print("푸시알림 파싱 실패:: \(error)")
+            }
         }
     }
     

--- a/App/Sources/KuringApp.swift
+++ b/App/Sources/KuringApp.swift
@@ -16,7 +16,6 @@ import ComposableArchitecture
 @main
 struct KuringApp: App {
     @State private var completesLink: Bool = false
-    @State private var newNotice: Notice?
     @Environment(\.scenePhase) private var scenePhase
 
     // TODO: 테스트용 변수

--- a/App/Sources/KuringApp.swift
+++ b/App/Sources/KuringApp.swift
@@ -112,7 +112,9 @@ struct KuringApp: App {
             )
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button { PushRouter.shared.activeNotice = nil } label: {
+                    Button {
+                        PushRouter.shared.activeNotice = nil
+                    } label: {
                         Image(systemName: "xmark")
                     }
                 }

--- a/App/Sources/KuringApp.swift
+++ b/App/Sources/KuringApp.swift
@@ -24,10 +24,10 @@ struct KuringApp: App {
     @State private var didAppear: Bool = false
     
     @Dependency(\.commons) var commons
-    
     @Dependency(\.swiftData) var swiftDataService
     
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @ObservedObject private var router = PushRouter.shared
     
     var modelContext: ModelContext {
         guard let modelContext = try? self.swiftDataService.context() else {
@@ -38,98 +38,85 @@ struct KuringApp: App {
     
     var body: some Scene {
         WindowGroup {
-            if completesLink {
-                // MARK: ContentView
-                NavigationStack {
-                    ContentView(didAppear: $didAppear)
-                }
-                // MARK: 앱 업데이트 알림
-                .versionUpdateAlert()
-                // MARK: 새 공지 보여주기 (알림 탭했을 때)
-                .fullScreenCover(item: $newNotice) { notice in
+            Group {
+                if completesLink {
+                    // MARK: ContentView
                     NavigationStack {
-                        NoticeDetailView(
-                            store: Store(
-                                initialState: NoticeDetailFeature.State(
-                                    notice: notice,
-                                    isBookmarked: false
-                                ),
-                                reducer: { NoticeDetailFeature() }
-                            )
-                        )
-                        .toolbar {
-                            ToolbarItem(placement: .navigationBarLeading) {
-                                Button {
-                                    self.newNotice = nil
-                                } label: {
-                                    Image(systemName: "xmark")
+                        ContentView(didAppear: $didAppear)
+                    }
+                    // MARK: 앱 업데이트 알림
+                    .versionUpdateAlert()
+                    // MARK: - 일주일 동안 공지를 확인하지 않았어요
+                    .onChange(of: scenePhase) { scenePhase in
+                        guard scenePhase == .active else { return }
+                        Task {
+                            await appDelegate.requestOneWeekInactiveNotification()
+                        }
+                    }
+                    
+                    // MARK: - 테스트: 새 공지
+                    //                #if DEBUG
+                    //                .onAppear {
+                    //                    Task { @MainActor in
+                    //                        try await Task.sleep(for: .seconds(1.5))
+                    //                        let notice = Notice.random
+                    //                        newMessagePublisher.send(.notice(notice))
+                    //                        try await Task.sleep(for: .seconds(1.5))
+                    //                        newMessagePublisher.send(
+                    //                            .custom(
+                    //                                title: "[건대교지] 건빵레터 #47",
+                    //                                body: "#47 [당근알바] 광화문 한복판에서 5미터 ‘천공’ 굴리기",
+                    //                                url: "https://stibee.com/api/v1.0/emails/share/1oXWNovPHiqH-CiArIVZn8tOQmkmHVU"
+                    //                            )
+                    //                        )
+                    //                    }
+                    //                }
+                    //                #endif
+                } else {
+                    // MARK: LaunchScreen
+                    SplashScreen()
+                        .kuringLink(
+                            onRequest: { },
+                            onCompletion: { result in
+                                showsOnboarding = !commons.isOnboardingCompleted()
+                                router.setReady()
+                                if !showsOnboarding {
+                                    completesLink = true
                                 }
                             }
-                        }
-                    }
+                        )
                 }
-                // MARK: 푸시 알림을 탭 했을 때 호출
-                .onReceive(newMessagePublisher) { message in
-                    switch message {
-                        // 새 공지
-                    case let .notice(notice):
-                        self.newNotice = notice
-                        
-                        // 커스텀 알림
-                    case let .custom(title, body, link):
-                        guard let link else { return }
-                        guard let url = URL(string: link) else { return }
-                        guard UIApplication.shared.canOpenURL(url) else { return }
-                        UIApplication.shared.open(url)
-                    default:
-                        return
-                    }
-                }
-                // MARK: - 일주일 동안 공지를 확인하지 않았어요
-                .onChange(of: scenePhase) { scenePhase in
-                    guard scenePhase == .active else { return }
-                    Task {
-                        await appDelegate.requestOneWeekInactiveNotification()
-                    }
-                }
-                
-                // MARK: - 테스트: 새 공지
-                //                #if DEBUG
-                //                .onAppear {
-                //                    Task { @MainActor in
-                //                        try await Task.sleep(for: .seconds(1.5))
-                //                        let notice = Notice.random
-                //                        newMessagePublisher.send(.notice(notice))
-                //                        try await Task.sleep(for: .seconds(1.5))
-                //                        newMessagePublisher.send(
-                //                            .custom(
-                //                                title: "[건대교지] 건빵레터 #47",
-                //                                body: "#47 [당근알바] 광화문 한복판에서 5미터 ‘천공’ 굴리기",
-                //                                url: "https://stibee.com/api/v1.0/emails/share/1oXWNovPHiqH-CiArIVZn8tOQmkmHVU"
-                //                            )
-                //                        )
-                //                    }
-                //                }
-                //                #endif
-            } else {
-                // MARK: LaunchScreen
-                SplashScreen()
-                    .kuringLink(
-                        onRequest: { },
-                        onCompletion: { result in
-                            showsOnboarding = !commons.isOnboardingCompleted()
-                            if !showsOnboarding {
-                                completesLink = true
-                            }
-                        }
-                    )
-                    .fullScreenCover(isPresented: $showsOnboarding) {
-                        completesLink = true
-                    } content: {
-                        OnboardingView()
-                    }
+            }
+            // MARK: 새 공지 보여주기 (알림 탭했을 때)
+            .fullScreenCover(item: $router.activeNotice) { notice in
+                noticeDetailDestination(notice: notice)
+            }
+            .fullScreenCover(isPresented: $showsOnboarding) {
+                completesLink = true
+            } content: {
+                OnboardingView()
             }
         }
         .modelContext(self.modelContext)
+    }
+    
+    /// 공지사항 푸시알림 탭시 보여주는 View
+    @ViewBuilder
+    private func noticeDetailDestination(notice: Notice) -> some View {
+        NavigationStack {
+            NoticeDetailView(
+                store: Store(
+                    initialState: NoticeDetailFeature.State(notice: notice, isBookmarked: false),
+                    reducer: { NoticeDetailFeature() }
+                )
+            )
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button { PushRouter.shared.activeNotice = nil } label: {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
+        }
     }
 }

--- a/App/Sources/PushNotificationRouter.swift
+++ b/App/Sources/PushNotificationRouter.swift
@@ -1,0 +1,47 @@
+//
+//  PushNotificationRouter.swift
+//  KuringApp
+//
+//  Created by Jung Hwan Park on 1/20/26.
+//
+
+import Models
+import SwiftUI
+import Combine
+import PushNotifications
+
+@MainActor
+class PushRouter: ObservableObject {
+    static let shared = PushRouter()
+    
+    @Published var activeNotice: Notice?
+    /// 앱이 준비되기 전, 공지사항을 임시로 들고있다가 준비됐을때 공지사항을 보여주기 위함
+    private var pendingNotice: Notice?
+    private var isAppReady = false
+
+    /// 푸시알림 라우터가 준비 되었을때 사용한다
+    func setReady() {
+        isAppReady = true
+        if let pending = pendingNotice {
+            activeNotice = pending
+            pendingNotice = nil
+        }
+    }
+
+    /// 푸시 알림 액션
+    func handle(_ message: Message) {
+        switch message {
+        case .notice(let notice):
+            if isAppReady {
+                activeNotice = notice
+            } else {
+                pendingNotice = notice
+            }
+        case .custom(_, _, let link):
+            if let link, let url = URL(string: link) {
+                UIApplication.shared.open(url)
+            }
+        default: break
+        }
+    }
+}

--- a/App/Sources/PushNotificationRouter.swift
+++ b/App/Sources/PushNotificationRouter.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import Combine
 import PushNotifications
 
+/// 쿠링의 푸시 알림 라우팅을 담당하는 싱글톤 클래스
 @MainActor
 class PushRouter: ObservableObject {
     static let shared = PushRouter()
@@ -17,6 +18,7 @@ class PushRouter: ObservableObject {
     @Published var activeNotice: Notice?
     /// 앱이 준비되기 전, 공지사항을 임시로 들고있다가 준비됐을때 공지사항을 보여주기 위함
     private var pendingNotice: Notice?
+    /// 앱이 준비된 상태인지 나타내는 플래그값
     private var isAppReady = false
 
     /// 푸시알림 라우터가 준비 되었을때 사용한다
@@ -28,7 +30,7 @@ class PushRouter: ObservableObject {
         }
     }
 
-    /// 푸시 알림 액션
+    /// 푸시 알림 핸들링
     func handle(_ message: Message) {
         switch message {
         case .notice(let notice):

--- a/Features/NoticeFeatures/Sources/NoticeApp.swift
+++ b/Features/NoticeFeatures/Sources/NoticeApp.swift
@@ -7,6 +7,7 @@ import Caches
 import Models
 import SwiftData
 import Foundation
+import Dependencies
 import LoginFeatures
 import DepartmentFeatures
 import SubscriptionFeatures
@@ -175,7 +176,12 @@ public struct NoticeAppFeature {
                 guard case let .departmentEditor(departmentEditorState) = state.path[id: id] else {
                     return .none
                 }
-                state.noticeList.provider = departmentEditorState.myDepartments.first ?? .emptyDepartment
+
+                @Dependency(\.departments) var departments
+                state.noticeList.provider = departments.getCurrent() ?? departmentEditorState.myDepartments.first ?? .emptyDepartment
+                if state.noticeList.noticeDictionary[state.noticeList.provider] == nil {
+                    return .send(.noticeList(.reloadNotices))
+                }
                 return .none
             case let .path(.element(id: id, action: .setPassword(.delegate(.pushToSignupComplete)))):
                 state.path.append(

--- a/Shared/PushNotifications/Sources/Publishers/Publishers.swift
+++ b/Shared/PushNotifications/Sources/Publishers/Publishers.swift
@@ -16,4 +16,4 @@ import Combine
 ///     }
 /// }
 /// ```
-public let newMessagePublisher = PassthroughSubject<Message, Never>()
+public let newMessagePublisher = CurrentValueSubject<Message?, Never>(nil)

--- a/UIKit/OnboardingUI/Sources/MyDepartmentSelector/MyDepartmentSelector.swift
+++ b/UIKit/OnboardingUI/Sources/MyDepartmentSelector/MyDepartmentSelector.swift
@@ -15,6 +15,7 @@ struct MyDepartmentSelector: View {
     @State private var currentStep: Step = .searchDepartment
     @State private var selectedDepartment: NoticeProvider? = nil
     
+    @Dependency(\.commons) var commons
     @Dependency(\.kuringLink) var kuringLink
     @Dependency(\.departments) var departments
     @Dependency(\.subscriptions) var subscriptions
@@ -69,6 +70,7 @@ struct MyDepartmentSelector: View {
             .padding(.vertical, 20)
         } else {
             Button(StringSet.button_start.rawValue) {
+                commons.completeOnboarding()
                 dismiss()
             }
             .buttonStyle(.kuringStyle(enabled: currentStep == .addedDepartment))

--- a/UIKit/OnboardingUI/Sources/OnboardingView/OnboardingView.swift
+++ b/UIKit/OnboardingUI/Sources/OnboardingView/OnboardingView.swift
@@ -52,7 +52,6 @@ public struct OnboardingView: View {
                 
                 Button {
                     if currentGuidance == .search {
-                        commons.completeOnboarding()
                         showsDepartmentSelector = true
                     }
                 } label: {


### PR DESCRIPTION
# 작업 내용 
<!--- 변경 사항에 대해 간단하게 작성 해주세요. -->

하기 버그 3건을 수정합니다.
1. [온보딩 중 API 응답이 오면 온보딩이 종료되버리는 이슈](https://github.com/ku-ring/ios-app/commit/f33fc9d47de82987c2a32eb2f0263fd80412038c)
2. [대표 학과 편집/삭제 했을때 공지 요청 안하는 이슈](https://github.com/ku-ring/ios-app/commit/3ce8dabf0f607a0522421e870a1725db5d4bbb6c)
3. [푸시알림 탭 시 동작 이슈 수정](https://github.com/ku-ring/ios-app/commit/bf78b319cb6f5f98269c7e36e8532c4562241dd3) ⭐️

# 스크린샷 
<!--- 작업된 내용의 스크린샷을 첨부 해주세요. -->
<!--- 번거롭더라도 부탁 드립니다~ 🙏 -->

## 버그 1
쿠링은 앱 구동시 모든 학과를 가져오는 API를 태우는데, 
사용자가 빠르게 온보딩을 진행해서 바로 대표 학과를 추가하는 단계로 넘어간다면,
`commons.completeOnboarding()`이 실행 되면서 API 응답이 오고, 온보딩이 끝났다고 간주되는 버그.

`commons.completeOnboarding()` 시점 변경

| AS-IS | TO-BE |
| ----- | ----- |
|   <video src="https://github.com/user-attachments/assets/99799ed4-adfe-4147-b39e-92a50de29a1d"> </video>  |   <video src="https://github.com/user-attachments/assets/9285adf6-896b-4579-9d98-13668929ac5d"> </video>  |

## 버그 2
내 학과 편집하기에서 학과를 추가 했을때, 첫번째로 추가된 학과가 선택되는, 공지사항을 불러오지 않는 버그.
학과가 추가/삭제 됐을때 `store`의 `provider`를 올바르게 업데이트 해주고, 선택된 학과의 공지사항을 안불러왔다면 불러오는 로직 추가.

| AS-IS | TO-BE |
| ----- | ----- |
|   <video src="https://github.com/user-attachments/assets/11aaf9fe-3afd-46e6-a957-c9eeed6f0279"> </video>  |   <video src="https://github.com/user-attachments/assets/a9f700bc-d569-4084-bbca-b28ec62cb2b3"> </video>  |

## 버그 3 ⭐️

쿠링 푸시 알림 탭 시 동작이 안되는 버그.
쿠링 푸시 알림 탭 시 앱이 멈추는 버그.
고질병이었는데, 드디어 수정 


여러 문제가 있었음..

첫번째로 `onTapRemoteNotification`에 있던 
```
 // 종료된 앱을 시작시키는 경우를 고려하여 2초 딜레이.
try await Task.sleep(for: .seconds(1.5))
```
^^^ 이 스파게티를 드디어 없애고 별도의 푸시알림 라우터 클래스 생성.

`.onReceive(newMessagePublisher)`도 안쪽 뷰에 붙어있어서 실행이 안됐는데, 어휘력이 딸려서
게미니의 설명을 첨부하자면 
<img width="704" height="309" alt="Screenshot 2026-01-22 at 12 23 52 AM" src="https://github.com/user-attachments/assets/0c30fa2c-21b7-488c-9c11-2f729f785dca" />

두번째로 `@MainActor` 추가해서 크래시 대응(XCode 26 환경에서 크래시남)
세번째로 서버에서 보내는 공지사항 알림 payload에 id라는 필드가 없어서, 파싱이 불가했었음. 서버에서 수정 해주실 예정.


| AS-IS | TO-BE |
| ----- | ----- |
|   <video src="https://github.com/user-attachments/assets/661c6550-abc1-4870-a7a7-930fded0f0f2"> </video>  |   <video src="https://github.com/user-attachments/assets/98638c5b-875c-43de-9853-416583afe836"> </video>  |


# 논의사항
<!--- 작업에 대해 논의가 필요한 내용이 있다면 남겨주세요. -->
