### PR TITLE
쿠링 2.5.1 버전

### DIFF
--- a/Features/ClubsFeatures/Sources/ClubsList.swift
+++ b/Features/ClubsFeatures/Sources/ClubsList.swift
@@ -125,9 +125,9 @@ public struct ClubsListFeature {
                 state.subscribedClubsSortType = by
                 return .none
             case .getClubsList:
-                return .run { [state] send in
+                return .run { send in
                     do {
-                        let result = try await kuringLink.getClubsList(state.selectedClubType, state.selectedDivisions.map { $0.code.lowercased() })
+                        let result = try await kuringLink.getClubsList(.all, [])
                         await send(.getClubsListResponse(.success(result)))
                     } catch {
                         await send(.getClubsListResponse(.failure(.error(error.localizedDescription))))

--- a/Shared/Models/Sources/Clubs.swift
+++ b/Shared/Models/Sources/Clubs.swift
@@ -24,6 +24,7 @@ public struct Club: Codable, Equatable {
     public let category, division: String
     public var isSubscribed: Bool
     public var subscriberCount: Int
+    public let recruitmentStatus: RecruitmentStatus
     public let recruitStartDate, recruitEndDate: String?
     
     public init(
@@ -35,6 +36,7 @@ public struct Club: Codable, Equatable {
         division: String,
         isSubscribed: Bool,
         subscriberCount: Int,
+        recruitmentStatus: RecruitmentStatus,
         recruitStartDate: String?,
         recruitEndDate: String?
     ) {
@@ -46,6 +48,7 @@ public struct Club: Codable, Equatable {
         self.division = division
         self.isSubscribed = isSubscribed
         self.subscriberCount = subscriberCount
+        self.recruitmentStatus = recruitmentStatus
         self.recruitStartDate = recruitStartDate
         self.recruitEndDate = recruitEndDate
     }
@@ -60,6 +63,7 @@ public struct Club: Codable, Equatable {
             division: "central",
             isSubscribed: true,
             subscriberCount: 19,
+            recruitmentStatus: .recruiting,
             recruitStartDate: "2026-05-01T00:00:00",
             recruitEndDate: "2026-06-03T23:59:59"
         )

--- a/Shared/Models/Sources/Notice.swift
+++ b/Shared/Models/Sources/Notice.swift
@@ -51,7 +51,7 @@ extension Notice {
     /// try Notice(userInfo: userInfo)
     /// ```
     public init(userInfo: [String: Any]) throws {
-        guard let id = userInfo["id"] as? Int else {
+        guard let idString = userInfo["id"] as? String, let id = Int(idString) else {
             throw DecodingError.noID
         }
         guard let articleID = userInfo["articleId"] as? String else {

--- a/Shared/PushNotifications/Sources/Message/Message.swift
+++ b/Shared/PushNotifications/Sources/Message/Message.swift
@@ -33,7 +33,6 @@ extension Message {
             self = .notice(
                 try Notice(userInfo: userInfo)
             )
-            
         // 커스텀 알림
         case "admin":
             @AppStorage("com.kuring.sdk.notification.custom")

--- a/UIKit/ClubsUI/Sources/ClubsDetail/ClubInfoDetailView.swift
+++ b/UIKit/ClubsUI/Sources/ClubsDetail/ClubInfoDetailView.swift
@@ -353,9 +353,11 @@ private extension ClubInfoDetailView {
     }
 
     private func ddayText(for club: Club) -> (text: String, isUrgent: Bool) {
+        // 마감일이 있다면 D-{n} 형식 노출, 없다면 recruitmentStatus 기반
         guard let end = parseDate(club.recruitEndDate ?? "") else {
-            return ("마감 종료", false)
+            return (club.recruitmentStatus.rawValue, false)
         }
+        
         let days = Calendar.current.dateComponents([.day], from: .now, to: end).day ?? 0
 
         switch days {

--- a/UIKit/ClubsUI/Sources/ClubsDetail/ClubInfoDetailView.swift
+++ b/UIKit/ClubsUI/Sources/ClubsDetail/ClubInfoDetailView.swift
@@ -354,7 +354,7 @@ private extension ClubInfoDetailView {
 
     private func ddayText(for club: Club) -> (text: String, isUrgent: Bool) {
         guard let end = parseDate(club.recruitEndDate ?? "") else {
-            return ("상시모집", false)
+            return ("마감 종료", false)
         }
         let days = Calendar.current.dateComponents([.day], from: .now, to: end).day ?? 0
 

--- a/UIKit/ClubsUI/Sources/ClubsList/Views/ClubCardView.swift
+++ b/UIKit/ClubsUI/Sources/ClubsList/Views/ClubCardView.swift
@@ -53,8 +53,8 @@ private extension ClubCardView {
                 AsyncImage(url: URL(string: club.iconImageUrl ?? "")) { image in
                     image
                         .resizable()
+                        .aspectRatio(1, contentMode: .fit)
                         .frame(width: 84)
-                        .aspectRatio(contentMode: .fit)
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                 } placeholder: {
                     RoundedRectangle(cornerRadius: 14)
@@ -105,7 +105,7 @@ private extension ClubCardView {
         Text(club.summary)
             .padding(.top, 4)
             .font(.system(size: 14))
-            .foregroundStyle(!isRecruiting ? Color.Kuring.caption2 : Color.Kuring.caption1)
+            .foregroundStyle(Color.Kuring.caption1)
             .lineLimit(2)
             .truncationMode(.tail)
     }

--- a/UIKit/ClubsUI/Sources/ClubsList/Views/ClubCardView.swift
+++ b/UIKit/ClubsUI/Sources/ClubsList/Views/ClubCardView.swift
@@ -18,7 +18,7 @@ struct ClubCardView: View {
     }
 
     private var isRecruiting: Bool {
-        dday.text != "마감 종료"
+        club.recruitmentStatus != .closed
     }
 
     // 12자 초과시 ... 처리
@@ -160,8 +160,9 @@ private extension ClubCardView {
     }
 
     func ddayText(for club: Club) -> (text: String, isUrgent: Bool) {
+        // 마감일이 있다면 D-{n} 형식 노출, 없다면 recruitmentStatus 기반
         guard let end = parseDate(club.recruitEndDate ?? "") else {
-            return ("마감 종료", false)
+            return (club.recruitmentStatus.rawValue, false)
         }
 
         let days = Calendar.current.dateComponents([.day], from: Date(), to: end).day ?? 0

--- a/UIKit/ClubsUI/Sources/ClubsList/Views/ClubCardView.swift
+++ b/UIKit/ClubsUI/Sources/ClubsList/Views/ClubCardView.swift
@@ -161,7 +161,7 @@ private extension ClubCardView {
 
     func ddayText(for club: Club) -> (text: String, isUrgent: Bool) {
         guard let end = parseDate(club.recruitEndDate ?? "") else {
-            return ("상시모집", false)
+            return ("마감 종료", false)
         }
 
         let days = Calendar.current.dateComponents([.day], from: Date(), to: end).day ?? 0

--- a/UIKit/ClubsUI/Sources/ClubsList/Views/ClubsListView.swift
+++ b/UIKit/ClubsUI/Sources/ClubsList/Views/ClubsListView.swift
@@ -65,9 +65,7 @@ struct ClubsListView: View {
 }
 
 // MARK: - Sub-views
-
 private extension ClubsListView {
-
     var sortByView: some View {
         HStack {
             Text("총 \(store.filteredClubs?.clubs.count ?? 0)개")


### PR DESCRIPTION
# 작업 내용 
<!--- 변경 사항에 대해 간단하게 작성 해주세요. -->

- 동아리 목록 DTO(Club)에 `RecruitmentStatus` 필드 추가
  - 기존에 없어서 `recruitmentStartDate`, `recruitmentEndDate`로 날짜 계산 로직으로 지원 마감 기준을 파악했었음
- 공지사항 알림 DTO에 `id` 필드를 String으로 파싱하도록 수정. String으로 먼저 파싱 후, Int 변환할 것
  - 서버에서 int 형식으로 보내면 안되는 이슈가 있다고 함
  - 이제 진짜 공지사항 알림 탭 동작이 되어야하는게 맞을 듯.. 
- 동아리 이미지 aspectRatio 변경

# 스크린샷 
<!--- 작업된 내용의 스크린샷을 첨부 해주세요. -->
<!--- 번거롭더라도 부탁 드립니다~ 🙏 -->

| AS-IS | TO-BE |
| ----- | ----- |
|   <img width="1242" height="2688" alt="스크린샷, 2026-06-22 오후 4 56 48" src="https://github.com/user-attachments/assets/f46a8644-ec07-4007-9ef8-7e89b1d734d6" />    | <img width="1242" height="2688" alt="IMG_4AAEEDB8907C-1" src="https://github.com/user-attachments/assets/faea09cb-a57f-4fdd-bb9f-af7fcca9080d" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 클럽 카드와 상세 화면에서 모집 상태가 더 정확하게 표시됩니다.
  * 모집 마감일을 확인할 수 없을 때도 상태 문구가 표시됩니다.

* **Bug Fixes**
  * 클럽 목록 조회가 항상 기본 전체 조건으로 동작하도록 조정되었습니다.
  * 알림/공지 데이터의 식별자 처리 안정성이 개선되었습니다.

* **Style**
  * 일부 화면 구성과 표시 정렬이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->